### PR TITLE
Fixed StoppingMode bug by making sure the tracker is operational, otherwise do not Announce.

### DIFF
--- a/src/MonoTorrent/MonoTorrent.Client/Modes/StoppingMode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/StoppingMode.cs
@@ -22,7 +22,7 @@ namespace MonoTorrent.Client
 			if (manager.Mode is HashingMode)
 				handle.AddHandle(((HashingMode)manager.Mode).hashingWaitHandle, "Hashing");
 
-			if (manager.TrackerManager.CurrentTracker != null)
+			if (manager.TrackerManager.CurrentTracker != null && manager.TrackerManager.CurrentTracker.Status == TrackerState.Ok)
 				handle.AddHandle(manager.TrackerManager.Announce(TorrentEvent.Stopped), "Announcing");
 
 			foreach (PeerId id in manager.Peers.ConnectedPeers)


### PR DESCRIPTION
Attempting to announce to a tracker that is in any other state than OK
will produce the widely reported "Stopping mode" bug.  Trackers that are not in the OK state will not respond because we have likely never established a connection to it; i.e. it is a dead tracker.
