### PR TITLE
[core] Retain peers when restarting torrents

### DIFF
--- a/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -685,9 +685,6 @@ namespace MonoTorrent.Client
             if (HasMetadata && Torrent.IsPrivate && !fromTrackers)
                 throw new InvalidOperationException ("You cannot add external peers to a private torrent");
 
-            if (Peers.TotalPeers >= Settings.MaximumPeerDetails)
-                return false;
-
             if (Peers.Contains (peer))
                 return false;
 
@@ -695,10 +692,23 @@ namespace MonoTorrent.Client
             if (InactivePeerManager.InactivePeerList.Contains (peer.ConnectionUri))
                 return false;
 
-            if (prioritise)
-                Peers.AvailablePeers.Insert (0, peer);
-            else
-                Peers.AvailablePeers.Add (peer);
+            if (Peers.TotalPeers < Settings.MaximumPeerDetails) {
+                if (prioritise)
+                    Peers.AvailablePeers.Insert (0, peer);
+                else
+                    Peers.AvailablePeers.Add (peer);
+            } else {
+                bool successful = false;
+                for (int i = 0; i < Peers.AvailablePeers.Count; i++) {
+                    if (Peers.AvailablePeers[i].MaybeStale) {
+                        Peers.AvailablePeers[i] = peer;
+                        successful = true;
+                        break;
+                    }
+                }
+                if (!successful)
+                    return false;
+            }
             OnPeerFound?.Invoke (this, new PeerAddedEventArgs (this, peer));
             // When we successfully add a peer we try to connect to the next available peer
             return true;

--- a/src/MonoTorrent/MonoTorrent.Client/Modes/StartingMode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/StartingMode.cs
@@ -85,6 +85,9 @@ namespace MonoTorrent.Client.Modes
                 return;
             }
 
+            foreach (var peer in Manager.Peers.AvailablePeers)
+                peer.MaybeStale = true;
+
             SendAnnounces ();
 
             if (Manager.Complete && Manager.Settings.AllowInitialSeeding && ClientEngine.SupportsInitialSeed) {

--- a/src/MonoTorrent/MonoTorrent.Client/Modes/StoppingMode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/StoppingMode.cs
@@ -59,7 +59,6 @@ namespace MonoTorrent.Client.Modes
                     Manager.Engine.ConnectionManager.CleanupSocket (Manager, id);
 
                 Manager.Monitor.Reset ();
-                Manager.Peers.ClearAll ();
                 Manager.PieceManager.Reset ();
                 Manager.finishedPieces.Clear ();
 

--- a/src/MonoTorrent/MonoTorrent.Client/Peers/Peer.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Peers/Peer.cs
@@ -75,6 +75,14 @@ namespace MonoTorrent.Client
         internal int LocalPort { get; set; }
 
         /// <summary>
+        /// A stale peer is one which came from an old announce/DHT/peer exchange request. These
+        /// peers may still be contactable, but if a new peer is provided via one of the normal
+        /// mechanisms then the new peer should replace any stale peers in the event the torrent
+        /// is already holding the maximum number of peers.
+        /// </summary>
+        internal bool MaybeStale { get; set; }
+
+        /// <summary>
         /// The 20 byte identifier for the peer.
         /// </summary>
         internal BEncodedString PeerId { get; set; }


### PR DESCRIPTION
We no longer clear the peer list when stopping
a torrent manager. Instead the peers are marked
as 'MaybeStale' the next time the manager is
started. We will connect to those as normal, but
if an announce occurs and we get new peers, we'll
replace any peers which are marked a 'MaybeStale'
with fresh ones which are more likely to be online.

Addresses https://github.com/alanmcgovern/monotorrent/issues/221