### PR TITLE
[core] Add a progress counter when hashing

### DIFF
--- a/src/MonoTorrent/MonoTorrent.Client/EventArgs/PieceHashedEventArgs.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/EventArgs/PieceHashedEventArgs.cs
@@ -45,16 +45,32 @@ namespace MonoTorrent.Client
         public bool HashPassed { get; }
 
         /// <summary>
+        /// If the TorrentManager is in the hashing state then this returns a value between 0 and 1 indicating
+        /// how complete the hashing progress is. If the manager is in the Downloading state then this will
+        /// return '1' as the torrent will have been fully hashed already. If some files in the torrent were
+        /// marked as 'DoNotDownload' during the initial hash, and those files are later marked as downloadable,
+        /// then this will still return '1'.
+        /// </summary>
+        public double Progress { get; }
+
+        /// <summary>
         /// Creates a new PieceHashedEventArgs
         /// </summary>
         /// <param name="manager">The <see cref="TorrentManager"/> whose piece was hashed</param>
         /// <param name="pieceIndex">The index of the piece that was hashed</param>
         /// <param name="hashPassed">True if the piece passed the hashcheck, false otherwise</param>
         internal PieceHashedEventArgs (TorrentManager manager, int pieceIndex, bool hashPassed)
+            : this (manager, pieceIndex, hashPassed, 1, 1)
+        {
+
+        }
+
+        internal PieceHashedEventArgs (TorrentManager manager, int pieceIndex, bool hashPassed, int piecesHashed, int totalToHash)
             : base (manager)
         {
             PieceIndex = pieceIndex;
             HashPassed = hashPassed;
+            Progress = (double) piecesHashed / totalToHash;
         }
     }
 }

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -753,6 +753,9 @@ namespace MonoTorrent.Client
         }
 
         internal void OnPieceHashed (int index, bool hashPassed)
+            => OnPieceHashed (index, hashPassed, 1, 1);
+
+        internal void OnPieceHashed (int index, bool hashPassed, int piecesHashed, int totalToHash)
         {
             Bitfield[index] = hashPassed;
             // The PiecePickers will no longer ignore this piece as it has now been hash checked.
@@ -834,7 +837,7 @@ namespace MonoTorrent.Client
                 throw new ArgumentException ("The fast resume data does not match this torrent", "fastResumeData");
 
             for (int i = 0; i < Torrent.Pieces.Count; i++)
-                OnPieceHashed (i, data.Bitfield[i]);
+                OnPieceHashed (i, data.Bitfield[i], i, Torrent.Pieces.Count);
             UnhashedPieces.From (data.UnhashedPieces);
 
             HashChecked = true;

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -773,7 +773,7 @@ namespace MonoTorrent.Client
                     connected[i].IsAllowedFastPieces.Remove (index);
             }
 
-            PieceHashed?.InvokeAsync (this, new PieceHashedEventArgs (this, index, hashPassed));
+            PieceHashed?.InvokeAsync (this, new PieceHashedEventArgs (this, index, hashPassed, piecesHashed, totalToHash));
         }
 
         internal void RaiseTorrentStateChanged (TorrentStateChangedEventArgs e)

--- a/src/MonoTorrent/MonoTorrent.Client/Modes/DownloadMode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/DownloadMode.cs
@@ -31,8 +31,6 @@ namespace MonoTorrent.Client.Modes
 {
     class DownloadMode : Mode
     {
-        BitField PartialProgressUpdater;
-
         TorrentState state;
         public override TorrentState State => state;
 
@@ -71,24 +69,6 @@ namespace MonoTorrent.Client.Modes
                     i--;
                 }
             }
-        }
-
-
-        internal void UpdatePartialProgress ()
-        {
-            if (PartialProgressUpdater == null || PartialProgressUpdater.Length != Manager.Bitfield.Length)
-                PartialProgressUpdater = new BitField (Manager.Bitfield.Length);
-
-            PartialProgressUpdater.SetAll (false);
-            if (Manager.Torrent != null) {
-                foreach (TorrentFile file in Manager.Torrent.Files) {
-                    if (file.Priority != Priority.DoNotDownload) {
-                        for (int i = file.StartPieceIndex; i <= file.EndPieceIndex; i++)
-                            PartialProgressUpdater[i] = true;
-                    }
-                }
-            }
-            Manager.PartialProgressSelector.From (PartialProgressUpdater);
         }
 
         internal void UpdateSeedingDownloadingState ()

--- a/src/MonoTorrent/MonoTorrent.Client/Modes/HashingMode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/HashingMode.cs
@@ -75,6 +75,10 @@ namespace MonoTorrent.Client.Modes
             if (!Manager.HasMetadata)
                 throw new TorrentException ("A hash check cannot be performed if TorrentManager.HasMetadata is false.");
 
+            // Ensure the partial progress selector is up to date before we start hashing
+            UpdatePartialProgress ();
+
+            int piecesHashed = 0;
             Manager.HashFails = 0;
             if (await DiskManager.CheckAnyFilesExistAsync (Manager.Torrent)) {
                 Cancellation.Token.ThrowIfCancellationRequested ();
@@ -82,7 +86,7 @@ namespace MonoTorrent.Client.Modes
                     if (!Manager.Torrent.Files.Any (f => index >= f.StartPieceIndex && index <= f.EndPieceIndex && f.Priority != Priority.DoNotDownload)) {
                         // If a file is marked 'do not download' ensure we update the TorrentFiles
                         // so they also report that the piece is not available/downloaded.
-                        Manager.OnPieceHashed (index, false);
+                        Manager.OnPieceHashed (index, false, piecesHashed, Manager.PartialProgressSelector.TrueCount);
                         // Then mark this piece as being unhashed so we don't try to download it.
                         Manager.UnhashedPieces[index] = true;
                         continue;
@@ -99,13 +103,13 @@ namespace MonoTorrent.Client.Modes
                     }
 
                     bool hashPassed = hash != null && Manager.Torrent.Pieces.IsValid (hash, index);
-                    Manager.OnPieceHashed (index, hashPassed);
+                    Manager.OnPieceHashed (index, hashPassed, ++piecesHashed, Manager.PartialProgressSelector.TrueCount);
                 }
             } else {
                 await PausedCompletionSource.Task;
 
                 for (int i = 0; i < Manager.Torrent.Pieces.Count; i++)
-                    Manager.OnPieceHashed (i, false);
+                    Manager.OnPieceHashed (i, false, ++piecesHashed, Manager.Torrent.Pieces.Count);
             }
         }
 


### PR DESCRIPTION
Users can tell how complete the hashing progress is. This takes
into account the fact that files which are marked as
DoNotDownload will not be hashed.

Fixes https://github.com/alanmcgovern/monotorrent/issues/180