### PR TITLE
[core] Optimise memory for TorrentFile

### DIFF
--- a/src/MonoTorrent.Tests/Client/PriorityPickerTests.cs
+++ b/src/MonoTorrent.Tests/Client/PriorityPickerTests.cs
@@ -209,20 +209,20 @@ namespace MonoTorrent.Client.PiecePicking
             Assert.IsFalse (picker.IsInteresting (bf.SetAll (false).Set (multiFile.Files[1].StartPieceIndex + 1, true)), "#4");
             Assert.IsFalse (picker.IsInteresting (bf.SetAll (false).Set (multiFile.Files[1].EndPieceIndex - 1, true)), "#5");
 
-            bf = multiFile.Files[2].GetSelector (multiBitfield.Length);
+            bf = new BitField (multiBitfield.Length).SetTrue (multiFile.Files[2].GetSelector ());
             Assert.AreEqual (bf, tester.PickPieceBitfield[0], "#6");
 
-            bf = multiFile.Files[3].GetSelector (multiBitfield.Length)
-                .Or (multiFile.Files[7].GetSelector (multiBitfield.Length));
+            bf = new BitField (multiBitfield.Length).SetTrue (multiFile.Files[3].GetSelector ())
+                .SetTrue (multiFile.Files[7].GetSelector ());
             Assert.AreEqual (bf, tester.PickPieceBitfield[1], "#7");
 
-            bf = multiFile.Files[0].GetSelector (multiBitfield.Length);
+            bf = new BitField (multiBitfield.Length).SetTrue (multiFile.Files[0].GetSelector ());
             Assert.AreEqual (bf, tester.PickPieceBitfield[2], "#8");
 
-            bf = multiFile.Files[5].GetSelector (multiBitfield.Length);
+            bf = new BitField (multiBitfield.Length).SetTrue (multiFile.Files[5].GetSelector ());
             Assert.AreEqual (bf, tester.PickPieceBitfield[3], "#9");
 
-            bf = multiFile.Files[4].GetSelector (multiBitfield.Length);
+            bf = new BitField (multiBitfield.Length).SetTrue (multiFile.Files[4].GetSelector ());
             Assert.AreEqual (bf, tester.PickPieceBitfield[4], "#10");
         }
 
@@ -253,11 +253,11 @@ namespace MonoTorrent.Client.PiecePicking
             picker.PickPiece (multiPeer, multiBitfield, new List<PeerId> ());
             Assert.AreEqual (2, tester.PickPieceBitfield.Count, "#1");
             Assert.IsTrue (picker.IsInteresting (multiBitfield), "#2");
-            Assert.AreEqual (multiFile.Files[1].GetSelector (multiBitfield.Length), tester.PickPieceBitfield[0], "#3");
+            Assert.AreEqual (new BitField (multiBitfield.Length).SetTrue (multiFile.Files[1].GetSelector ()), tester.PickPieceBitfield[0], "#3");
 
             var bf = new BitField (multiBitfield.Length);
             foreach (var v in multiFile.Files.Except (new[] { multiFile.Files[1] }))
-                bf.Or (v.GetSelector (bf.Length));
+                bf.SetTrue (v.GetSelector ());
 
             Assert.AreEqual (bf, tester.PickPieceBitfield[1], "#4");
         }

--- a/src/MonoTorrent/MonoTorrent.Client.PiecePicking/EndGameSwitcher.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.PiecePicking/EndGameSwitcher.cs
@@ -142,7 +142,7 @@ namespace MonoTorrent.Client.PiecePicking
             endgameSelector.SetAll (false);
             for (int i = 0; i < torrentData.Files.Length; i++)
                 if (torrentData.Files[i].Priority != Priority.DoNotDownload)
-                    endgameSelector.Or (torrentData.Files[i].GetSelector (bitfield.Length));
+                    endgameSelector.SetTrue (torrentData.Files[i].GetSelector ());
 
             // NAND it with the pieces we already have (i.e. AND it with the pieces we still need to receive)
             endgameSelector.NAnd (bitfield);

--- a/src/MonoTorrent/MonoTorrent/BitField.cs
+++ b/src/MonoTorrent/MonoTorrent/BitField.cs
@@ -333,6 +333,13 @@ namespace MonoTorrent
             return this;
         }
 
+        internal BitField SetTrue (ValueTuple<int, int> range)
+        {
+            for (int i = range.Item1; i <= range.Item2; i++)
+                Set (i, true);
+            return this;
+        }
+
         internal BitField SetTrue (params int[] indices)
         {
             foreach (int index in indices)

--- a/src/MonoTorrent/MonoTorrent/TorrentFile.cs
+++ b/src/MonoTorrent/MonoTorrent/TorrentFile.cs
@@ -163,15 +163,9 @@ namespace MonoTorrent
             return Path.GetHashCode ();
         }
 
-        internal BitField GetSelector (int totalPieces)
+        internal ValueTuple<int, int> GetSelector ()
         {
-            if (selector != null)
-                return selector;
-
-            selector = new BitField (totalPieces);
-            for (int i = StartPieceIndex; i <= EndPieceIndex; i++)
-                selector[i] = true;
-            return selector;
+            return ValueTuple.Create (StartPieceIndex, EndPieceIndex);
         }
 
         public override string ToString ()


### PR DESCRIPTION
Rather than storing one bitfield per TorrentFile just
to represent the start/end piece, we can use a simple
ValueTuple. The bitfield is used as a selector to
simplify some operations, but a ValueTuple representing
the (inclusive) start/end piece can perform the same
job.

The typical usecase is when some files are marked as
'DoNotDownload' and the selector is used to exclude
those pieces in the PiecePicker.