### PR TITLE
[core] Prefer named tuple syntax over ValueTuple

### DIFF
--- a/src/MonoTorrent/MonoTorrent.Client.PiecePicking/PriorityPicker.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.PiecePicking/PriorityPicker.cs
@@ -40,9 +40,9 @@ namespace MonoTorrent.Client.PiecePicking
         {
             public Priority Priority { get; private set; }
             readonly TorrentFile File;
-            public readonly ValueTuple<int, int> Selector;
+            public readonly (int startPiece, int endPiece) Selector;
 
-            public Files (TorrentFile file, ValueTuple<int, int> selector)
+            public Files (TorrentFile file, (int startPiece, int endPiece) selector)
             {
                 Priority = file.Priority;
                 File = file;

--- a/src/MonoTorrent/MonoTorrent.Client.PiecePicking/StandardPicker.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.PiecePicking/StandardPicker.cs
@@ -164,7 +164,7 @@ namespace MonoTorrent.Client.PiecePicking
             requests.Clear ();
         }
 
-        static int IndexComparer (Piece piece, int comparand)
+        static readonly Func<Piece, int, int> IndexComparer = (Piece piece, int comparand)
             => piece.Index.CompareTo (comparand);
 
         public override bool ValidatePiece (IPieceRequester peer, int pieceIndex, int startOffset, int length, out Piece piece)

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/DiskManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/DiskManager.cs
@@ -450,7 +450,7 @@ namespace MonoTorrent.Client
             }
         }
 
-        static Func<TorrentFile, ValueTuple<long, int>, int> Comparator = (file, offsetAndPieceLength) => {
+        static readonly Func<TorrentFile, (long offset, int pieceLength), int> Comparator = (file, offsetAndPieceLength) => {
             // Force these two be longs right at the start so we don't overflow
             // int32s when dealing with large torrents.
             (long offset, long pieceLength) = offsetAndPieceLength;
@@ -466,7 +466,7 @@ namespace MonoTorrent.Client
 
         public static int FindFileIndex (TorrentFile[] files, long offset, int pieceLength)
         {
-            return files.BinarySearch (Comparator, ValueTuple.Create(offset, pieceLength));
+            return files.BinarySearch (Comparator, (offset, pieceLength));
         }
 
         bool Read (ITorrentData manager, long offset, byte[] buffer, int count)

--- a/src/MonoTorrent/MonoTorrent/BitField.cs
+++ b/src/MonoTorrent/MonoTorrent/BitField.cs
@@ -333,9 +333,9 @@ namespace MonoTorrent
             return this;
         }
 
-        internal BitField SetTrue (ValueTuple<int, int> range)
+        internal BitField SetTrue ((int startPiece, int endPiece) range)
         {
-            for (int i = range.Item1; i <= range.Item2; i++)
+            for (int i = range.startPiece; i <= range.endPiece; i++)
                 Set (i, true);
             return this;
         }

--- a/src/MonoTorrent/MonoTorrent/TorrentFile.cs
+++ b/src/MonoTorrent/MonoTorrent/TorrentFile.cs
@@ -155,9 +155,9 @@ namespace MonoTorrent
             return Path.GetHashCode ();
         }
 
-        internal ValueTuple<int, int> GetSelector ()
+        internal (int startPiece, int endPiece) GetSelector ()
         {
-            return ValueTuple.Create (StartPieceIndex, EndPieceIndex);
+            return (StartPieceIndex, EndPieceIndex);
         }
 
         public override string ToString ()


### PR DESCRIPTION
It allows naming the various parameters, which makes
it much easier to consume tuples throughout the codebase.

Suggestion from Therzok.