### PR TITLE
[core] Move some Web operations to the threadpool

### DIFF
--- a/src/MonoTorrent/MonoTorrent.Client.Tracker/HTTPTracker.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Tracker/HTTPTracker.cs
@@ -71,6 +71,11 @@ namespace MonoTorrent.Client.Tracker
 
         protected override async Task<List<Peer>> DoAnnounceAsync (AnnounceParameters parameters)
         {
+            // WebRequest.Create can be a comparatively slow operation as reported
+            // by profiling. Switch this to the threadpool so the querying of default
+            // proxies, and any DNS requests, are definitely not run on the main thread.
+            await MainLoop.SwitchToThreadpool ();
+
             // Clear out previous failure state
             FailureMessage = "";
             WarningMessage = "";
@@ -109,6 +114,11 @@ namespace MonoTorrent.Client.Tracker
 
         protected override async Task DoScrapeAsync (ScrapeParameters parameters)
         {
+            // WebRequest.Create can be a comparatively slow operation as reported
+            // by profiling. Switch this to the threadpool so the querying of default
+            // proxies, and any DNS requests, are definitely not run on the main thread.
+            await MainLoop.SwitchToThreadpool ();
+
             string url = ScrapeUri.OriginalString;
             // If you want to scrape the tracker for *all* torrents, don't append the info_hash.
             if (url.IndexOf ('?') == -1)


### PR DESCRIPTION
The profiler shows these as being potentially slow operations,
so ensure we bounce them to the threadpool so the synchronous
aspect of WebRequest.Create (and WebRequest itself) has no
impact on the main thread.

Partially address https://github.com/alanmcgovern/monotorrent/issues/223