### PR TITLE
[core] Ensure crypto is not on the engine thread

### DIFF
--- a/src/MonoTorrent/MonoTorrent.Client.Encryption/EncryptedSocket.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Encryption/EncryptedSocket.cs
@@ -140,8 +140,8 @@ namespace MonoTorrent.Client.Encryption
             ReusableTask first = SendY ();
             ReusableTask second = ReceiveY ();
             try {
-                await first;
-                await second;
+                await first.ConfigureAwait (false);
+                await second.ConfigureAwait (false);
             } catch (Exception ex) {
                 socket.Dispose ();
                 throw new EncryptionException ("Encrypted handshake failed", ex);
@@ -161,7 +161,7 @@ namespace MonoTorrent.Client.Encryption
             this.initialBuffer = initialBuffer;
             initialBufferOffset = offset;
             initialBufferCount = count;
-            await HandshakeAsync (socket);
+            await HandshakeAsync (socket).ConfigureAwait (false);
         }
 
 
@@ -222,9 +222,9 @@ namespace MonoTorrent.Client.Encryption
         protected async ReusableTask ReceiveY ()
         {
             byte[] otherY = new byte[96];
-            await ReceiveMessage (otherY, 96);
+            await ReceiveMessage (otherY, 96).ConfigureAwait (false);
             S = ModuloCalculator.Calculate (otherY, X);
-            await doneReceiveY ();
+            await doneReceiveY ().ConfigureAwait (false);
         }
 
         protected abstract ReusableTask doneReceiveY ();

--- a/src/MonoTorrent/MonoTorrent.Client.Encryption/PeerAEncryption.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Encryption/PeerAEncryption.cs
@@ -106,25 +106,25 @@ namespace MonoTorrent.Client.Encryption
             }
 
             DoDecrypt (VerificationConstant, 0, VerificationConstant.Length);
-            await Synchronize (VerificationConstant, 616); // 4 B->A: ENCRYPT(VC)
+            await Synchronize (VerificationConstant, 616).ConfigureAwait (false); // 4 B->A: ENCRYPT(VC)
         }
 
         protected override async ReusableTask doneSynchronize ()
         {
-            await base.doneSynchronize (); // 4 B->A: ENCRYPT(VC, ...
+            await base.doneSynchronize ().ConfigureAwait (false); // 4 B->A: ENCRYPT(VC, ...
 
             // The first 4 bytes are the crypto selector. The last 2 bytes are the length of padD.
             byte[] padD = null;
             int verifyBytesLength = 4 + 2;
             byte[] verifyBytes = ClientEngine.BufferPool.Rent (verifyBytesLength);
             try {
-                await ReceiveMessage (verifyBytes, verifyBytesLength); // crypto_select, len(padD) ...
+                await ReceiveMessage (verifyBytes, verifyBytesLength).ConfigureAwait (false); // crypto_select, len(padD) ...
                 DoDecrypt (verifyBytes, 0, verifyBytesLength);
 
                 short padDLength = Message.ReadShort (verifyBytes, 4);
                 padD = ClientEngine.BufferPool.Rent (padDLength);
 
-                await ReceiveMessage (padD, padDLength);
+                await ReceiveMessage (padD, padDLength).ConfigureAwait (false);
                 DoDecrypt (padD, 0, padDLength);
                 SelectCrypto (verifyBytes, true);
             } finally {

--- a/src/MonoTorrent/MonoTorrent.Client.Encryption/PeerBEncryption.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Encryption/PeerBEncryption.cs
@@ -55,17 +55,17 @@ namespace MonoTorrent.Client.Encryption
         protected override async ReusableTask doneReceiveY ()
         {
             byte[] req1 = Hash (Req1Bytes, S);
-            await Synchronize (req1, 628); // 3 A->B: HASH('req1', S)
+            await Synchronize (req1, 628).ConfigureAwait (false); // 3 A->B: HASH('req1', S)
         }
 
         protected override async ReusableTask doneSynchronize ()
         {
-            await base.doneSynchronize ();
+            await base.doneSynchronize ().ConfigureAwait (false);
 
             byte[] verifyBytes = new byte[20 + VerificationConstant.Length + 4 + 2]; // ... HASH('req2', SKEY) xor HASH('req3', S), ENCRYPT(VC, crypto_provide, len(PadC), PadC, len(IA))
 
-            await ReceiveMessage (verifyBytes, verifyBytes.Length);
-            await gotVerification (verifyBytes);
+            await ReceiveMessage (verifyBytes, verifyBytes.Length).ConfigureAwait (false);
+            await gotVerification (verifyBytes).ConfigureAwait (false);
         }
 
         async ReusableTask gotVerification (byte[] verifyBytes)
@@ -94,7 +94,7 @@ namespace MonoTorrent.Client.Encryption
             int lenPadC = Message.ReadShort (verifyBytes, 32) + 2;
             byte[] padC = ClientEngine.BufferPool.Rent (lenPadC);
             try {
-                await ReceiveMessage (padC, lenPadC); // padC
+                await ReceiveMessage (padC, lenPadC).ConfigureAwait (false); // padC
 
                 DoDecrypt (padC, 0, lenPadC);
                 lenInitialPayload = Message.ReadShort (padC, lenPadC - 2);
@@ -103,7 +103,7 @@ namespace MonoTorrent.Client.Encryption
             }
 
             InitialData = new byte[lenInitialPayload]; // ... ENCRYPT(IA)
-            await ReceiveMessage (InitialData, InitialData.Length);
+            await ReceiveMessage (InitialData, InitialData.Length).ConfigureAwait (false);
             DoDecrypt (InitialData, 0, InitialData.Length); // ... ENCRYPT(IA)
 
             // Step Four


### PR DESCRIPTION
Push all the socket crypto work to a background thread.
While it's not a lot of CPU time, it's still stuff which
should be executed on the threadpool so the main loop is
available for syncing, and also to handle things like
StopAsync/StartAsync etc.

Partially addresses https://github.com/alanmcgovern/monotorrent/issues/223