### PR TITLE
[core] Add two states to the TrackerState enum

### DIFF
--- a/src/MonoTorrent/MonoTorrent.Client.Tracker/HTTPTracker.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Tracker/HTTPTracker.cs
@@ -63,6 +63,7 @@ namespace MonoTorrent.Client.Tracker
 
             CanAnnounce = true;
             CanScrape = ScrapeUri != null;
+            Status = TrackerState.Unknown;
 
             // Use a random integer prefixed by our identifier.
             lock (random)
@@ -91,6 +92,7 @@ namespace MonoTorrent.Client.Tracker
             using CancellationTokenRegistration registration = cts.Token.Register (() => request.Abort ());
 
             try {
+                Status = TrackerState.Connecting;
                 response = await request.GetResponseAsync ().ConfigureAwait (false);
             } catch (Exception ex) {
                 Status = TrackerState.Offline;

--- a/src/MonoTorrent/MonoTorrent.Client.Tracker/UdpTracker.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Tracker/UdpTracker.cs
@@ -28,6 +28,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
@@ -36,6 +37,7 @@ using MonoTorrent.Client.Messages.UdpTracker;
 
 namespace MonoTorrent.Client.Tracker
 {
+    [DebuggerDisplay("{" + nameof(Uri)+ "}")]
     class UdpTracker : Tracker
     {
         Task<long> ConnectionIdTask { get; set; }
@@ -48,6 +50,7 @@ namespace MonoTorrent.Client.Tracker
         {
             CanScrape = true;
             CanAnnounce = true;
+            Status = TrackerState.Unknown;
         }
 
         protected override async Task<List<Peer>> DoAnnounceAsync (AnnounceParameters parameters)
@@ -57,6 +60,7 @@ namespace MonoTorrent.Client.Tracker
                     ConnectionIdTask = ConnectAsync ();
                 long connectionId = await ConnectionIdTask;
 
+                Status = TrackerState.Connecting;
                 var message = new AnnounceMessage (DateTime.Now.GetHashCode (), connectionId, parameters);
                 var announce = (AnnounceResponseMessage) await SendAndReceiveAsync (message);
                 MinUpdateInterval = announce.Interval;
@@ -173,11 +177,6 @@ namespace MonoTorrent.Client.Tracker
                     return false;
                 }
             });
-        }
-
-        public override string ToString ()
-        {
-            return Uri.ToString ();
         }
     }
 }

--- a/src/MonoTorrent/MonoTorrent/Enums.cs
+++ b/src/MonoTorrent/MonoTorrent/Enums.cs
@@ -58,8 +58,25 @@ namespace MonoTorrent.Client.Tracker
 {
     public enum TrackerState
     {
+        /// <summary>
+        /// A request has not been sent yet.
+        /// </summary>
+        Unknown,
+        /// <summary>
+        /// Currently sending a request.
+        /// </summary>
+        Connecting,
+        /// <summary>
+        /// The most recent request completed successfully.
+        /// </summary>
         Ok,
+        /// <summary>
+        /// The tracker was unreachable/offline.
+        /// </summary>
         Offline,
+        /// <summary>
+        /// The tracker was reachable but the response it sent was invalid.
+        /// </summary>
         InvalidResponse
     }
 }


### PR DESCRIPTION
Add an 'Unknown' state to represent when we haven't
sent an announce or scrape request to a tracker yet.

Add a 'Connecting' state to represent when we're
sending an Announce or Scrape request.

NOTE: There's the potential for trampling here as
the Announce and Scrape codepaths both write to
the same 'FailureMessage', 'WarningMessage' and
'State' variables. Fixing this will be an API
break.

Fixes https://github.com/alanmcgovern/monotorrent/issues/255