### PR TITLE
[core] Add the ability to wait for metadata to download

### DIFF
--- a/src/MonoTorrent/MonoTorrent.Client/ClientEngine.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/ClientEngine.cs
@@ -284,7 +284,7 @@ namespace MonoTorrent.Client
             var manager = new TorrentManager (magnetLink);
             var metadataCompleted = new TaskCompletionSource<byte[]> ();
             using var registration = token.Register (() => metadataCompleted.TrySetResult (null));
-            manager.MetadataReceived += (o, e) => metadataCompleted.TrySetResult (e);
+            manager.MetadataReceived += (o, e) => metadataCompleted.TrySetResult (e.dict);
 
             await Register (manager, isPublic: false);
             await manager.StartAsync (metadataOnly: true);

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -45,7 +45,7 @@ namespace MonoTorrent.Client
     {
         #region Events
 
-        internal event EventHandler<byte[]> MetadataReceived;
+        internal event EventHandler<(Torrent torrent, byte[] dict)> MetadataReceived;
 
         /// <summary>
         /// This asynchronous event is raised whenever a new incoming, or outgoing, connection
@@ -140,9 +140,9 @@ namespace MonoTorrent.Client
             }
         }
 
-        internal void RaiseMetadataReceived (BEncodedDictionary dict)
+        internal void RaiseMetadataReceived (Torrent torrent, BEncodedDictionary dict)
         {
-            MetadataReceived?.Invoke (this, dict.Encode ());
+            MetadataReceived?.Invoke (this, (torrent, dict.Encode ()));
         }
 
         /// <summary>

--- a/src/MonoTorrent/MonoTorrent.Client/Modes/MetadataMode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/MetadataMode.cs
@@ -157,7 +157,7 @@ namespace MonoTorrent.Client.Modes
                             };
                             // FIXME: Add the trackers too
                             if (Torrent.TryLoad (dict.Encode (), out Torrent t)) {
-                                Manager.RaiseMetadataReceived (dict);
+                                Manager.RaiseMetadataReceived (t, dict);
                                 if (stopWhenDone)
                                     return;
 


### PR DESCRIPTION
StreamProvider can only work when we know which file
needs to be streamed. Add a simple way for users to wait
for the metadata to be downloaded, taking into account the
existence of cached versions of the metadata.

This also exposes a 'Files' property so there is ready
access to the piece of information we need to get a
local or http stream.