### PR TITLE
Upload slots

### DIFF
--- a/src/MonoTorrent.Tests/Client/ChokeUnchokeManagerTests.cs
+++ b/src/MonoTorrent.Tests/Client/ChokeUnchokeManagerTests.cs
@@ -1,0 +1,102 @@
+﻿//
+// ChokeUnchokeManagerTests.cs
+//
+// Authors:
+//   Alan McGovern alan.mcgovern@gmail.com
+//
+// Copyright (C) 2020 Alan McGovern
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+
+
+using System;
+using System.Collections.Generic;
+using MonoTorrent.Client.Messages.Standard;
+
+using NUnit.Framework;
+
+namespace MonoTorrent.Client.Unchoking
+{
+    [TestFixture]
+    public class ChokeUnchokeManagerTests
+    {
+        class Unchokeable : IUnchokeable
+        {
+            public bool Complete { get; set; }
+
+            public long DownloadSpeed { get; set; }
+
+            public long UploadSpeed { get; set; }
+
+            public long MaximumDownloadSpeed { get; set; }
+
+            public long MaximumUploadSpeed { get; set; }
+
+            public int UploadSlots { get; set; }
+
+            public int UploadingTo { get; set; }
+
+            public List<PeerId> Peers { get; } = new List<PeerId> ();
+
+            public Unchokeable (params PeerId[] peers)
+            {
+                Peers.AddRange (peers);
+            }
+        }
+
+        [Test]
+        public void UnchokeOneWithOneSlot ()
+        {
+            var unchokeable = new Unchokeable (PeerId.CreateInterested (10)) {
+                UploadSlots = 1
+            };
+            Assert.IsTrue (unchokeable.Peers[0].AmChoking);
+            new ChokeUnchokeManager (unchokeable).UnchokeReview ();
+            Assert.IsFalse (unchokeable.Peers[0].AmChoking);
+            Assert.AreEqual (1, unchokeable.UploadingTo);
+        }
+        [Test]
+        public void UnchokeThreeWithOneSlot ()
+        {
+            var unchokeable = new Unchokeable (
+                PeerId.CreateInterested (10),
+                PeerId.CreateInterested (10),
+                PeerId.CreateInterested (10)) {
+                UploadSlots = 1
+            };
+            new ChokeUnchokeManager (unchokeable).UnchokeReview ();
+            Assert.AreEqual (1, unchokeable.UploadingTo);
+        }
+
+        [Test]
+        public void UnchokeOneWithUnlimitedSlots()
+        {
+            var unchokeable = new Unchokeable (PeerId.CreateInterested (10)) {
+                UploadSlots = 0
+            };
+            Assert.IsTrue (unchokeable.Peers[0].AmChoking);
+            new ChokeUnchokeManager (unchokeable).UnchokeReview ();
+            Assert.IsFalse (unchokeable.Peers[0].AmChoking);
+            Assert.AreEqual (1, unchokeable.UploadingTo);
+        }
+    }
+}

--- a/src/MonoTorrent/MonoTorrent.Client.Connections/PeerId.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Connections/PeerId.cs
@@ -73,6 +73,13 @@ namespace MonoTorrent.Client
             };
         }
 
+        internal static PeerId CreateInterested (int bitfieldLength)
+        {
+            var peer = CreateNull (bitfieldLength);
+            peer.IsInterested = true;
+            return peer;
+        }
+
         #region Choke/Unchoke
 
         internal long BytesDownloadedAtLastReview { get; set; } = 0;

--- a/src/MonoTorrent/MonoTorrent.Client/ClientEngine.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/ClientEngine.cs
@@ -60,7 +60,7 @@ namespace MonoTorrent.Client
         static readonly Random PeerIdRandomGenerator = new Random ();
         #region Global Constants
 
-        public static readonly bool SupportsInitialSeed = true;
+        public static readonly bool SupportsInitialSeed = false;
         public static readonly bool SupportsLocalPeerDiscovery = true;
         public static readonly bool SupportsWebSeed = true;
         public static readonly bool SupportsExtended = true;

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -152,15 +152,6 @@ namespace MonoTorrent.Client
         /// </summary>
         internal BitField UnhashedPieces { get; set; }
 
-        internal int PeerReviewRoundsComplete {
-            get {
-                if (chokeUnchoker is ChokeUnchokeManager)
-                    return ((ChokeUnchokeManager) chokeUnchoker).ReviewsExecuted;
-                else
-                    return 0;
-            }
-        }
-
         public bool HashChecked { get; internal set; }
 
         public int HashFails { get; internal set; }

--- a/src/MonoTorrent/MonoTorrent.Client/Modes/Mode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/Mode.cs
@@ -67,7 +67,7 @@ namespace MonoTorrent.Client.Modes
             Manager = manager;
             Settings = settings;
 
-            manager.chokeUnchoker = new ChokeUnchokeManager (manager, manager.Settings.MinimumTimeBetweenReviews, manager.Settings.PercentOfMaxRateToSkipReview);
+            manager.chokeUnchoker = new ChokeUnchokeManager (new TorrentManagerUnchokeable (manager));
         }
 
         public void HandleMessage (PeerId id, PeerMessage message)
@@ -636,7 +636,7 @@ namespace MonoTorrent.Client.Modes
 
             // Now choke/unchoke peers; first instantiate the choke/unchoke manager if we haven't done so already
             if (Manager.chokeUnchoker == null)
-                Manager.chokeUnchoker = new ChokeUnchokeManager (Manager, Manager.Settings.MinimumTimeBetweenReviews, Manager.Settings.PercentOfMaxRateToSkipReview);
+                Manager.chokeUnchoker = new ChokeUnchokeManager (new TorrentManagerUnchokeable (Manager));
             Manager.chokeUnchoker.UnchokeReview ();
         }
 
@@ -644,7 +644,7 @@ namespace MonoTorrent.Client.Modes
         {
             //Choke/unchoke peers; first instantiate the choke/unchoke manager if we haven't done so already
             if (Manager.chokeUnchoker == null)
-                Manager.chokeUnchoker = new ChokeUnchokeManager (Manager, Manager.Settings.MinimumTimeBetweenReviews, Manager.Settings.PercentOfMaxRateToSkipReview);
+                Manager.chokeUnchoker = new ChokeUnchokeManager (new TorrentManagerUnchokeable (Manager));
 
             Manager.chokeUnchoker.UnchokeReview ();
         }

--- a/src/MonoTorrent/MonoTorrent.Client/Settings/TorrentSettings.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Settings/TorrentSettings.cs
@@ -107,22 +107,6 @@ namespace MonoTorrent.Client
         public int WebSeedSpeedTrigger { get; set; } = 15 * 1024;
 
         /// <summary>
-        /// The choke/unchoke manager reviews how each torrent is making use of its upload slots.  If appropriate, it releases one of the available slots and uses it to try a different peer
-        /// in case it gives us more data.  This value determines how long (in seconds) needs to expire between reviews.  If set too short, peers will have insufficient time to start
-        /// downloading data and the choke/unchoke manager will choke them too early.  If set too long, we will spend more time than is necessary waiting for a peer to give us data.
-        /// The default is 30 seconds.  A value of 0 disables the choke/unchoke manager altogether.
-        /// </summary>
-        internal TimeSpan MinimumTimeBetweenReviews { get; set; } = TimeSpan.FromSeconds (30);
-
-        /// <summary>
-        /// A percentage between 0 and 100; default 90.
-        /// When downloading, the choke/unchoke manager doesn't make any adjustments if the download speed is greater than this percentage of the maximum download rate.
-        /// That way it will not try to improve download speed when the only likley effect will be to reduce download speeds.
-        /// When uploading, the choke/unchoke manager doesn't make any adjustments if the upload speed is greater than this percentage of the maximum upload rate.
-        /// </summary>
-        internal int PercentOfMaxRateToSkipReview { get; set; } = 90;
-
-        /// <summary>
         /// The time, in seconds, the inactivity manager should wait until it can consider a peer eligible for disconnection.  Peers are disconnected only if they have not provided
         /// any data.  Default is 600.  A value of 0 disables the inactivity manager.
         /// </summary>

--- a/src/MonoTorrent/MonoTorrent.Client/Unchokers/IUnchokeable.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Unchokers/IUnchokeable.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+
+namespace MonoTorrent.Client
+{
+    interface IUnchokeable
+    {
+        /// <summary>
+        /// True if we are currently seeding.
+        /// </summary>
+        bool Complete { get; }
+
+        /// <summary>
+        /// Download speed in bytes/second.
+        /// </summary>
+        long DownloadSpeed { get; }
+
+        /// <summary>
+        /// Upload speed in bytes/second.
+        /// </summary>
+        long UploadSpeed { get; }
+
+        /// <summary>
+        /// Maximum download speed in bytes/second.
+        /// </summary>
+        long MaximumDownloadSpeed { get; }
+
+        /// <summary>
+        /// Maximum upload speed in bytes/second
+        /// </summary>
+        long MaximumUploadSpeed { get; }
+
+        /// <summary>
+        /// The maximum number of peers which can be unchoked concurrently. 0 means unlimited.
+        /// </summary>
+        int UploadSlots { get; }
+
+        /// <summary>
+        /// The number of peers which are currently unchoked.
+        /// </summary>
+        int UploadingTo { get; set; }
+
+        /// <summary>
+        /// List of peers which can be choked/unchoked
+        /// </summary>
+        List<PeerId> Peers { get; }
+    }
+}

--- a/src/MonoTorrent/MonoTorrent.Client/Unchokers/TorrentManagerUnchokeable.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Unchokers/TorrentManagerUnchokeable.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MonoTorrent.Client
+{
+    class TorrentManagerUnchokeable : IUnchokeable
+    {
+        TorrentManager Manager { get; }
+
+        public bool Complete => Manager.Complete;
+
+        public long DownloadSpeed => Manager.Monitor.DownloadSpeed;
+
+        public long UploadSpeed => Manager.Monitor.UploadSpeed;
+
+        public long MaximumDownloadSpeed => Manager.Settings.MaximumDownloadSpeed;
+
+        public long MaximumUploadSpeed => Manager.Settings.MaximumUploadSpeed;
+
+        public int UploadSlots => Manager.Settings.UploadSlots;
+
+        public int UploadingTo {
+            get => Manager.UploadingTo;
+            set => Manager.UploadingTo = value;
+        }
+
+        public List<PeerId> Peers => Manager.Peers.ConnectedPeers;
+
+        public TorrentManagerUnchokeable (TorrentManager manager)
+        {
+            Manager = manager;
+        }
+    }
+}


### PR DESCRIPTION
Fixes some issues with ChokeUnchokeManager.

Firstly, to aid testing, I wrapped TorrentManager in an `IUnchokeable` interface. This lets me mock up the appropriate objects so I can exercise the various parts of the unchoker logic much more easily!

As part of this I removed the old checks for `Connection == null` because this is literally impossible (it's a readonly property) nowadays.

I then fixed the issue where settings UploadSlots to zero would result in no peers being unchoked when we actually want *all* peers to be unchoked.