### PR TITLE
[core] Clean up more code from the Unchoker

### DIFF
--- a/src/MonoTorrent/MonoTorrent.Client/Unchokers/IUnchokeable.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Unchokers/IUnchokeable.cs
@@ -1,13 +1,19 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace MonoTorrent.Client
 {
     interface IUnchokeable
     {
         /// <summary>
+        /// Raised whenever the torrent manager's state changes.
+        /// </summary>
+        event EventHandler<TorrentStateChangedEventArgs> StateChanged;
+
+        /// <summary>
         /// True if we are currently seeding.
         /// </summary>
-        bool Complete { get; }
+        bool Seeding { get; }
 
         /// <summary>
         /// Download speed in bytes/second.

--- a/src/MonoTorrent/MonoTorrent.Client/Unchokers/TorrentManagerUnchokeable.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Unchokers/TorrentManagerUnchokeable.cs
@@ -8,7 +8,12 @@ namespace MonoTorrent.Client
     {
         TorrentManager Manager { get; }
 
-        public bool Complete => Manager.Complete;
+        public event EventHandler<TorrentStateChangedEventArgs> StateChanged {
+            add { Manager.TorrentStateChanged += value; }
+            remove { Manager.TorrentStateChanged -= value; }
+        }
+
+        public bool Seeding => Manager.Complete;
 
         public long DownloadSpeed => Manager.Monitor.DownloadSpeed;
 

--- a/src/MonoTorrent/MonoTorrent/ValueStopwatch.cs
+++ b/src/MonoTorrent/MonoTorrent/ValueStopwatch.cs
@@ -39,6 +39,16 @@ namespace MonoTorrent
             return new ValueStopwatch { startedAt = Stopwatch.GetTimestamp () };
         }
 
+        public static ValueStopwatch WithTime (TimeSpan time)
+        {
+            var offset = Stopwatch.Frequency == TimeSpan.TicksPerSecond
+                ? time.Ticks
+                : time.Ticks * ((double) Stopwatch.Frequency / TimeSpan.TicksPerSecond);
+            return new ValueStopwatch {
+                startedAt = Stopwatch.GetTimestamp () - (long)offset
+            };
+        }
+
         long elapsed;
         long startedAt;
 


### PR DESCRIPTION
Greatly simplify the code in ChokeUnchokeManager. We now run a review every `minimumTimeBetweenReviews` even if we currently have enough free slots
to unchoke all currently interested peers.

The need to track `firstCall` and `isDownloading` was removed. `firstCall` is
unnecessary as we already track 'time since last review' and know when
we have *never* run a review. isDownloading is unnecessary as we used
it to trigger a review when the torrentmanager goes from downloading
to seeding - we handle that case by resetting the timer for the last
review so we execute  a review on the next iteration.