### PR TITLE
Fix for DownloadMode.UpdateSeedingDownloadingState logic

### DIFF
--- a/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/DownloadModeTests.cs
+++ b/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/DownloadModeTests.cs
@@ -397,6 +397,39 @@ namespace MonoTorrent.Client.Modes
         }
 
         [Test]
+        public void PartialProgress_RelatedDownloaded_FileAdded ()
+        {
+            Manager.OnPieceHashed (0, true);
+
+            foreach (var file in Manager.Torrent.Files)
+                file.Priority = Priority.DoNotDownload;
+            Manager.Torrent.Files.First ().Priority = Priority.Normal;
+
+            var mode = new DownloadMode (Manager, DiskManager, ConnectionManager, Settings);
+            Manager.Mode = mode;
+            mode.UpdateSeedingDownloadingState ();
+            Assert.AreEqual (TorrentState.Seeding, Manager.State, "#1");
+
+            Manager.Torrent.Files.Skip (1).First ().Priority = Priority.Normal;
+            TorrentState oldState = TorrentState.Error;
+            TorrentState newState = TorrentState.Error;
+            Manager.TorrentStateChanged += (object sender, TorrentStateChangedEventArgs e) => {
+                oldState = e.OldState;
+                newState = e.NewState;
+            };
+            mode.UpdateSeedingDownloadingState ();
+
+            Assert.That (Manager.Progress, Is.GreaterThan (0.0), "#3a");
+            Assert.That (Manager.Progress, Is.LessThan (100.0), "#3b");
+
+            Assert.That (Manager.PartialProgress, Is.LessThan (100.0), "#4");
+            Assert.AreEqual (TorrentState.Downloading, Manager.State, "#5");
+
+            Assert.AreEqual (TorrentState.Seeding, oldState, "#6");
+            Assert.AreEqual (TorrentState.Downloading, newState, "#7");
+        }
+
+        [Test]
         public void PartialProgress_UnrelatedDownloaded_AllDoNotDownload ()
         {
             Manager.OnPieceHashed (0, true);

--- a/src/MonoTorrent/MonoTorrent.Client/Modes/DownloadMode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/DownloadMode.cs
@@ -87,8 +87,8 @@ namespace MonoTorrent.Client.Modes
                     state = TorrentState.Seeding;
                     Manager.RaiseTorrentStateChanged (new TorrentStateChangedEventArgs (Manager, TorrentState.Downloading, TorrentState.Seeding));
                 } else if (Manager.Bitfield.CountTrue (Manager.PartialProgressSelector) < Manager.PartialProgressSelector.TrueCount && state == TorrentState.Seeding) {
-                    state = TorrentState.Seeding;
-                    Manager.RaiseTorrentStateChanged (new TorrentStateChangedEventArgs (Manager, TorrentState.Downloading, TorrentState.Seeding));
+                    state = TorrentState.Downloading;
+                    Manager.RaiseTorrentStateChanged (new TorrentStateChangedEventArgs (Manager, TorrentState.Seeding, TorrentState.Downloading));
                 }
             }
         }


### PR DESCRIPTION
- Fix for DownloadMode.UpdateSeedingDownloadingState logic. Currently it sends multiple TorrentStateChanged events during download