### PR TITLE
[core] Properly handle bitfield messages in metadata mode

### DIFF
--- a/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/MetadataModeTests.cs
+++ b/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/MetadataModeTests.cs
@@ -34,6 +34,7 @@ using System.Threading.Tasks;
 
 using MonoTorrent.Client.Encryption;
 using MonoTorrent.Client.Messages;
+using MonoTorrent.Client.Messages.FastPeer;
 using MonoTorrent.Client.Messages.Libtorrent;
 using MonoTorrent.Client.Messages.Standard;
 
@@ -113,11 +114,35 @@ namespace MonoTorrent.Client.Modes
         }
 
         [Test]
+        public async Task AfterHandshake_SendBitfieldMessage()
+        {
+            var torrent = Path.Combine (AppDomain.CurrentDomain.BaseDirectory, "file.torrent");
+            await Setup (true, torrent);
+            await SendMetadataCore (torrent, new BitfieldMessage (rig.Torrent.Pieces.Count));
+        }
+
+        [Test]
+        public async Task AfterHandshake_SendHaveAllMessage()
+        {
+            var torrent = Path.Combine (AppDomain.CurrentDomain.BaseDirectory, "file.torrent");
+            await Setup (true, torrent);
+            await SendMetadataCore (torrent, new HaveAllMessage ());
+        }
+
+        [Test]
+        public async Task AfterHandshake_SendHaveNoneMessage()
+        {
+            var torrent = Path.Combine (AppDomain.CurrentDomain.BaseDirectory, "file.torrent");
+            await Setup (true, torrent);
+            await SendMetadataCore (torrent, new HaveNoneMessage ());
+        }
+
+        [Test]
         public async Task SendMetadata_ToFile ()
         {
             var torrent = Path.Combine (AppDomain.CurrentDomain.BaseDirectory, "file.torrent");
             await Setup (true, torrent);
-            await SendMetadataCore (torrent);
+            await SendMetadataCore (torrent, new HaveNoneMessage ());
         }
 
         [Test]
@@ -126,7 +151,7 @@ namespace MonoTorrent.Client.Modes
             var torrent = Path.Combine (AppDomain.CurrentDomain.BaseDirectory, "file.torrent");
             File.Create (torrent).Close ();
             await Setup (true, torrent);
-            await SendMetadataCore (torrent);
+            await SendMetadataCore (torrent, new HaveNoneMessage ());
         }
 
         [Test]
@@ -136,7 +161,7 @@ namespace MonoTorrent.Client.Modes
             await Setup (true, torrent);
             File.WriteAllBytes (torrent, rig.Torrent.ToBytes ());
 
-            await SendMetadataCore (torrent);
+            await SendMetadataCore (torrent, new HaveNoneMessage ());
         }
 
         [Test]
@@ -144,7 +169,8 @@ namespace MonoTorrent.Client.Modes
         {
             await Setup (true, AppDomain.CurrentDomain.BaseDirectory);
             await SendMetadataCore (Path.Combine (AppDomain.CurrentDomain.BaseDirectory,
-                $"{rig.Torrent.InfoHash.ToHex ()}.torrent"));
+                $"{rig.Torrent.InfoHash.ToHex ()}.torrent")
+                , new HaveNoneMessage ());
         }
 
         [Test]
@@ -152,7 +178,7 @@ namespace MonoTorrent.Client.Modes
         {
             var torrent = Path.Combine (AppDomain.CurrentDomain.BaseDirectory, "file.torrent");
             await Setup (true, torrent, multiFile: false);
-            await SendMetadataCore (torrent);
+            await SendMetadataCore (torrent, new HaveNoneMessage ());
 
             Assert.AreEqual (@"test.files", rig.Manager.Torrent.Name);
             Assert.AreEqual (@"", rig.Manager.SavePath);
@@ -168,7 +194,7 @@ namespace MonoTorrent.Client.Modes
         {
             var torrent = Path.Combine (AppDomain.CurrentDomain.BaseDirectory, "file.torrent");
             await Setup (true, torrent, multiFile: true);
-            await SendMetadataCore (torrent);
+            await SendMetadataCore (torrent, new HaveNoneMessage ());
 
             Assert.AreEqual (@"test.files", rig.Manager.Torrent.Name);
             Assert.AreEqual (@"test.files", rig.Manager.SavePath);
@@ -186,7 +212,7 @@ namespace MonoTorrent.Client.Modes
             Assert.AreEqual (Path.Combine ("test.files", "File4"), torrentFiles[3].FullPath);
         }
 
-        public async Task SendMetadataCore (string expectedPath)
+        internal async Task SendMetadataCore (string expectedPath, PeerMessage sendAfterHandshakeMessage)
         {
             CustomConnection connection = pair.Incoming;
 
@@ -198,6 +224,9 @@ namespace MonoTorrent.Client.Modes
             exHand.Supports.Add (LTMetadata.Support);
             await PeerIO.SendMessageAsync (connection, encryptor, exHand);
 
+            await PeerIO.SendMessageAsync (connection, encryptor, sendAfterHandshakeMessage);
+
+            bool receivedHaveNone = false;
             // 2) Receive the metadata requests from the other peer and fulfill them
             byte[] buffer = rig.Torrent.Metadata;
             int length = (buffer.Length + 16383) / 16384;
@@ -205,6 +234,8 @@ namespace MonoTorrent.Client.Modes
             while (length > 0 && (m = await PeerIO.ReceiveMessageAsync (connection, decryptor)) != null) {
                 if (m is ExtendedHandshakeMessage ex) {
                     Assert.AreEqual (ClientEngine.DefaultMaxPendingRequests, ex.MaxRequests);
+                } else if (m is HaveNoneMessage) {
+                    receivedHaveNone = true;
                 } else if (m is LTMetadata metadata) {
                     if (metadata.MetadataMessageType == LTMetadata.eMessageType.Request) {
                         metadata = new LTMetadata (LTMetadata.Support.MessageId, LTMetadata.eMessageType.Data, metadata.Piece, buffer);
@@ -224,6 +255,7 @@ namespace MonoTorrent.Client.Modes
             Assert.AreEqual (2, rig.Manager.Torrent.AnnounceUrls.Count, "#3");
             Assert.AreEqual (2, rig.Manager.Torrent.AnnounceUrls[0].Count, "#4");
             Assert.AreEqual (3, rig.Manager.Torrent.AnnounceUrls[1].Count, "#5");
+            Assert.IsTrue (receivedHaveNone, "#6");
         }
     }
 }

--- a/src/MonoTorrent/MonoTorrent.Client.Messages/BitfieldMessage.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Messages/BitfieldMessage.cs
@@ -27,6 +27,8 @@
 //
 
 
+using System;
+
 namespace MonoTorrent.Client.Messages.Standard
 {
     /// <summary>
@@ -35,6 +37,8 @@ namespace MonoTorrent.Client.Messages.Standard
     class BitfieldMessage : PeerMessage
     {
         internal static readonly byte MessageId = 5;
+
+        internal static readonly BitfieldMessage UnknownLength = new BitfieldMessage (null);
 
         #region Member Variables
         /// <summary>
@@ -71,11 +75,13 @@ namespace MonoTorrent.Client.Messages.Standard
 
         public override void Decode (byte[] buffer, int offset, int length)
         {
-            BitField.FromArray (buffer, offset);
+            BitField?.FromArray (buffer, offset);
         }
 
         public override int Encode (byte[] buffer, int offset)
         {
+            if (BitField == null)
+                throw new InvalidOperationException ("Cannot send a BitfieldMessage without a Bitfield. Are you trying to send a bitfield during metadata mode?");
             int written = offset;
 
             written += Write (buffer, written, BitField.LengthInBytes + 1);

--- a/src/MonoTorrent/MonoTorrent.Client.Messages/PeerMessage.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Messages/PeerMessage.cs
@@ -48,7 +48,7 @@ namespace MonoTorrent.Client.Messages
             // Note - KeepAlive messages aren't registered as they have no payload or ID and are never 'decoded'
             //      - Handshake messages aren't registered as they are always the first message sent/received
             Register (AllowedFastMessage.MessageId, data => new AllowedFastMessage ());
-            Register (BitfieldMessage.MessageId, data => new BitfieldMessage ((int) Math.Ceiling ((double) data.Size / data.PieceLength)));
+            Register (BitfieldMessage.MessageId, data => data == null ? BitfieldMessage.UnknownLength : new BitfieldMessage (data.PieceCount ()));
             Register (CancelMessage.MessageId, data => new CancelMessage ());
             Register (ChokeMessage.MessageId, data => new ChokeMessage ());
             Register (HaveAllMessage.MessageId, data => new HaveAllMessage ());

--- a/src/MonoTorrent/MonoTorrent.Client/Modes/InitialSeedingMode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/InitialSeedingMode.cs
@@ -50,7 +50,7 @@ namespace MonoTorrent.Client.Modes
 
         protected override void AppendBitfieldMessage (PeerId id, MessageBundle bundle)
         {
-            if (id.SupportsFastPeer)
+            if (ClientEngine.SupportsFastPeer && id.SupportsFastPeer)
                 bundle.Messages.Add (new HaveNoneMessage ());
             else
                 bundle.Messages.Add (new BitfieldMessage (zero));
@@ -93,7 +93,7 @@ namespace MonoTorrent.Client.Modes
                 PeerMessage bitfieldMessage = new BitfieldMessage (Manager.Bitfield);
                 PeerMessage haveAllMessage = new HaveAllMessage ();
                 foreach (PeerId peer in Manager.Peers.ConnectedPeers) {
-                    PeerMessage message = peer.SupportsFastPeer && Manager.Complete ? haveAllMessage : bitfieldMessage;
+                    PeerMessage message = ClientEngine.SupportsFastPeer && peer.SupportsFastPeer && Manager.Complete ? haveAllMessage : bitfieldMessage;
                     peer.Enqueue (message);
                 }
                 Manager.Mode = new DownloadMode (Manager, DiskManager, ConnectionManager, Settings);

--- a/src/MonoTorrent/MonoTorrent.Client/Modes/MetadataMode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/MetadataMode.cs
@@ -36,7 +36,9 @@ using System.Threading.Tasks;
 
 using MonoTorrent.BEncoding;
 using MonoTorrent.Client.Messages;
+using MonoTorrent.Client.Messages.FastPeer;
 using MonoTorrent.Client.Messages.Libtorrent;
+using MonoTorrent.Client.Messages.Standard;
 
 namespace MonoTorrent.Client.Modes
 {
@@ -284,8 +286,20 @@ namespace MonoTorrent.Client.Modes
 
         protected override void AppendBitfieldMessage (PeerId id, MessageBundle bundle)
         {
-            // We can't send a bitfield message in metadata mode as
-            // we don't know what size the bitfield is
+            if (ClientEngine.SupportsFastPeer && id.SupportsFastPeer)
+                bundle.Messages.Add (new HaveNoneMessage ());
+            // If the fast peer extensions are not supported we must not send a
+            // bitfield message because we don't know how many pieces the torrent
+            // has. We could probably send an invalid one and force the connection
+            // to close.
+        }
+
+        protected override void HandleBitfieldMessage (PeerId id, BitfieldMessage message)
+        {
+            // If we receive a bitfield message we should ignore it. We don't know how many
+            // pieces the torrent has so we can't actually safely decode the bitfield.
+            if (message != BitfieldMessage.UnknownLength)
+                throw new InvalidOperationException ("BitfieldMessages should not be decoded normally while in metadata mode.");
         }
 
         protected override void HandleExtendedHandshakeMessage (PeerId id, ExtendedHandshakeMessage message)

--- a/src/MonoTorrent/MonoTorrent/ITorrentData.cs
+++ b/src/MonoTorrent/MonoTorrent/ITorrentData.cs
@@ -31,8 +31,31 @@ namespace MonoTorrent
 {
     public interface ITorrentData
     {
+        // FIXME: Make all instances of TorrentFile[] be a readonly IList<T>
+        /// <summary>
+        /// The files contained within the Torrent
+        /// </summary>
         TorrentFile[] Files { get; }
+
+        /// <summary>
+        /// The size, in bytes, of each piece
+        /// </summary>
         int PieceLength { get; }
+
+        /// <summary>
+        /// The size, in bytes, of the torrent.
+        /// </summary>
         long Size { get; }
+    }
+
+    static class ITorrentDataExtensions
+    {
+        /// <summary>
+        /// The number of pieces in the torrent
+        /// </summary>
+        /// <param name="self"></param>
+        /// <returns></returns>
+        public static int PieceCount (this ITorrentData self)
+            => (int) (self.Size / self.PieceLength) + (self.Size % self.PieceLength != 0 ? 1 : 0);
     }
 }


### PR DESCRIPTION
We should ignore them when they're received. This is
implemented by special casing the situation where a
BitfieldMessage is received while we do not have
metadata - in this scenario we return the special value
'BitfieldMessage.UnknownValue' which we can check for
later.

If we attempt to *send* this to a peer it will error
out when you invoke 'Encode'. The MetadataMode overload
for 'HandleBitfield' asserts that all bitfields were
decoded as this sentinal value.

Before this patch we could only retrieve metadata from
peers which have no data, or from seeders. With this
patch we can download metadata from leechers too.