### PR TITLE
accepting block even if hash check failed for other peer

### DIFF
--- a/src/MonoTorrent/MonoTorrent.Client.PiecePicking/StandardPicker.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.PiecePicking/StandardPicker.cs
@@ -239,8 +239,7 @@ namespace MonoTorrent.Client.PiecePicking
                 Piece p = requests[pIndex];
                 // If the peer who this piece is assigned to is dodgy or if the blocks are all request or
                 // the peer doesn't have this piece, we don't want to help download the piece.
-                if (p.AllBlocksRequested || p.AllBlocksReceived || !peer.BitField[p.Index] ||
-                    (p.Blocks[0].RequestedOff != null && p.Blocks[0].RequestedOff.RepeatedHashFails != 0))
+                if (p.AllBlocksRequested || p.AllBlocksReceived || !peer.BitField[p.Index])
                     continue;
 
                 for (int i = p.Blocks.Length - 1; i >= 0; i--)


### PR DESCRIPTION
When I debugged picker logic I got to this line.
I'm not sure that I understand why it is necessary to skip block when hash check fails for some other random peer. I think this is not necessary.
Of course I might be missing something, please take a look.