### PR TITLE
issue#322 Using MulticastIpAddress instead of IPAddress.Broadcast for initializing UdpClient in LPD

### DIFF
--- a/src/MonoTorrent/MonoTorrent.Client/LocalPeerDiscovery.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/LocalPeerDiscovery.cs
@@ -108,7 +108,7 @@ namespace MonoTorrent.Client
 
             lock (Random)
                 Cookie = $"{VersionInfo.ClientVersion}-{Random.Next (1, int.MaxValue)}";
-            BroadcastEndPoint = new IPEndPoint (IPAddress.Broadcast, MulticastPort);
+            BroadcastEndPoint = new IPEndPoint (MulticastIpAddress, MulticastPort);
             BaseSearchString = $"BT-SEARCH * HTTP/1.1\r\nHost: {MulticastIpAddress}:{MulticastPort}\r\nPort: {{0}}\r\nInfohash: {{1}}\r\ncookie: {Cookie}\r\n\r\n\r\n";
             PendingAnnounces = new Queue<InfoHash> ();
             RateLimiterTask = Task.CompletedTask;


### PR DESCRIPTION
The description of a problem is [here](https://github.com/alanmcgovern/monotorrent/issues/322)