### PR TITLE
Fixed the issue when Torrent.Source stays null when torrent was loaded using Torrent.Load(string path) method

### DIFF
--- a/src/MonoTorrent/MonoTorrent/Torrent.cs
+++ b/src/MonoTorrent/MonoTorrent/Torrent.cs
@@ -560,7 +560,9 @@ namespace MonoTorrent
             Check.Path (path);
 
             try {
-                return LoadCore ((BEncodedDictionary) BEncodedValue.Decode (stream));
+                var torrent = LoadCore ((BEncodedDictionary) BEncodedValue.Decode (stream));
+                torrent.Source = path;
+                return torrent;
             } catch (BEncodingException ex) {
                 throw new TorrentException ("Invalid torrent file specified", ex);
             }


### PR DESCRIPTION
These lines were replaced in 6a32c0c0421a05054361711ae41108821234988a commit, but I think this was done by mistake, because now Torrent.Source is always null even if loading torrent from file. 