### PR TITLE
Mono.Nat package update fix.

### DIFF
--- a/src/MonoTorrent/MonoTorrent.Client.PortForwarding/MonoNatPortForwarder.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.PortForwarding/MonoNatPortForwarder.cs
@@ -60,11 +60,6 @@ namespace MonoTorrent.Client.PortForwarding
 
                 RaiseMappingsChangedAsync ();
             };
-
-            NatUtility.DeviceLost += async (o, e) => {
-                await ClientEngine.MainLoop;
-                Devices = Devices.Except (new[] { e.Device }).ToArray ();
-            };
         }
 
         public async Task RegisterMappingAsync (Mapping mapping)

--- a/src/MonoTorrent/MonoTorrent.csproj
+++ b/src/MonoTorrent/MonoTorrent.csproj
@@ -91,8 +91,8 @@ Notable features include:
   </Target>
 
   <ItemGroup>
-    <PackageReference Include="GitInfo" Version="2.0.26" PrivateAssets="all" />
-    <PackageReference Include="Mono.Nat" Version="2.0.2" />
+    <PackageReference Include="GitInfo" Version="2.0.34" PrivateAssets="all" />
+    <PackageReference Include="Mono.Nat" Version="3.0.0" />
     <PackageReference Include="ReusableTasks" Version="2.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
App is crashing after Mono.Nat was updated. Previous implementation had a DeviceLost event, that is was removed.
Exception: System.MissingMethodException: Method not found: 'Void Mono.Nat.NatUtility.add_DeviceLost(System.EventHandler`1<Mono.Nat.DeviceEventArgs>)'.