### PR TITLE
Fix moving unfinished, stopped torrent.

### DIFF
--- a/src/MonoTorrent/MonoTorrent.Client/Managers/DiskManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/DiskManager.cs
@@ -343,7 +343,9 @@ namespace MonoTorrent.Client
 
             foreach (TorrentFileInfo file in manager.Files) {
                 string newPath = Path.Combine (newRoot, file.Path);
-                await Writer.MoveAsync (file, newPath, overwrite);
+                if (await Writer.ExistsAsync (file)) {
+                    await Writer.MoveAsync (file, newPath, overwrite);
+                }
                 file.FullPath = newPath;
             }
         }


### PR DESCRIPTION
Moving files of even a stopped torrent will crash if a file does not yet exist. This checks for existence first and does not move the not existing file.