### PR TITLE
[core] Compute the correct infohash for misordered dictionaries

### DIFF
--- a/src/MonoTorrent.Tests/Common/BEncodingTest.cs
+++ b/src/MonoTorrent.Tests/Common/BEncodingTest.cs
@@ -420,6 +420,15 @@ namespace MonoTorrent.Common
         }
 
         [Test]
+        public void DecodeDictionary_OutOfOrder_DefaultIsNotStrict()
+        {
+            string benString = "d1:b1:b1:a1:ae";
+            var dict = (BEncodedDictionary) BEncodedValue.Decode (Encoding.UTF8.GetBytes (benString));
+            Assert.IsTrue (dict.ContainsKey ("a"));
+            Assert.IsTrue (dict.ContainsKey ("b"));
+        }
+
+        [Test]
         public void DecodeDictionary_OutOfOrder_NotStrict ()
         {
             string benString = "d1:b1:b1:a1:ae";
@@ -525,14 +534,15 @@ namespace MonoTorrent.Common
         }
 
         [Test]
-        public void DecodeTorrentWithDict ()
+        public void DecodeTorrentWithOutOfOrderKeys ()
         {
-            var dict = new BEncodedDictionary {
-                { "other", new BEncodedDictionary   { { "test", new BEncodedString ("value") } } }
-            };
+            var good = "d4:infod5:key_a7:value_a5:key_b7:value_bee";
+            var bad = "d4:infod5:key_b7:value_b5:key_a7:value_aee";
 
-            var result = BEncodedDictionary.DecodeTorrent (dict.Encode ());
-            Assert.IsTrue (Toolbox.ByteMatch (dict.Encode (), result.Encode ()));
+            var good_result = BEncodedDictionary.DecodeTorrent (Encoding.UTF8.GetBytes (good));
+            var bad_result = BEncodedDictionary.DecodeTorrent (Encoding.UTF8.GetBytes (bad));
+            Assert.IsTrue (Toolbox.ByteMatch (good_result.torrent.Encode (), bad_result.torrent.Encode ()));
+            Assert.AreNotEqual (good_result.infohash, bad_result.infohash);
         }
 
         [Test]
@@ -546,7 +556,7 @@ namespace MonoTorrent.Common
             };
 
             var result = BEncodedDictionary.DecodeTorrent (dict.Encode ());
-            Assert.IsTrue (Toolbox.ByteMatch (dict.Encode (), result.Encode ()));
+            Assert.IsTrue (Toolbox.ByteMatch (dict.Encode (), result.torrent.Encode ()));
         }
 
 
@@ -558,7 +568,7 @@ namespace MonoTorrent.Common
             };
 
             var result = BEncodedDictionary.DecodeTorrent (dict.Encode ());
-            Assert.IsTrue (Toolbox.ByteMatch (dict.Encode (), result.Encode ()));
+            Assert.IsTrue (Toolbox.ByteMatch (dict.Encode (), result.torrent.Encode ()));
         }
 
     }

--- a/src/MonoTorrent/MonoTorrent.BEncoding/BEncodedDictionary.cs
+++ b/src/MonoTorrent/MonoTorrent.BEncoding/BEncodedDictionary.cs
@@ -84,12 +84,12 @@ namespace MonoTorrent.BEncoding
             return written;
         }
 
-        public static BEncodedDictionary DecodeTorrent (byte[] bytes)
+        public static (BEncodedDictionary torrent, InfoHash infohash) DecodeTorrent (byte[] bytes)
         {
             return DecodeTorrent (new MemoryStream (bytes));
         }
 
-        public static BEncodedDictionary DecodeTorrent (Stream s)
+        public static (BEncodedDictionary torrent, InfoHash infohash) DecodeTorrent (Stream s)
         {
             return DecodeTorrent (new RawReader (s));
         }
@@ -100,7 +100,7 @@ namespace MonoTorrent.BEncoding
         /// overall torrent file, but imposes strict rules on the info dictionary.
         /// </summary>
         /// <returns></returns>
-        public static BEncodedDictionary DecodeTorrent (RawReader reader)
+        public static (BEncodedDictionary torrent, InfoHash infohash) DecodeTorrent (RawReader reader)
         {
             return BEncodeDecoder.DecodeTorrent (reader);
         }

--- a/src/MonoTorrent/MonoTorrent.Client/Modes/MetadataMode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/MetadataMode.cs
@@ -260,22 +260,6 @@ namespace MonoTorrent.Client.Modes
             requestTimeout = DateTime.Now.Add (timeout);
         }
 
-        internal Torrent GetTorrent ()
-        {
-            byte[] calculatedInfoHash;
-            using (SHA1 sha = HashAlgoFactory.SHA1 ())
-                calculatedInfoHash = sha.ComputeHash (Stream.ToArray ());
-            if (!Manager.InfoHash.Equals (calculatedInfoHash))
-                throw new Exception ("invalid metadata");//restart ?
-
-            var d = BEncodedValue.Decode (Stream);
-            var dict = new BEncodedDictionary {
-                { "info", d }
-            };
-
-            return Torrent.LoadCore (dict);
-        }
-
         protected override void AppendBitfieldMessage (PeerId id, MessageBundle bundle)
         {
             if (ClientEngine.SupportsFastPeer && id.SupportsFastPeer)


### PR DESCRIPTION
If a BEncodedDictionary has been encoded with the keys in the
wrong order, we will now compute the infohash based on the
underlying bytes. This is the other spec compliant approach.

The first spec compliant approach is to reject the torrent.
Unfortunately there are plenty of invalid torrents out there,
so at this stage we may as well do the work to support this.

This should not be any worse performance wise as the original
approach.

Solves https://github.com/alanmcgovern/monotorrent/issues/332