### PR TITLE
[core] Fix a threading issue in FlushAsync

### DIFF
--- a/src/MonoTorrent.Tests/Client/DiskWriterTests.cs
+++ b/src/MonoTorrent.Tests/Client/DiskWriterTests.cs
@@ -66,6 +66,8 @@ namespace MonoTorrent.Client.PieceWriters
         public async Task CloseFileAsync_Opened ()
         {
             using var writer = new DiskWriter ();
+            using var locker = await TorrentFile.Locker.EnterAsync ();
+
             await writer.WriteAsync (TorrentFile, 0, new byte[10], 0, 10);
             Assert.IsTrue (File.Exists (TorrentFile.FullPath));
 
@@ -74,10 +76,11 @@ namespace MonoTorrent.Client.PieceWriters
         }
 
         [Test]
-        public void CloseFileAsync_Unopened()
+        public async Task CloseFileAsync_Unopened()
         {
             using var writer = new DiskWriter ();
-            Assert.DoesNotThrowAsync (async () => await writer.CloseAsync (TorrentFile));
+            using (await TorrentFile.Locker.EnterAsync ())
+                Assert.DoesNotThrowAsync (async () => await writer.CloseAsync (TorrentFile));
         }
 
         [Test]
@@ -94,11 +97,15 @@ namespace MonoTorrent.Client.PieceWriters
             };
             using var writer = new DiskWriter (creator, 1);
 
+            using var locker = await TorrentFile.Locker.EnterAsync ();
+
             var writeTask = writer.WriteAsync (TorrentFile, 0, new byte[100], 0, 100);
             await streamCreated.Task.WithTimeout ();
 
             // There's a limit of 1 concurrent read/write.
             var secondStreamWaiter = streamCreated.Task.AsTask ();
+
+            using var secondLocker = await Others.First ().Locker.EnterAsync ();
             var secondStream = writer.WriteAsync (Others.First (), 0, new byte[100], 0, 100);
             Assert.ThrowsAsync<TimeoutException> (() => secondStreamWaiter.WithTimeout (100));
 

--- a/src/MonoTorrent/MonoTorrent.Client/FileStreamBuffer.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/FileStreamBuffer.cs
@@ -96,6 +96,8 @@ namespace MonoTorrent.Client.PieceWriters
 
         internal RentedStream GetStream (ITorrentFileInfo file)
         {
+            file.ThrowIfNotLocked ();
+
             if (Streams.TryGetValue (file, out ITorrentFileStream stream))
                 return new RentedStream (stream);
             return new RentedStream (null);
@@ -103,6 +105,8 @@ namespace MonoTorrent.Client.PieceWriters
 
         internal async ReusableTask<RentedStream> GetStreamAsync (ITorrentFileInfo file, FileAccess access)
         {
+            file.ThrowIfNotLocked ();
+
             if (!Streams.TryGetValue (file, out ITorrentFileStream s))
                 s = null;
 
@@ -160,6 +164,8 @@ namespace MonoTorrent.Client.PieceWriters
 
         void CloseAndRemove (ITorrentFileInfo file, ITorrentFileStream s)
         {
+            file.ThrowIfNotLocked ();
+
             logger.InfoFormatted ("Closing and removing: {0}", file.Path);
             Streams.Remove (file);
             UsageOrder.Remove (file);

--- a/src/MonoTorrent/MonoTorrent.Client/MainLoop.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/MainLoop.cs
@@ -30,6 +30,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
@@ -203,6 +204,13 @@ namespace MonoTorrent.Client
             return new ThreadSwitcher ();
         }
 
-#endregion
+        [Conditional("DEBUG")]
+        internal void CheckThread ()
+        {
+            if (Thread.CurrentThread != thread)
+                throw new InvalidOperationException ($"Missing context switch to the {thread.Name} MainLoop.");
+        }
+
+        #endregion
     }
 }

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/ITorrentFileInfo.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/ITorrentFileInfo.cs
@@ -27,6 +27,7 @@
 //
 
 
+using System.Diagnostics;
 using System.Threading;
 
 namespace MonoTorrent.Client
@@ -34,9 +35,12 @@ namespace MonoTorrent.Client
 
     public interface ITorrentFileInfo : ITorrentFile
     {
+        // FIXME: make BitField readonly.
         BitField BitField { get; }
         string FullPath { get; }
         Priority Priority { get; set; }
+
+        // FIXME: Make this internal.
         SemaphoreSlim Locker { get; }
 
         (int startPiece, int endPiece) GetSelector ();
@@ -46,5 +50,12 @@ namespace MonoTorrent.Client
     {
         public static long BytesDownloaded (this ITorrentFileInfo info)
             => (long) (info.BitField.PercentComplete * info.Length / 100.0);
+
+        [Conditional ("DEBUG")]
+        internal static void ThrowIfNotLocked(this ITorrentFileInfo info)
+        {
+            if (info.Locker.CurrentCount > 0)
+                throw new System.InvalidOperationException ("File should have been locked before it was accessed");
+        }
     }
 }


### PR DESCRIPTION
We should ensure we're executing on the IO thread
when we're interacting with the filestreams.

The 'Tick' method is invoked from the main engine's
tick so it'll be on the wrong thread unless we swap
here.

Also, ensure we take an async lock on the filestream
we intend to flush. This ensures there's multi-threaded
IO, but each stream is accessed in a single-threaded way.

Fixes https://github.com/alanmcgovern/monotorrent/issues/345