### PR TITLE
[core] Swap to a more efficient SemaphoreSlim impl

### DIFF
--- a/src/MonoTorrent.Tests/Client/ManualStream.cs
+++ b/src/MonoTorrent.Tests/Client/ManualStream.cs
@@ -45,7 +45,7 @@ namespace MonoTorrent.Client.PieceWriters
 
         public long Position { get; private set; }
 
-        public SemaphoreSlim Locker { get; } = new SemaphoreSlim (1);
+        public ReusableExclusiveSemaphore Locker { get; } = new ReusableExclusiveSemaphore ();
 
         public ReusableTaskCompletionSource<int> WriteTcs { get; set; }
 

--- a/src/MonoTorrent/MonoTorrent.Client/ITorrentFileStream.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/ITorrentFileStream.cs
@@ -41,7 +41,7 @@ namespace MonoTorrent.Client
         long Length { get; }
         long Position { get; }
 
-        SemaphoreSlim Locker { get; }
+        ReusableExclusiveSemaphore Locker { get; }
 
         ReusableTask FlushAsync ();
         ReusableTask<int> ReadAsync (byte[] buffer, int offset, int count);

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentFileInfo.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentFileInfo.cs
@@ -40,7 +40,7 @@ namespace MonoTorrent.Client
 
         public BitField BitField { get; }
 
-        public SemaphoreSlim Locker { get; } = new SemaphoreSlim (1, 1);
+        public ReusableExclusiveSemaphore Locker { get; } = new ReusableExclusiveSemaphore ();
 
         public Priority Priority { get; set; } = Priority.Normal;
 


### PR DESCRIPTION
This allocates far less than the built-in implementation
so it's a net win for monotorrent. The perf delta is
not detectable from a profiler.