### PR TITLE
[core] Improve 'ContinueAnyExistingRequest'

### DIFF
--- a/src/MonoTorrent.Tests/Client/EndGameSwitcherTests.cs
+++ b/src/MonoTorrent.Tests/Client/EndGameSwitcherTests.cs
@@ -93,13 +93,18 @@ namespace MonoTorrent.Client.PiecePicking
             };
 
             foreach (var peer in seeders) {
-                Assert.IsNotNull (Switcher.PickPiece (peer, onePieceLeft, Array.Empty<IPieceRequester> ()), "#1");
+                Assert.IsNotNull (Switcher.PickPiece (peer, onePieceLeft, Array.Empty<IPieceRequester> ()) ?? Switcher.ContinueAnyExisting (peer), "#1");
                 Assert.AreEqual (1, peer.AmRequestingPiecesCount, "#2");
                 Assert.AreSame (Standard, Switcher.ActivePicker, "#3");
             }
 
-            // The next request *should* trigger endgame mode and give a valid request.
-            Assert.IsNotNull (Switcher.PickPiece (SmallTorrent.Seeder, onePieceLeft, Array.Empty<IPieceRequester> ()), "#4");
+            // Trigger endgame mode, but don't pick a piece.
+            Assert.IsInstanceOf<StandardPicker> (Switcher.ActivePicker);
+            Assert.IsNull (Switcher.ContinueAnyExisting (LargeTorrent.Seeder));
+            Assert.IsInstanceOf<EndGamePicker> (Switcher.ActivePicker);
+
+            // The next request *should* get a valid request.
+            Assert.IsNotNull (Switcher.PickPiece (SmallTorrent.Seeder, onePieceLeft, Array.Empty<IPieceRequester> ()) ?? Switcher.ContinueAnyExisting (SmallTorrent.Seeder), "#4");
             Assert.AreSame (Endgame, Switcher.ActivePicker, "#5");
         }
 
@@ -119,12 +124,17 @@ namespace MonoTorrent.Client.PiecePicking
 
             // 256 blocks per piece, request 1 block per peer.
             foreach (var peer in seeders) {
-                Assert.IsNotNull (Switcher.PickPiece (peer, onePieceLeft, Array.Empty<IPieceRequester> ()), "#1");
+                Assert.IsNotNull (Switcher.PickPiece (peer, onePieceLeft, Array.Empty<IPieceRequester> ()) ?? Switcher.ContinueAnyExisting (peer), "#1");
                 Assert.AreEqual (1, peer.AmRequestingPiecesCount, "#2");
                 Assert.AreSame (Standard, Switcher.ActivePicker, "#3");
             }
 
-            // The final request *should* trigger endgame mode and give a valid request.
+            // Trigger endgame mode, but don't pick a piece.
+            Assert.IsInstanceOf<StandardPicker> (Switcher.ActivePicker);
+            Assert.IsNull (Switcher.ContinueAnyExisting (LargeTorrent.Seeder));
+            Assert.IsInstanceOf<EndGamePicker> (Switcher.ActivePicker);
+
+            // The next request *should* get a valid request.
             Assert.IsNotNull (Switcher.PickPiece (LargeTorrent.Seeder, onePieceLeft, Array.Empty<IPieceRequester> ()), "#4");
             Assert.AreSame (Endgame, Switcher.ActivePicker, "#5");
         }

--- a/src/MonoTorrent.Tests/Client/StandardPickerTests.cs
+++ b/src/MonoTorrent.Tests/Client/StandardPickerTests.cs
@@ -408,9 +408,12 @@ namespace MonoTorrent.Client.PiecePicking
                 peer.BitField[i] = true;
 
             IList<PieceRequest> bundle;
+            PieceRequest request;
 
             while ((bundle = picker.PickPiece (peer, peer.BitField, peers, torrentData.BlocksPerPiece * 5)) != null)
                 messages.AddRange (bundle);
+            while ((request = picker.ContinueAnyExisting (peer)) != null)
+                messages.Add (request);
 
             Assert.AreEqual (torrentData.BlocksPerPiece * 7, messages.Count, "#2");
         }

--- a/src/MonoTorrent/MonoTorrent.Client.PiecePicking/EndGamePicker.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.PiecePicking/EndGamePicker.cs
@@ -85,7 +85,10 @@ namespace MonoTorrent.Client.PiecePicking
         {
             CancelWhere (TimedOut, false);
         }
-
+        public override PieceRequest ContinueAnyExisting (IPieceRequester peer)
+        {
+            return null;
+        }
         public override PieceRequest ContinueExistingRequest (IPieceRequester peer)
         {
             return null;

--- a/src/MonoTorrent/MonoTorrent.Client.PiecePicking/EndGameSwitcher.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.PiecePicking/EndGameSwitcher.cs
@@ -81,7 +81,11 @@ namespace MonoTorrent.Client.PiecePicking
 
         public override PieceRequest ContinueAnyExisting (IPieceRequester peer)
         {
-            return ActivePicker.ContinueAnyExisting (peer);
+            var bundle = ActivePicker.ContinueAnyExisting (peer);
+            if (bundle == null && TryEnableEndgame ())
+                return ActivePicker.ContinueAnyExisting (peer);
+            return bundle;
+
         }
         public override PieceRequest ContinueExistingRequest (IPieceRequester peer)
         {
@@ -124,10 +128,7 @@ namespace MonoTorrent.Client.PiecePicking
 
         public override IList<PieceRequest> PickPiece (IPieceRequester peer, BitField available, IReadOnlyList<IPieceRequester> otherPeers, int count, int startIndex, int endIndex)
         {
-            IList<PieceRequest> bundle = ActivePicker.PickPiece (peer, available, otherPeers, count, startIndex, endIndex);
-            if (bundle == null && TryEnableEndgame ())
-                return ActivePicker.PickPiece (peer, available, otherPeers, count, startIndex, endIndex);
-            return bundle;
+            return ActivePicker.PickPiece (peer, available, otherPeers, count, startIndex, endIndex);
         }
 
         bool TryEnableEndgame ()

--- a/src/MonoTorrent/MonoTorrent.Client.PiecePicking/EndGameSwitcher.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.PiecePicking/EndGameSwitcher.cs
@@ -79,6 +79,10 @@ namespace MonoTorrent.Client.PiecePicking
             ActivePicker.CancelTimedOutRequests ();
         }
 
+        public override PieceRequest ContinueAnyExisting (IPieceRequester peer)
+        {
+            return ActivePicker.ContinueAnyExisting (peer);
+        }
         public override PieceRequest ContinueExistingRequest (IPieceRequester peer)
         {
             return ActivePicker.ContinueExistingRequest (peer);

--- a/src/MonoTorrent/MonoTorrent.Client.PiecePicking/PiecePicker.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.PiecePicking/PiecePicker.cs
@@ -65,6 +65,11 @@ namespace MonoTorrent.Client.PiecePicking
             CheckOverriden ();
             BasePicker.CancelTimedOutRequests ();
         }
+        public virtual PieceRequest ContinueAnyExisting (IPieceRequester peer)
+        {
+            CheckOverriden ();
+            return BasePicker.ContinueAnyExisting (peer);
+        }
         public virtual PieceRequest ContinueExistingRequest (IPieceRequester peer)
         {
             CheckOverriden ();

--- a/src/MonoTorrent/MonoTorrent.Client.PiecePicking/StandardPicker.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.PiecePicking/StandardPicker.cs
@@ -137,15 +137,6 @@ namespace MonoTorrent.Client.PiecePicking
             if (peer.IsChoking)
                 return null;
 
-            // Disable this particular piece of logic to increase the likelihood we'll be able
-            // to incrementally hash a piece. If we allow peers to prefer downloading their own
-            // piece then we are much more likely to get every block in order and thus have a full
-            // and successful incremental hash.
-            //// If we are only requesting 1 piece, then we can continue any existing. Otherwise we should try
-            //// to request the full amount first, then try to continue any existing.
-            //if (count == 1 && (message = ContinueAnyExisting(id)) != null)
-            //    return new [] { message };
-
             // We see if the peer has suggested any pieces we should request
             if ((message = GetFromList (peer, available, peer.SuggestedPieces)) != null)
                 return new[] { message };
@@ -153,12 +144,6 @@ namespace MonoTorrent.Client.PiecePicking
             // Now we see what pieces the peer has that we don't have and try and request one
             if ((bundle = GetStandardRequest (peer, available, startIndex, endIndex, count)) != null)
                 return bundle;
-
-            // If all else fails we should request blocks from a piece another peer is retrieving. If we do
-            // this we should start requesting from the end of the piece to give the best chance of having a
-            // good incremental hash
-            if ((message = ContinueAnyExisting (peer)) != null)
-                return new[] { message };
 
             return null;
         }
@@ -226,7 +211,7 @@ namespace MonoTorrent.Client.PiecePicking
             return null;
         }
 
-        protected PieceRequest ContinueAnyExisting (IPieceRequester peer)
+        public override PieceRequest ContinueAnyExisting (IPieceRequester peer)
         {
             // If this peer is currently a 'dodgy' peer, then don't allow him to help with someone else's
             // piece request.

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/PieceManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/PieceManager.cs
@@ -142,6 +142,16 @@ namespace MonoTorrent.Client
                         break;
                 }
             }
+
+            if (!id.IsChoking && id.AmRequestingPiecesCount == 0) {
+                while (id.AmRequestingPiecesCount < maxRequests) {
+                    PieceRequest request = Picker.ContinueAnyExisting (id);
+                    if (request != null)
+                        id.MessageQueue.Enqueue (new RequestMessage (request.PieceIndex, request.StartOffset, request.RequestLength));
+                    else
+                        break;
+                }
+            }
         }
 
         internal bool IsInteresting (PeerId id)


### PR DESCRIPTION
Now we only try to continue an existing request if the
peer has been unable to select one normally.

Additionally, we only continue other peer's pieces if
the peer in question has zero pending requests. This
is slightly inefficient in terms of pipelining, but
it's probably better that a peer finish it's queue of
up to 300-500 pieces *before* it starts stealing pieces
from other peers.