### PR TITLE
[core] Lock fewer times when iterating the main loop

### DIFF
--- a/src/MonoTorrent/MonoTorrent.Client/MainLoop.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/MainLoop.cs
@@ -58,8 +58,8 @@ namespace MonoTorrent.Client
             }
         }
 
-        readonly Queue<QueuedTask> actions = new Queue<QueuedTask> ();
-        readonly ManualResetEventSlim actionsWaiter = new ManualResetEventSlim ();
+        Queue<QueuedTask> actions = new Queue<QueuedTask> ();
+        readonly object actionsLock = new object ();
         readonly Thread thread;
 
         public MainLoop (string name)
@@ -73,29 +73,32 @@ namespace MonoTorrent.Client
 
         void Loop ()
         {
+            var currentQueue = new Queue<QueuedTask> ();
+
             SetSynchronizationContext (this);
 #if ALLOW_EXECUTION_CONTEXT_SUPPRESSION
             using (ExecutionContext.SuppressFlow ())
 #endif
                 while (true) {
-                    QueuedTask? task = null;
 
-                    lock (actions) {
-                        if (actions.Count == 0)
-                            Monitor.Wait (actions);
-                        task = actions.Dequeue ();
+                    lock (actionsLock) {
+                       if (actions.Count == 0)
+                            Monitor.Wait (actionsLock);
+
+                        var swap = actions;
+                        actions = currentQueue;
+                        currentQueue = swap;
                     }
 
-                    if (!task.HasValue) {
-                        //actionsWaiter.Wait ();
-                    } else {
+                    while (currentQueue.Count > 0) {
+                        var task = currentQueue.Dequeue ();
                         try {
-                            task.Value.Action?.Invoke ();
-                            task.Value.SendOrPostCallback?.Invoke (task.Value.State);
+                            task.Action?.Invoke ();
+                            task.SendOrPostCallback?.Invoke (task.State);
                         } catch (Exception ex) {
                             Console.WriteLine ("Unexpected main loop exception: {0}", ex);
                         } finally {
-                            task.Value.WaitHandle?.Set ();
+                            task.WaitHandle?.Set ();
                         }
                     }
                 }
@@ -135,10 +138,10 @@ namespace MonoTorrent.Client
 
         void Queue (QueuedTask task)
         {
-            lock (actions) {
+            lock (actionsLock) {
                 actions.Enqueue (task);
                 if (actions.Count == 1)
-                    Monitor.Pulse (actions);
+                    Monitor.Pulse (actionsLock);
             }
         }
 


### PR DESCRIPTION
Use two queues to allow tasks to be processed with
fewer locks.

By swapping the queue object we can dequeue every
message in the old queue object without needing
to take further locks. When the old queue is empty,
we can swap it again and start processing tasks
in the new queue.