### PR TITLE
[core] Small optimisation to avoid excessive cancelling

### DIFF
--- a/src/MonoTorrent.Tests/Client/StreamingPiecePickerTests.cs
+++ b/src/MonoTorrent.Tests/Client/StreamingPiecePickerTests.cs
@@ -87,7 +87,7 @@ namespace MonoTorrent.Client.PiecePicking
         }
 
         [Test]
-        public void SeekDoesCancelRequests ()
+        public void SeekToDifferentPieceCancelsRequests ()
         {
             (var picker, var checker) = CreatePicker<TestPicker> ();
 
@@ -97,11 +97,29 @@ namespace MonoTorrent.Client.PiecePicking
                 PeerId.CreateNull (pieceCount, seeder: true, isChoking: false, amInterested: true),
             };
             picker.PickPiece (peer, peer.BitField, peers);
-            picker.SeekToPosition (data.Files[0], 0);
+            picker.SeekToPosition (data.Files[0], data.PieceLength);
             picker.PickPiece (peer, peer.BitField, peers);
             Assert.IsTrue(checker.HasCancelledRequests);
             Assert.IsTrue (peers.All (p => checker.CancelledRequestsFrom.Contains (p)));
             Assert.IsTrue (checker.CancelledRequestsFrom.Contains (peer));
+        }
+
+        [Test]
+        public void SeekToSamePieceDoesNotCancelRequests ()
+        {
+            (var picker, var checker) = CreatePicker<TestPicker> ();
+
+            PeerId[] peers = new[] {
+                PeerId.CreateNull (pieceCount, seeder: true, isChoking: false, amInterested: true),
+                PeerId.CreateNull (pieceCount, seeder: true, isChoking: false, amInterested: true),
+                PeerId.CreateNull (pieceCount, seeder: true, isChoking: false, amInterested: true),
+            };
+            picker.PickPiece (peer, peer.BitField, peers);
+            picker.SeekToPosition (data.Files[0], 0);
+            picker.PickPiece (peer, peer.BitField, peers);
+            Assert.IsFalse (checker.HasCancelledRequests);
+            Assert.IsFalse (peers.All (p => checker.CancelledRequestsFrom.Contains (p)));
+            Assert.IsFalse (checker.CancelledRequestsFrom.Contains (peer));
         }
 
         [Test]

--- a/src/MonoTorrent/MonoTorrent.Client.PiecePicking/StreamingPiecePicker.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.PiecePicking/StreamingPiecePicker.cs
@@ -106,8 +106,10 @@ namespace MonoTorrent.Client.PiecePicking
         internal void SeekToPosition (ITorrentFileInfo file, long position)
         {
             // Update the high priority set, then cancel pending requests.
+            var oldPosition = HighPriorityPieceIndex;
             ReadToPosition (file, position);
-            CancelPendingRequests = true;
+            if (oldPosition != HighPriorityPieceIndex)
+                CancelPendingRequests = true;
         }
 
         /// <summary>


### PR DESCRIPTION
If we seek to the same piece we're already in then we don't
need to cancel pending piece requests.