### PR TITLE
WIP: Add a safe API to export the active requests

### DIFF
--- a/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -424,6 +424,12 @@ namespace MonoTorrent.Client
             ChangePicker (picker);
         }
 
+        public async Task<List<Piece>> ExportActiveRequests ()
+        {
+            await ClientEngine.MainLoop;
+            return PieceManager.Picker.ExportActiveRequests ();
+        }
+
         public void Dispose ()
         {
             if (disposed)


### PR DESCRIPTION
Example usage:

```
var requests = await torrentManager.ExportActiveRequests ();
foreach (var piece in requests)
    for (int i = 0; i < piece.BlockCount; i++)
        Console.WriteLine (piece[i].Requested);
```