### PR TITLE
[core] Handle peers who do not have metadata yet

### DIFF
--- a/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/MetadataModeTests.cs
+++ b/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/MetadataModeTests.cs
@@ -83,6 +83,16 @@ namespace MonoTorrent.Client.Modes
         }
 
         [Test]
+        public async Task UnknownMetadataLength ()
+        {
+            await Setup (true, "path.torrent");
+
+            ExtendedHandshakeMessage exHand = new ExtendedHandshakeMessage (false, null, 5555);
+            exHand.Supports.Add (LTMetadata.Support);
+            Assert.DoesNotThrow (() => rig.Manager.Mode.HandleMessage (PeerId.CreateNull (1), exHand));
+        }
+
+        [Test]
         public async Task RequestMetadata ()
         {
             await Setup (false, "path.torrent");
@@ -254,6 +264,7 @@ namespace MonoTorrent.Client.Modes
             PeerMessage m;
             while (unrequestedPieces.Count > 0 && (m = await PeerIO.ReceiveMessageAsync (connection, decryptor)) != null) {
                 if (m is ExtendedHandshakeMessage ex) {
+                    Assert.IsNull (ex.MetadataSize);
                     Assert.AreEqual (ClientEngine.DefaultMaxPendingRequests, ex.MaxRequests);
                 } else if (m is HaveNoneMessage) {
                     receivedHaveNone = true;

--- a/src/MonoTorrent/MonoTorrent.Client.Messages.Libtorrent/ExtendedHandshakeMessage.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Messages.Libtorrent/ExtendedHandshakeMessage.cs
@@ -65,7 +65,7 @@ namespace MonoTorrent.Client.Messages.Libtorrent
 
         public string Version => version ?? "";
 
-        public int MetadataSize { get; set; }
+        public int? MetadataSize { get; set; }
 
         #region Constructors
         public ExtendedHandshakeMessage ()
@@ -74,7 +74,7 @@ namespace MonoTorrent.Client.Messages.Libtorrent
             Supports = new ExtensionSupports ();
         }
 
-        public ExtendedHandshakeMessage (bool privateTorrent, int metadataSize, int localListenPort)
+        public ExtendedHandshakeMessage (bool privateTorrent, int? metadataSize, int localListenPort)
             : base (Support.MessageId)
         {
             Supports = new ExtensionSupports (SupportedMessages);
@@ -143,7 +143,8 @@ namespace MonoTorrent.Client.Messages.Libtorrent
             SupportedMessages.ForEach (delegate (ExtensionSupport s) { supportsDict.Add (s.Name, (BEncodedNumber) s.MessageId); });
             mainDict.Add (SupportsKey, supportsDict);
 
-            mainDict.Add (MetadataSizeKey, (BEncodedNumber) MetadataSize);
+            if (MetadataSize.HasValue)
+                mainDict.Add (MetadataSizeKey, (BEncodedNumber) MetadataSize);
 
             return mainDict;
         }

--- a/src/MonoTorrent/MonoTorrent.Client/Modes/Mode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/Mode.cs
@@ -464,7 +464,7 @@ namespace MonoTorrent.Client.Modes
         protected virtual void AppendExtendedHandshake (PeerId id, MessageBundle bundle)
         {
             if (id.SupportsLTMessages && ClientEngine.SupportsExtended)
-                bundle.Messages.Add (new ExtendedHandshakeMessage (Manager.Torrent?.IsPrivate ?? false, Manager.HasMetadata ? Manager.Torrent.InfoMetadata.Length : 0, Settings.ListenPort));
+                bundle.Messages.Add (new ExtendedHandshakeMessage (Manager.Torrent?.IsPrivate ?? false, Manager.HasMetadata ? Manager.Torrent.InfoMetadata.Length : (int?) null, Settings.ListenPort));
         }
 
         protected virtual void AppendFastPieces (PeerId id, MessageBundle bundle)


### PR DESCRIPTION
If a peer does not send the 'MetadataSize' key it
means they do not have metadata to send us. We
cannot create the Stream using these peers as
we'd end up creating a Bitfield of length 0.

This can cause unusual NullReferenceExceptions
later on.