### PR TITLE
Some fixes and CreateSubFolder torrent config

### DIFF
--- a/src/MonoTorrent/MonoTorrent.Client.Encryption/EncryptionType.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Encryption/EncryptionType.cs
@@ -54,13 +54,14 @@ namespace MonoTorrent.Client
 
         internal static IList<EncryptionType> Remove (IList<EncryptionType> allowedEncryption, EncryptionType encryptionType)
         {
-            var result = new EncryptionType[allowedEncryption.Count - 1];
-            int j = 0;
-            for (int i = 0; i < allowedEncryption.Count; i++)
-                if (allowedEncryption[i] != encryptionType)
-                    result[j++] = allowedEncryption[i];
-
-            return MakeReadOnly (result);
+            if (allowedEncryption.Count > 0) {
+                var result = new EncryptionType[allowedEncryption.Count - 1];
+                int j = 0;
+                for (int i = 0; i < allowedEncryption.Count; i++)
+                    if (allowedEncryption[i] != encryptionType)
+                        result[j++] = allowedEncryption[i];
+            }
+            return MakeReadOnly (allowedEncryption);
         }
 
         internal static EncryptionType? PreferredRC4 (IList<EncryptionType> allowedEncryption)

--- a/src/MonoTorrent/MonoTorrent.Client/FileStreamBuffer.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/FileStreamBuffer.cs
@@ -168,9 +168,11 @@ namespace MonoTorrent.Client.PieceWriters
                 logger.InfoFormatted ("Opening filestream: {0}", oldest.Key.FullPath);
 
                 using (await oldest.Value.Locker.EnterAsync ()) {
-                    oldest.Value.Stream.Dispose ();
-                    oldest.Value.Stream = null;
-                    Count--;
+                    if (oldest.Value.Stream != null) {
+                        oldest.Value.Stream.Dispose ();
+                        oldest.Value.Stream = null;
+                        Count--;
+                    }
                 }
             }
         }

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -586,7 +586,7 @@ namespace MonoTorrent.Client
 
             // Now we know the torrent name, use it as the base directory name when it's a multi-file torrent
             var savePath = SavePath;
-            if (Torrent.Files.Count > 1)
+            if (Torrent.Files.Count > 1 && Settings.CreateSubFolder)
                 savePath = Path.Combine (savePath, Torrent.Name);
 
             Files = Torrent.Files.Select (file =>

--- a/src/MonoTorrent/MonoTorrent.Client/Settings/TorrentSettings.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Settings/TorrentSettings.cs
@@ -101,12 +101,17 @@ namespace MonoTorrent.Client
         /// </summary>
         internal TimeSpan TimeToWaitUntilIdle => TimeSpan.FromMinutes (10);
 
+        /// <summary>
+        /// If set to false then root folder will be not created for multi-files torrents
+        /// </summary>
+        internal bool CreateSubFolder { get; } = true;
+
         public TorrentSettings ()
         {
 
         }
 
-        internal TorrentSettings (bool allowDht, bool allowInitialSeeding, bool allowPeerExchange, int maximumConnections, int maximumDownloadSpeed, int maximumUploadSpeed, int uploadSlots, TimeSpan webSeedDelay, int webSeedSpeedTrigger)
+        internal TorrentSettings (bool allowDht, bool allowInitialSeeding, bool allowPeerExchange, int maximumConnections, int maximumDownloadSpeed, int maximumUploadSpeed, int uploadSlots, TimeSpan webSeedDelay, int webSeedSpeedTrigger, bool createSubFolder)
         {
             AllowDht = allowDht;
             AllowInitialSeeding = allowInitialSeeding;
@@ -117,6 +122,7 @@ namespace MonoTorrent.Client
             UploadSlots = uploadSlots;
             WebSeedDelay = webSeedDelay;
             WebSeedSpeedTrigger = webSeedSpeedTrigger;
+            CreateSubFolder = createSubFolder;
         }
 
         public override bool Equals (object obj)
@@ -133,7 +139,8 @@ namespace MonoTorrent.Client
                 && MaximumUploadSpeed == other.MaximumUploadSpeed
                 && UploadSlots == other.UploadSlots
                 && WebSeedDelay == other.WebSeedDelay
-                && WebSeedSpeedTrigger == other.WebSeedSpeedTrigger;
+                && WebSeedSpeedTrigger == other.WebSeedSpeedTrigger
+                && CreateSubFolder == other.CreateSubFolder;
         }
 
         public override int GetHashCode ()

--- a/src/MonoTorrent/MonoTorrent.Client/Settings/TorrentSettingsBuilder.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Settings/TorrentSettingsBuilder.cs
@@ -99,6 +99,11 @@ namespace MonoTorrent.Client
         /// </summary>
         public int WebSeedSpeedTrigger { get; set; }
 
+        /// <summary>
+        /// If set to false then root folder will be not created for multi-files torrents
+        /// </summary>
+        public bool CreateSubFolder { get; set; }
+
         public TorrentSettingsBuilder ()
             : this (new TorrentSettings ())
         {
@@ -116,6 +121,7 @@ namespace MonoTorrent.Client
             UploadSlots = settings.UploadSlots;
             WebSeedDelay = settings.WebSeedDelay;
             WebSeedSpeedTrigger = settings.WebSeedSpeedTrigger;
+            CreateSubFolder = settings.CreateSubFolder;
         }
 
         public TorrentSettings ToSettings ()
@@ -129,7 +135,8 @@ namespace MonoTorrent.Client
                 MaximumUploadSpeed,
                 UploadSlots,
                 WebSeedDelay,
-                WebSeedSpeedTrigger
+                WebSeedSpeedTrigger,
+                CreateSubFolder
             );
         }
 

--- a/src/MonoTorrent/MonoTorrent/UdpListener.cs
+++ b/src/MonoTorrent/MonoTorrent/UdpListener.cs
@@ -53,8 +53,10 @@ namespace MonoTorrent
         public async Task SendAsync (byte[] buffer, IPEndPoint endpoint)
         {
             try {
-                if (endpoint.Address != IPAddress.Any)
-                    await Client.SendAsync (buffer, buffer.Length, endpoint).ConfigureAwait (false);
+                if (Client != null) {
+                    if (endpoint.Address != IPAddress.Any)
+                        await Client.SendAsync (buffer, buffer.Length, endpoint).ConfigureAwait (false);
+                }
             } catch (Exception ex) {
                 logger.Exception (ex, "UdpListener could not send message");
             }


### PR DESCRIPTION
- CreateSubFolder: If set to false then root folder will be not created for multi-files torrents (Usable in cases when MonoTorrent using as self-update engine.)
- Fixed ArrayIndexOutOfBound exception when peer allowedEncryption is empty
- Fixed NPE in FileStreamBuffer.MaybeRemoveOldestStream() when buffer stream is null
- Fixed NPE when trying send message to listener who already in NotListening state after torrent manager disposed (calling from MessageLoop.SendMessages())

