### PR TITLE
Added CreateSubFolder property to TorrentSetting

### DIFF
--- a/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -586,7 +586,7 @@ namespace MonoTorrent.Client
 
             // Now we know the torrent name, use it as the base directory name when it's a multi-file torrent
             var savePath = SavePath;
-            if (Torrent.Files.Count > 1)
+            if (Torrent.Files.Count > 1 && Settings.CreateSubFolder)
                 savePath = Path.Combine (savePath, Torrent.Name);
 
             Files = Torrent.Files.Select (file =>

--- a/src/MonoTorrent/MonoTorrent.Client/Settings/TorrentSettings.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Settings/TorrentSettings.cs
@@ -104,7 +104,7 @@ namespace MonoTorrent.Client
         /// <summary>
         /// If set to false then root folder will be not created for multi-files torrents
         /// </summary>
-        internal bool CreateSubFolder { get; } = true;
+        public bool CreateSubFolder { get; } = true;
 
         public TorrentSettings ()
         {

--- a/src/MonoTorrent/MonoTorrent.Client/Settings/TorrentSettings.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Settings/TorrentSettings.cs
@@ -101,12 +101,17 @@ namespace MonoTorrent.Client
         /// </summary>
         internal TimeSpan TimeToWaitUntilIdle => TimeSpan.FromMinutes (10);
 
+        /// <summary>
+        /// If set to false then root folder will be not created for multi-files torrents
+        /// </summary>
+        internal bool CreateSubFolder { get; } = true;
+
         public TorrentSettings ()
         {
 
         }
 
-        internal TorrentSettings (bool allowDht, bool allowInitialSeeding, bool allowPeerExchange, int maximumConnections, int maximumDownloadSpeed, int maximumUploadSpeed, int uploadSlots, TimeSpan webSeedDelay, int webSeedSpeedTrigger)
+        internal TorrentSettings (bool allowDht, bool allowInitialSeeding, bool allowPeerExchange, int maximumConnections, int maximumDownloadSpeed, int maximumUploadSpeed, int uploadSlots, TimeSpan webSeedDelay, int webSeedSpeedTrigger, bool createSubFolder)
         {
             AllowDht = allowDht;
             AllowInitialSeeding = allowInitialSeeding;
@@ -117,6 +122,7 @@ namespace MonoTorrent.Client
             UploadSlots = uploadSlots;
             WebSeedDelay = webSeedDelay;
             WebSeedSpeedTrigger = webSeedSpeedTrigger;
+            CreateSubFolder = createSubFolder;
         }
 
         public override bool Equals (object obj)
@@ -133,7 +139,8 @@ namespace MonoTorrent.Client
                 && MaximumUploadSpeed == other.MaximumUploadSpeed
                 && UploadSlots == other.UploadSlots
                 && WebSeedDelay == other.WebSeedDelay
-                && WebSeedSpeedTrigger == other.WebSeedSpeedTrigger;
+                && WebSeedSpeedTrigger == other.WebSeedSpeedTrigger
+                && CreateSubFolder == other.CreateSubFolder;
         }
 
         public override int GetHashCode ()

--- a/src/MonoTorrent/MonoTorrent.Client/Settings/TorrentSettingsBuilder.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Settings/TorrentSettingsBuilder.cs
@@ -99,6 +99,11 @@ namespace MonoTorrent.Client
         /// </summary>
         public int WebSeedSpeedTrigger { get; set; }
 
+        /// <summary>
+        /// If set to false then root folder will be not created for multi-files torrents
+        /// </summary>
+        public bool CreateSubFolder { get; set; }
+
         public TorrentSettingsBuilder ()
             : this (new TorrentSettings ())
         {
@@ -116,6 +121,7 @@ namespace MonoTorrent.Client
             UploadSlots = settings.UploadSlots;
             WebSeedDelay = settings.WebSeedDelay;
             WebSeedSpeedTrigger = settings.WebSeedSpeedTrigger;
+            CreateSubFolder = settings.CreateSubFolder;
         }
 
         public TorrentSettings ToSettings ()
@@ -129,7 +135,8 @@ namespace MonoTorrent.Client
                 MaximumUploadSpeed,
                 UploadSlots,
                 WebSeedDelay,
-                WebSeedSpeedTrigger
+                WebSeedSpeedTrigger,
+                CreateSubFolder
             );
         }
 

--- a/src/MonoTorrent/MonoTorrent.Client/Settings/TorrentSettingsBuilder.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Settings/TorrentSettingsBuilder.cs
@@ -100,7 +100,7 @@ namespace MonoTorrent.Client
         public int WebSeedSpeedTrigger { get; set; }
 
         /// <summary>
-        /// If set to false then root folder will be not created for multi-files torrents
+        /// If set to false then root folder will be not created for multi-files torrents, otherwise all files will be placed inside a root folder named <see cref="TorrentManager.Name"/>. Defaults to true.
         /// </summary>
         public bool CreateSubFolder { get; set; }
 


### PR DESCRIPTION
Added CreateSubFolder property to TorrentSetting (if set to false root folder will be not created for multi-file torrent)
Usefull when MonoTorrent using in application as self-update engine.