### PR TITLE
[core] Fix how TorrentFile's are created

### DIFF
--- a/src/MonoTorrent.Tests/Client/DiskManagerExceptionTests.cs
+++ b/src/MonoTorrent.Tests/Client/DiskManagerExceptionTests.cs
@@ -111,18 +111,19 @@ namespace MonoTorrent.Client
         [SetUp]
         public void Setup ()
         {
-            var files = new[] {
-                new TorrentFileInfo (new TorrentFile ("First",  Piece.BlockSize / 2)),
-                new TorrentFileInfo (new TorrentFile ("Second", Piece.BlockSize)),
-                new TorrentFileInfo (new TorrentFile ("Third",  Piece.BlockSize + Piece.BlockSize / 2)),
-                new TorrentFileInfo (new TorrentFile ("Fourth", Piece.BlockSize * 2 + Piece.BlockSize / 2)),
-            };
+            var pieceLength = Piece.BlockSize * 2;
+            var files = TorrentFileInfo.Create (pieceLength,
+                Piece.BlockSize / 2,
+                Piece.BlockSize,
+                Piece.BlockSize + Piece.BlockSize / 2,
+                Piece.BlockSize * 2 + Piece.BlockSize / 2
+            );
 
             buffer = new byte[Piece.BlockSize];
             data = new TestTorrentData {
                 Files = files,
                 Size = files.Sum (f => f.Length),
-                PieceLength = Piece.BlockSize * 2
+                PieceLength = pieceLength
             };
 
             writer = new ExceptionWriter ();

--- a/src/MonoTorrent.Tests/Client/DiskManagerTests.cs
+++ b/src/MonoTorrent.Tests/Client/DiskManagerTests.cs
@@ -122,7 +122,7 @@ namespace MonoTorrent.Client
         public void OnetimeSetup ()
         {
             var random = new Random ();
-            var filePieces = new[] {
+            var filePieces = new long[] {
                 Piece.BlockSize / 2,
                 Piece.BlockSize,
                 Piece.BlockSize + Piece.BlockSize / 2,

--- a/src/MonoTorrent.Tests/Client/DiskWriterTests.cs
+++ b/src/MonoTorrent.Tests/Client/DiskWriterTests.cs
@@ -46,13 +46,18 @@ namespace MonoTorrent.Client.PieceWriters
         [SetUp]
         public void Setup ()
         {
+            var pieceLength = Piece.BlockSize * 2;
             Temp = Path.GetTempPath () + "monotorrent_tests";
-            TorrentFile = new TorrentFileInfo (new TorrentFile ("test.file", 12345), Path.Combine (Temp, "test.file"));
-            Others = new[] {
-                new TorrentFileInfo (new TorrentFile ("test2.file", 12345), Path.Combine (Temp, "test2.file")),
-                new TorrentFileInfo (new TorrentFile ("test3.file", 12345), Path.Combine (Temp, "test3.file")),
-                new TorrentFileInfo (new TorrentFile ("test4.file", 12345), Path.Combine (Temp, "test4.file")),
-            };
+
+            var files = TorrentFileInfo.Create (pieceLength,
+                ("test1.file", 12345, Path.Combine (Temp, "test1.file")),
+                ("test2.file", 12345, Path.Combine (Temp, "test2.file")),
+                ("test3.file", 12345, Path.Combine (Temp, "test3.file")),
+                ("test4.file", 12345, Path.Combine (Temp, "test4.file"))
+            );
+
+            TorrentFile = files.First ();
+            Others = files.Skip (1).ToArray ();
         }
 
         [TearDown]

--- a/src/MonoTorrent.Tests/Client/MemoryCacheTests.cs
+++ b/src/MonoTorrent.Tests/Client/MemoryCacheTests.cs
@@ -116,11 +116,12 @@ namespace MonoTorrent.Client.PieceWriters
         [SetUp]
         public void Setup ()
         {
-            var file = new TorrentFileInfo (new TorrentFile ("Relative/Path.txt", Piece.BlockSize * 5));
+            var pieceLength = Piece.BlockSize * 8;
+            var files = TorrentFileInfo.Create (pieceLength, ("Relative/Path.txt", Piece.BlockSize * 5, "Full/Path/Relative/Path.txt"));
             torrent = new TorrentData {
-                Files = new[] { file },
-                PieceLength = Piece.BlockSize * 8,
-                Size = file.Length,
+                Files = files,
+                PieceLength = pieceLength,
+                Size = files.Single ().Length,
             };
 
             writer = new MemoryWriter ();

--- a/src/MonoTorrent.Tests/Client/PieceManagerTests.cs
+++ b/src/MonoTorrent.Tests/Client/PieceManagerTests.cs
@@ -62,7 +62,7 @@ namespace MonoTorrent.Client.PiecePicking
             int pieceCount = 40;
             int pieceLength = 256 * 1024;
             var torrentData = new TestTorrentData {
-                Files = new[] { new TorrentFileInfo (new TorrentFile ("File", pieceLength * pieceCount)) },
+                Files = TorrentFileInfo.Create (pieceLength, ("File", pieceLength * pieceCount, "full/path/File")),
                 PieceLength = pieceLength,
                 Size = pieceLength * pieceCount
             };

--- a/src/MonoTorrent.Tests/Client/PieceWriterExtensionTests.cs
+++ b/src/MonoTorrent.Tests/Client/PieceWriterExtensionTests.cs
@@ -37,16 +37,17 @@ namespace MonoTorrent.Client
         {
             var pieceLength = Piece.BlockSize;
             var files = TorrentFileInfo.Create (pieceLength, 1024, 1024, 1024, pieceLength - 3 * 1024, Piece.BlockSize, 0);
-            Assert.AreEqual (files.Length - 2, IPieceWriterExtensions.FindFileByOffset (files, Piece.BlockSize * 2 - 1, pieceLength));
+            Assert.AreEqual (files.Length - 1, IPieceWriterExtensions.FindFileByOffset (files, Piece.BlockSize * 2 - 1, pieceLength));
         }
 
         [Test]
-        [Ignore("Figure out how to load/handle multiple empty files")]
         public void Offset_TwoEmptyFilesAtEnd ()
         {
             var pieceLength = Piece.BlockSize;
+            // If two files start at the same offset (which zero length files do), then the files are ordered based on
+            // their length. This way zero length files are never the last file, unless the whole torrent is empty. Which is nonsense :p
             var files = TorrentFileInfo.Create (pieceLength, 1024, 1024, 1024, pieceLength - 3 * 1024, Piece.BlockSize, 0, 0);
-            Assert.AreEqual (files.Length - 3, IPieceWriterExtensions.FindFileByOffset (files, Piece.BlockSize * 2 - 1, pieceLength));
+            Assert.AreEqual (files.Length - 1, IPieceWriterExtensions.FindFileByOffset (files, Piece.BlockSize * 2 - 1, pieceLength));
         }
 
         [Test]

--- a/src/MonoTorrent.Tests/Client/PriorityPickerTests.cs
+++ b/src/MonoTorrent.Tests/Client/PriorityPickerTests.cs
@@ -84,11 +84,11 @@ namespace MonoTorrent.Client.PiecePicking
         {
             int pieceLength = Piece.BlockSize * 16;
             var size = pieceLength * 32 + 123;
-            var file = new TorrentFileInfo (new TorrentFile ("Single", size, 0, size / pieceLength + ((size % pieceLength == 0) ? -1 : 0)));
+            var files = TorrentFileInfo.Create (pieceLength, ("Single", size, "full/path/Single"));
             return new TestTorrentData {
-                Files = new[] { file },
+                Files = files,
                 PieceLength = pieceLength,
-                Size = file.Length
+                Size = files.Single ().Length
             };
         }
 
@@ -96,7 +96,7 @@ namespace MonoTorrent.Client.PiecePicking
         {
             int pieceLength = Piece.BlockSize * 16;
 
-            int[] sizes = {
+            long[] sizes = {
                 pieceLength * 10,
                 pieceLength * 7  + 123,
                 pieceLength * 32 + 123,
@@ -107,14 +107,7 @@ namespace MonoTorrent.Client.PiecePicking
                 pieceLength * 7,
             };
 
-            int start = 0;
-            var files = sizes.Select ((size, index) => {
-                var startIndex = start / pieceLength;
-                var endIndex = (start + size) / pieceLength + ((start + size) % pieceLength == 0 ? -1 : 0);
-                start += size;
-                return new TorrentFileInfo (new TorrentFile ($"File {index}", size, startIndex, endIndex));
-            }).ToArray ();
-
+            var files = TorrentFileInfo.Create (pieceLength, sizes);
             return new TestTorrentData {
                 Files = files,
                 PieceLength = pieceLength,

--- a/src/MonoTorrent.Tests/Client/RandomisedPickerTests.cs
+++ b/src/MonoTorrent.Tests/Client/RandomisedPickerTests.cs
@@ -38,7 +38,7 @@ namespace MonoTorrent.Client.PiecePicking
     {
         class TestTorrentData : ITorrentData
         {
-            public IList<ITorrentFileInfo> Files { get; } = new[] { new TorrentFileInfo (new TorrentFile ("First", 64 * 1024 * 40, 0, 39)) };
+            public IList<ITorrentFileInfo> Files { get; } = TorrentFileInfo.Create (64 * 1024, 64 * 1024 * 40);
             public int PieceLength { get; } = 64 * 1024;
             public long Size { get; } = 64 * 1024 * 40;
         }

--- a/src/MonoTorrent.Tests/Client/RarestFirstPickerTests.cs
+++ b/src/MonoTorrent.Tests/Client/RarestFirstPickerTests.cs
@@ -62,7 +62,7 @@ namespace MonoTorrent.Client.PiecePicking
 
             bitfield = new BitField (pieces);
             torrentData = new TestTorrentData {
-                Files = new[] { new TorrentFileInfo (new TorrentFile ("Test", size)) },
+                Files = TorrentFileInfo.Create (pieceLength, ("Test", size, "Full/Path/Test")),
                 PieceLength = pieceLength,
                 Size = size
             };

--- a/src/MonoTorrent.Tests/Client/StandardPickerTests.cs
+++ b/src/MonoTorrent.Tests/Client/StandardPickerTests.cs
@@ -62,7 +62,7 @@ namespace MonoTorrent.Client.PiecePicking
             int pieceLength = 256 * 1024;
             bitfield = new BitField (pieceCount);
             torrentData = new TestTorrentData {
-                Files = new[] { new TorrentFileInfo (new TorrentFile ("File", pieceLength * pieceCount)) },
+                Files = TorrentFileInfo.Create (pieceLength, ("File", pieceLength * pieceCount, "Full/Path/File")),
                 PieceLength = pieceLength,
                 Size = pieceLength * pieceCount
             };

--- a/src/MonoTorrent.Tests/Client/TestRig.cs
+++ b/src/MonoTorrent.Tests/Client/TestRig.cs
@@ -507,19 +507,17 @@ namespace MonoTorrent.Client
 
         static TorrentFile[] StandardMultiFile ()
         {
-            return new[] {
-                new TorrentFile ("Dir1/File1", (int)(StandardPieceSize () * 0.44)),
-                new TorrentFile ("Dir1/Dir2/File2", (int)(StandardPieceSize () * 13.25)),
-                new TorrentFile ("File3", (int)(StandardPieceSize () * 23.68)),
-                new TorrentFile ("File4", (int)(StandardPieceSize () * 2.05)),
-            };
+            return TorrentFile.Create (StandardPieceSize (),
+                ("Dir1/File1", (int)(StandardPieceSize () * 0.44)),
+                ("Dir1/Dir2/File2", (int)(StandardPieceSize () * 13.25)),
+                ("File3", (int)(StandardPieceSize () * 23.68)),
+                ("File4", (int)(StandardPieceSize () * 2.05))
+            );
         }
 
         static TorrentFile[] StandardSingleFile ()
         {
-            return new[] {
-                 new TorrentFile ("Dir1/File1", (int)(StandardPieceSize () * 0.44))
-            };
+            return TorrentFile.Create (StandardPieceSize (), ("Dir1/File1", (int) (StandardPieceSize () * 0.44)));
         }
 
         static string[][] StandardTrackers ()
@@ -541,7 +539,7 @@ namespace MonoTorrent.Client
 
         internal static TorrentManager CreatePrivate ()
         {
-            var dict = CreateTorrent (16 * 1024 * 8, new[] { new TorrentFile ("File", 16 * 1024 * 8) }, null);
+            var dict = CreateTorrent (16 * 1024 * 8, TorrentFile.Create (16 * 1024 * 8 , ("File", 16 * 1024 * 8)), null);
             var editor = new TorrentEditor (dict) {
                 CanEditSecureMetadata = true,
                 Private = true,
@@ -557,7 +555,7 @@ namespace MonoTorrent.Client
         internal static TestRig CreateSingleFile (long torrentSize, int pieceLength, bool metadataMode)
         {
             TorrentFile[] files = StandardSingleFile ();
-            files[0] = new TorrentFile (files[0].Path, torrentSize);
+            files[0] = TorrentFile.Create (pieceLength, (files[0].Path, torrentSize)).Single ();
             return new TestRig ("", pieceLength, StandardWriter (), StandardTrackers (), files, metadataMode);
         }
 
@@ -571,9 +569,9 @@ namespace MonoTorrent.Client
             return CreateSingleFile (torrentSize, pieceLength, false).Manager;
         }
 
-        internal static TorrentManager CreateMultiFileManager (int[] fileSizes, int pieceLength, IPieceWriter writer = null)
+        internal static TorrentManager CreateMultiFileManager (long[] fileSizes, int pieceLength, IPieceWriter writer = null)
         {
-            var files = fileSizes.Select ((size, index) => new TorrentFile ($"File {index}", size)).ToArray ();
+            var files = TorrentFile.Create (pieceLength, fileSizes).ToArray ();
             return CreateMultiFileManager (files, pieceLength, writer);
         }
 

--- a/src/MonoTorrent.Tests/Common/TorrentTest.cs
+++ b/src/MonoTorrent.Tests/Common/TorrentTest.cs
@@ -328,15 +328,15 @@ namespace MonoTorrent.Common
         public void StartEndIndices ()
         {
             int pieceLength = 32 * 32;
-            TorrentFile[] files = {
-                new TorrentFile ("File0", 0),
-                new TorrentFile ("File1", pieceLength),
-                new TorrentFile ("File2", 0),
-                new TorrentFile ("File3", pieceLength - 1),
-                new TorrentFile ("File4", 1),
-                new TorrentFile ("File5", 236),
-                new TorrentFile ("File6", pieceLength * 7)
-            };
+            TorrentFile[] files = TorrentFile.Create (pieceLength,
+                ("File0", 0),
+                ("File1", pieceLength),
+                ("File2", 0),
+                ("File3", pieceLength - 1),
+                ("File4", 1),
+                ("File5", 236),
+                ("File6", pieceLength * 7)
+            );
             Torrent t = TestRig.CreateMultiFileTorrent (files, pieceLength);
 
             Assert.AreEqual (0, t.Files[0].StartPieceIndex, "#0a");
@@ -365,10 +365,10 @@ namespace MonoTorrent.Common
         public void StartEndIndices2 ()
         {
             int pieceLength = 32 * 32;
-            TorrentFile[] files = {
-                new TorrentFile ("File0", pieceLength),
-                new TorrentFile ("File1", 0)
-            };
+            TorrentFile[] files = TorrentFile.Create (pieceLength,
+                ("File0", pieceLength),
+                ("File1", 0)
+            );
             Torrent t = TestRig.CreateMultiFileTorrent (files, pieceLength);
 
             Assert.AreEqual (0, t.Files[0].StartPieceIndex, "#1");
@@ -382,10 +382,10 @@ namespace MonoTorrent.Common
         public void StartEndIndices3 ()
         {
             int pieceLength = 32 * 32;
-            TorrentFile[] files = {
-                new TorrentFile ("File0", pieceLength- 10),
-                new TorrentFile ("File1", 10)
-            };
+            TorrentFile[] files = TorrentFile.Create (pieceLength,
+                ("File0", pieceLength - 10),
+                ("File1", 10)
+            );
             Torrent t = TestRig.CreateMultiFileTorrent (files, pieceLength);
 
             Assert.AreEqual (0, t.Files[0].StartPieceIndex, "#1");
@@ -399,10 +399,10 @@ namespace MonoTorrent.Common
         public void StartEndIndices4 ()
         {
             int pieceLength = 32 * 32;
-            TorrentFile[] files = {
-                new TorrentFile ("File0", pieceLength- 10),
-                new TorrentFile ("File1", 11)
-            };
+            TorrentFile[] files = TorrentFile.Create (pieceLength,
+                ("File0", pieceLength- 10),
+                ("File1", 11)
+            );
             Torrent t = TestRig.CreateMultiFileTorrent (files, pieceLength);
 
             Assert.AreEqual (0, t.Files[0].StartPieceIndex, "#1");
@@ -416,11 +416,11 @@ namespace MonoTorrent.Common
         public void StartEndIndices5 ()
         {
             int pieceLength = 32 * 32;
-            TorrentFile[] files = {
-                new TorrentFile ("File0", pieceLength- 10),
-                new TorrentFile ("File1", 10),
-                new TorrentFile ("File1", 1)
-            };
+            TorrentFile[] files = TorrentFile.Create (pieceLength,
+                ("File0", pieceLength - 10),
+                ("File1", 10),
+                ("File1", 1)
+            );
             Torrent t = TestRig.CreateMultiFileTorrent (files, pieceLength);
 
             Assert.AreEqual (0, t.Files[0].StartPieceIndex, "#1");

--- a/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/DownloadModeTests.cs
+++ b/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/DownloadModeTests.cs
@@ -60,7 +60,7 @@ namespace MonoTorrent.Client.Modes
             ConnectionManager = new ConnectionManager ("LocalPeerId", Settings, DiskManager);
             TrackerManager = new ManualTrackerManager ();
 
-            int[] fileSizes = {
+            long[] fileSizes = {
                 Piece.BlockSize / 2,
                 Piece.BlockSize * 32,
                 Piece.BlockSize * 2,

--- a/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/HashingModeTests.cs
+++ b/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/HashingModeTests.cs
@@ -55,7 +55,7 @@ namespace MonoTorrent.Client.Modes
             PieceWriter = new TestWriter ();
             TrackerManager = new ManualTrackerManager ();
 
-            int[] fileSizes = {
+            long[] fileSizes = {
                 Piece.BlockSize / 2,
                 Piece.BlockSize * 32,
                 Piece.BlockSize * 2,

--- a/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/StartingModeTests.cs
+++ b/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/StartingModeTests.cs
@@ -60,7 +60,7 @@ namespace MonoTorrent.Client.Modes
             ConnectionManager = new ConnectionManager ("LocalPeerId", Settings, DiskManager);
             TrackerManager = new ManualTrackerManager ();
 
-            int[] fileSizes = {
+            long[] fileSizes = {
                 Piece.BlockSize / 2,
                 Piece.BlockSize * 32,
                 Piece.BlockSize * 2,

--- a/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/StoppedModeTests.cs
+++ b/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/StoppedModeTests.cs
@@ -55,7 +55,7 @@ namespace MonoTorrent.Client.Modes
             ConnectionManager = new ConnectionManager ("LocalPeerId", Settings, DiskManager);
             TrackerManager = new ManualTrackerManager ();
 
-            int[] fileSizes = {
+            long[] fileSizes = {
                 Piece.BlockSize / 2,
                 Piece.BlockSize * 32,
                 Piece.BlockSize * 2,

--- a/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/StoppingModeTests.cs
+++ b/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/StoppingModeTests.cs
@@ -57,7 +57,7 @@ namespace MonoTorrent.Client.Modes
             ConnectionManager = new ConnectionManager ("LocalPeerId", Settings, DiskManager);
             TrackerManager = new ManualTrackerManager ();
 
-            int[] fileSizes = {
+            long[] fileSizes = {
                 Piece.BlockSize / 2,
                 Piece.BlockSize * 32,
                 Piece.BlockSize * 2,

--- a/src/MonoTorrent/MonoTorrent.Client.PiecePicking/StreamingPieceRequester.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.PiecePicking/StreamingPieceRequester.cs
@@ -262,7 +262,8 @@ namespace MonoTorrent.Client.PiecePicking
         /// <param name="position"></param>
         internal void ReadToPosition (ITorrentFileInfo file, long position)
         {
-            HighPriorityPieceIndex = Math.Min (file.EndPieceIndex, file.StartPieceIndex + (int) ((file.StartPieceOffset + position) / TorrentData.PieceLength));
+            var pieceIndex = TorrentData.ByteOffsetToPieceIndex (position + file.OffsetInTorrent);
+            HighPriorityPieceIndex = Math.Min (file.EndPieceIndex, pieceIndex);
         }
     }
 }

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/ITorrentFile.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/ITorrentFile.cs
@@ -33,8 +33,8 @@ namespace MonoTorrent
     {
         string Path { get; }
         int StartPieceIndex { get; }
-        int StartPieceOffset { get; }
         int EndPieceIndex { get; }
         long Length { get; }
+        long OffsetInTorrent { get; }
     }
 }

--- a/src/MonoTorrent/MonoTorrent.Streaming/LocalStream.cs
+++ b/src/MonoTorrent/MonoTorrent.Streaming/LocalStream.cs
@@ -94,7 +94,7 @@ namespace MonoTorrent.Streaming
             ThrowIfDisposed ();
 
             // The torrent is treated as one big block of data, so this is the offset at which the current file's data starts at.
-            var torrentFileStartOffset = (long) File.StartPieceIndex * (long) Manager.Torrent.PieceLength + File.StartPieceOffset;
+            var torrentFileStartOffset = File.OffsetInTorrent;
 
             // Clamp things so we cannot overread.
             if (Position + count > Length)

--- a/src/MonoTorrent/MonoTorrent/ITorrentData.cs
+++ b/src/MonoTorrent/MonoTorrent/ITorrentData.cs
@@ -58,5 +58,8 @@ namespace MonoTorrent.Client
         /// <returns></returns>
         public static int PieceCount (this ITorrentData self)
             => (int) (self.Size / self.PieceLength) + (self.Size % self.PieceLength != 0 ? 1 : 0);
+
+        public static int ByteOffsetToPieceIndex (this ITorrentData self, long offset)
+            => (int)((offset / self.PieceLength) + (offset % self.PieceLength != 0 ? 1 : 0));
     }
 }

--- a/src/MonoTorrent/MonoTorrent/TorrentCreator.cs
+++ b/src/MonoTorrent/MonoTorrent/TorrentCreator.cs
@@ -75,7 +75,7 @@ namespace MonoTorrent
 
             public int StartPieceIndex => throw new NotImplementedException ();
 
-            public int StartPieceOffset => throw new NotImplementedException ();
+            public long OffsetInTorrent => throw new NotImplementedException ();
 
             public int EndPieceIndex => throw new NotImplementedException ();
 


### PR DESCRIPTION
Now we can handle multiple consecutive zero length files while
retaining the new logic to binary search files either by offset
within the overall torrent, or by piece index.

As part of this the test suite has been updated to ensure it
always sets the start and end piece index correctly, and also
the offset within the torrent file.