### PR TITLE
Engine addremove

### DIFF
--- a/src/MonoTorrent.Tests/Client/ClientEngineTests.cs
+++ b/src/MonoTorrent.Tests/Client/ClientEngineTests.cs
@@ -91,8 +91,7 @@ namespace MonoTorrent.Client
                 Private = true
             };
 
-            var manager = new TorrentManager (editor.ToTorrent (), "path", new TorrentSettings ());
-            await rig.Engine.Register (manager);
+            var manager = await rig.Engine.AddAsync (editor.ToTorrent (), "path", new TorrentSettings ());
 
             var dht = (ManualDhtEngine) rig.Engine.DhtEngine;
 
@@ -137,8 +136,7 @@ namespace MonoTorrent.Client
                 Private = true
             };
 
-            var manager = new TorrentManager (editor.ToTorrent (), "path", new TorrentSettings ());
-            await rig.Engine.Register (manager);
+            var manager = await rig.Engine.AddAsync (editor.ToTorrent (), "path", new TorrentSettings ());
 
             var localPeer = (ManualLocalPeerListener) rig.Engine.LocalPeerDiscovery;
 
@@ -162,25 +160,6 @@ namespace MonoTorrent.Client
             var task = rig.Engine.DownloadMetadataAsync (new MagnetLink (new InfoHash (new byte[20])), cts.Token);
             cts.Cancel ();
             Assert.ThrowsAsync<OperationCanceledException> (() => task);
-        }
-
-        [Test]
-        public async Task ReregisterManager ()
-        {
-            var downloadLimiters = rig.Manager.DownloadLimiters.ToArray ();
-            var uploadLimiters = rig.Manager.UploadLimiters.ToArray ();
-
-            await rig.Engine.Unregister (rig.Manager);
-            Assert.IsNull (rig.Manager.Engine, "#1");
-            CollectionAssert.AreNotEquivalent (downloadLimiters, rig.Manager.DownloadLimiters, "#2");
-            CollectionAssert.AreNotEquivalent (uploadLimiters, rig.Manager.UploadLimiters, "#3");
-            Assert.IsFalse (rig.Engine.ConnectionManager.Contains (rig.Manager), "#4");
-
-            await rig.Engine.Register (rig.Manager);
-            Assert.AreEqual (rig.Engine, rig.Manager.Engine, "#5");
-            CollectionAssert.AreEquivalent (downloadLimiters, rig.Manager.DownloadLimiters, "#6");
-            CollectionAssert.AreEquivalent (uploadLimiters, rig.Manager.UploadLimiters, "#7");
-            Assert.IsTrue (rig.Engine.ConnectionManager.Contains (rig.Manager), "#8");
         }
 
         [Test]

--- a/src/MonoTorrent.Tests/Client/TestRig.cs
+++ b/src/MonoTorrent.Tests/Client/TestRig.cs
@@ -392,12 +392,12 @@ namespace MonoTorrent.Client
             this.piecelength = piecelength;
             this.tier = trackers;
             MetadataMode = metadataMode;
-            var metadataDir = Path.Combine (Path.GetDirectoryName (typeof (TestRig).Assembly.Location), "test_metadata_dir");
+            var cacheDir = Path.Combine (Path.GetDirectoryName (typeof (TestRig).Assembly.Location), "test_cache_dir");
             PeerListenerFactory.Creator = endpoint => new CustomListener ();
             LocalPeerDiscoveryFactory.Creator = port => new ManualLocalPeerListener ();
             Dht.Listeners.DhtListenerFactory.Creator = endpoint => new Dht.Listeners.NullDhtListener ();
             Engine = new ClientEngine (new EngineSettingsBuilder {
-                MetadataSaveDirectory = metadataDir,
+                CacheDirectory = cacheDir,
                 ListenPort = 12345
             }.ToSettings ());
             if (Directory.Exists (Engine.Settings.MetadataSaveDirectory))
@@ -406,7 +406,7 @@ namespace MonoTorrent.Client
             Writer = writer;
 
             RecreateManager ().Wait ();
-            MetadataPath = Path.Combine (metadataDir, $"{Engine.Torrents.Single ().InfoHash.ToHex ()}.torrent");
+            MetadataPath = Path.Combine (Engine.Settings.MetadataSaveDirectory, $"{Engine.Torrents.Single ().InfoHash.ToHex ()}.torrent");
         }
 
         static TestRig ()

--- a/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/DownloadModeTests.cs
+++ b/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/DownloadModeTests.cs
@@ -133,9 +133,9 @@ namespace MonoTorrent.Client.Modes
             id.SupportsFastPeer = true;
             id.SupportsLTMessages = true;
 
-            var manager = TestRig.CreatePrivate ();
+            var torrent = TestRig.CreatePrivate ();
             using var engine = new ClientEngine ();
-            await engine.Register (manager);
+            var manager = await engine.AddAsync (torrent, "");
 
             manager.Mode = new DownloadMode (manager, DiskManager, ConnectionManager, Settings);
             var peersTask = new TaskCompletionSource<PeerExchangePeersAdded> ();
@@ -154,9 +154,9 @@ namespace MonoTorrent.Client.Modes
         [Test]
         public async Task AddPeers_Tracker_Private ()
         {
-            var manager = TestRig.CreatePrivate ();
+            var torrent = TestRig.CreatePrivate ();
             using var engine = new ClientEngine ();
-            await engine.Register (manager);
+            var manager = await engine.AddAsync (torrent, "");
 
             manager.SetTrackerManager (TrackerManager);
 
@@ -237,9 +237,9 @@ namespace MonoTorrent.Client.Modes
         [Test]
         public async Task EmptyPeerId_PrivateTorrent ()
         {
-            var manager = TestRig.CreatePrivate ();
+            var torrent = TestRig.CreatePrivate ();
             using var engine = new ClientEngine ();
-            await engine.Register (manager);
+            var manager = await engine.AddAsync (torrent, "");
 
             manager.Mode = new DownloadMode (manager, DiskManager, ConnectionManager, Settings);
             var peer = PeerId.CreateNull (manager.Bitfield.Length);
@@ -265,9 +265,9 @@ namespace MonoTorrent.Client.Modes
         [Test]
         public async Task MismatchedPeerId_PrivateTorrent ()
         {
-            var manager = TestRig.CreatePrivate ();
+            var torrent = TestRig.CreatePrivate ();
             using var engine = new ClientEngine ();
-            await engine.Register (manager);
+            var manager = await engine.AddAsync (torrent, "");
 
             manager.Mode = new DownloadMode (manager, DiskManager, ConnectionManager, Settings);
             var peer = PeerId.CreateNull (manager.Bitfield.Length);

--- a/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/MetadataModeTests.cs
+++ b/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/MetadataModeTests.cs
@@ -55,11 +55,10 @@ namespace MonoTorrent.Client.Modes
         private ConnectionPair pair;
         private TestRig rig;
 
-        public async Task Setup (bool metadataMode, string metadataPath, bool multiFile = false, bool metadataOnly = false)
+        public async Task Setup (bool metadataMode, bool multiFile = false, bool metadataOnly = false)
         {
             pair = new ConnectionPair ().WithTimeout ();
             rig = multiFile ? TestRig.CreateMultiFile (32768, metadataMode) : TestRig.CreateSingleFile (1024 * 1024 * 1024, 32768, metadataMode);
-            rig.MetadataPath = metadataPath;
             rig.RecreateManager ().Wait ();
 
             rig.Manager.HashChecked = true;
@@ -85,7 +84,7 @@ namespace MonoTorrent.Client.Modes
         [Test]
         public async Task UnknownMetadataLength ()
         {
-            await Setup (true, "path.torrent");
+            await Setup (true);
 
             ExtendedHandshakeMessage exHand = new ExtendedHandshakeMessage (false, null, 5555);
             exHand.Supports.Add (LTMetadata.Support);
@@ -95,7 +94,7 @@ namespace MonoTorrent.Client.Modes
         [Test]
         public async Task RequestMetadata ()
         {
-            await Setup (false, "path.torrent");
+            await Setup (false);
             CustomConnection connection = pair.Incoming;
 
             // 1) Send local handshake. We've already received the remote handshake as part
@@ -130,9 +129,8 @@ namespace MonoTorrent.Client.Modes
         [Test]
         public async Task AfterHandshake_SendBitfieldMessage()
         {
-            var torrent = Path.Combine (AppDomain.CurrentDomain.BaseDirectory, "file.torrent");
-            await Setup (true, torrent);
-            await SendMetadataCore (torrent, new BitfieldMessage (rig.Torrent.Pieces.Count));
+            await Setup (true);
+            await SendMetadataCore (rig.MetadataPath, new BitfieldMessage (rig.Torrent.Pieces.Count));
         }
 
         [Test]
@@ -143,71 +141,64 @@ namespace MonoTorrent.Client.Modes
                 .Token
                 .Register (() => tcs.TrySetCanceled ());
 
-            var torrent = Path.Combine (AppDomain.CurrentDomain.BaseDirectory, "file.torrent");
-            await Setup (true, torrent, metadataOnly: true);
+            await Setup (true, metadataOnly: true);
 
             rig.Manager.MetadataReceived += (o, e) => tcs.TrySetResult (e);
-            await SendMetadataCore (torrent, new BitfieldMessage (rig.Torrent.Pieces.Count), metadataOnly: true);
+            await SendMetadataCore (rig.MetadataPath, new BitfieldMessage (rig.Torrent.Pieces.Count), metadataOnly: true);
             Assert.IsNotNull (await tcs.Task);
         }
 
         [Test]
         public async Task AfterHandshake_SendHaveAllMessage()
         {
-            var torrent = Path.Combine (AppDomain.CurrentDomain.BaseDirectory, "file.torrent");
-            await Setup (true, torrent);
-            await SendMetadataCore (torrent, new HaveAllMessage ());
+            await Setup (true);
+            await SendMetadataCore (rig.MetadataPath, new HaveAllMessage ());
         }
 
         [Test]
         public async Task AfterHandshake_SendHaveNoneMessage()
         {
-            var torrent = Path.Combine (AppDomain.CurrentDomain.BaseDirectory, "file.torrent");
-            await Setup (true, torrent);
-            await SendMetadataCore (torrent, new HaveNoneMessage ());
+            await Setup (true);
+            await SendMetadataCore (rig.MetadataPath, new HaveNoneMessage ());
         }
 
         [Test]
         public async Task SendMetadata_ToFile ()
         {
-            var torrent = Path.Combine (AppDomain.CurrentDomain.BaseDirectory, "file.torrent");
-            await Setup (true, torrent);
-            await SendMetadataCore (torrent, new HaveNoneMessage ());
+            await Setup (true);
+            await SendMetadataCore (rig.MetadataPath, new HaveNoneMessage ());
         }
 
         [Test]
         public async Task SendMetadata_ToFile_CorruptFileExists ()
         {
-            var torrent = Path.Combine (AppDomain.CurrentDomain.BaseDirectory, "file.torrent");
-            File.Create (torrent).Close ();
-            await Setup (true, torrent);
-            await SendMetadataCore (torrent, new HaveNoneMessage ());
+            File.Create (rig.MetadataPath).Close ();
+            await Setup (true);
+            await SendMetadataCore (rig.MetadataPath, new HaveNoneMessage ());
         }
 
         [Test]
         public async Task SendMetadata_ToFile_RealFileExists ()
         {
-            var torrent = Path.Combine (AppDomain.CurrentDomain.BaseDirectory, "file.torrent");
-            await Setup (true, torrent);
-            File.WriteAllBytes (torrent, rig.TorrentDict.Encode ());
+            await Setup (true);
+            Directory.CreateDirectory (Path.GetDirectoryName (rig.MetadataPath));
+            File.WriteAllBytes (rig.MetadataPath, rig.TorrentDict.Encode ());
 
-            await SendMetadataCore (torrent, new HaveNoneMessage ());
+            await SendMetadataCore (rig.MetadataPath, new HaveNoneMessage ());
         }
 
         [Test]
         public async Task SendMetadata_ToFolder ()
         {
-            await Setup (true, Path.Combine (AppDomain.CurrentDomain.BaseDirectory, "test"));
-            await SendMetadataCore (Path.Combine (AppDomain.CurrentDomain.BaseDirectory, "test")
-                , new HaveNoneMessage ());
+            await Setup (true);
+            await SendMetadataCore (rig.MetadataPath, new HaveNoneMessage ());
         }
 
         [Test]
         public async Task SingleFileSavePath ()
         {
-            var torrent = Path.Combine (AppDomain.CurrentDomain.BaseDirectory, "file.torrent");
-            await Setup (true, torrent, multiFile: false);
-            await SendMetadataCore (torrent, new HaveNoneMessage ());
+            await Setup (true, multiFile: false);
+            await SendMetadataCore (rig.MetadataPath, new HaveNoneMessage ());
 
             Assert.AreEqual (@"test.files", rig.Manager.Torrent.Name);
             Assert.AreEqual (Environment.CurrentDirectory, rig.Manager.SavePath);
@@ -221,9 +212,8 @@ namespace MonoTorrent.Client.Modes
         [Test]
         public async Task MultiFileSavePath ()
         {
-            var torrent = Path.Combine (AppDomain.CurrentDomain.BaseDirectory, "file.torrent");
-            await Setup (true, torrent, multiFile: true);
-            await SendMetadataCore (torrent, new HaveNoneMessage ());
+            await Setup (true, multiFile: true);
+            await SendMetadataCore (rig.MetadataPath, new HaveNoneMessage ());
 
             Assert.AreEqual (@"test.files", rig.Manager.Torrent.Name);
             Assert.AreEqual (Environment.CurrentDirectory, rig.Manager.SavePath);
@@ -302,9 +292,8 @@ namespace MonoTorrent.Client.Modes
             }
 
             Assert.AreEqual (rig.Manager.InfoHash, torrent.InfoHash, "#2");
-            Assert.AreEqual (2, torrent.AnnounceUrls.Count, "#3");
+            Assert.AreEqual (1, torrent.AnnounceUrls.Count, "#3");
             Assert.AreEqual (2, torrent.AnnounceUrls[0].Count, "#4");
-            Assert.AreEqual (3, torrent.AnnounceUrls[1].Count, "#5");
 
             Assert.IsTrue (receivedHaveNone, "#6");
 

--- a/src/MonoTorrent.Tests/Streaming/StreamProviderTests.cs
+++ b/src/MonoTorrent.Tests/Streaming/StreamProviderTests.cs
@@ -254,16 +254,17 @@ namespace MonoTorrent.Streaming
         }
 
         [Test]
+        [Ignore("delete this? ClientEngine has AddAsync now.")]
         public async Task StartManagerManually ()
         {
             var provider = new StreamProvider (Engine, "testDir", Torrent);
             // It hasn't been registered with the engine
             Assert.ThrowsAsync<TorrentException> (() => provider.Manager.StartAsync ());
-            await Engine.Register (provider.Manager);
+            await Engine.AddAsync (provider.Manager.Torrent, "");
             await provider.Manager.StartAsync ();
 
             // People should not register and start the manager manually.
-            Assert.ThrowsAsync<InvalidOperationException> (() => provider.StartAsync ());
+            Assert.ThrowsAsync<TorrentException> (() => provider.StartAsync ());
         }
 
         [Test]

--- a/src/MonoTorrent.Tests/Streaming/StreamProviderTests.cs
+++ b/src/MonoTorrent.Tests/Streaming/StreamProviderTests.cs
@@ -29,6 +29,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -45,6 +46,7 @@ namespace MonoTorrent.Streaming
     {
         ClientEngine Engine { get; set; }
         MagnetLink MagnetLink { get; set; }
+        TestWriter PieceWriter { get; set; }
         BEncodedDictionary torrentInfo;
         Torrent Torrent { get; set; }
 
@@ -52,8 +54,10 @@ namespace MonoTorrent.Streaming
         public void Setup ()
         {
             LocalPeerDiscoveryFactory.Creator = port => new ManualLocalPeerListener ();
-            Engine = new ClientEngine (new EngineSettings ());
-            Engine.DiskManager.ChangePieceWriter (new TestWriter ());
+            Engine = new ClientEngine ();
+
+            PieceWriter = new TestWriter ();
+            Engine.DiskManager.ChangePieceWriter (PieceWriter);
             Torrent = TestRig.CreateMultiFileTorrent (new[] { new TorrentFile ("path", Piece.BlockSize * 1024, 0, 1024 / 8 - 1, 0, null, null, null) }, Piece.BlockSize * 8, out torrentInfo);
             MagnetLink = new MagnetLink (Torrent.InfoHash, "MagnetDownload");
         }
@@ -61,93 +65,53 @@ namespace MonoTorrent.Streaming
         [TearDown]
         public async Task Teardown ()
         {
-            await Engine.StopAllAsync ();
+            await Engine.StopAllAsync ().WithTimeout ();
             Engine.Dispose ();
-        }
-
-        [Test]
-        public async Task DownloadMagnetLink ()
-        {
-            var provider = new StreamProvider (Engine, "testDir", MagnetLink, "magnetLinkDir");
-            Assert.IsNull (provider.Files);
-
-            await provider.StartAsync ();
-            CollectionAssert.Contains (Engine.Torrents, provider.Manager);
-        }
-
-        [Test]
-        public void DownloadMagnetLink_CachedTorrent ()
-        {
-            var metadataCacheDir = Path.Combine (Path.GetTempPath (), "magnetLinkDir");
-            var filePath = Path.Combine (metadataCacheDir, $"{MagnetLink.InfoHash.ToHex()}.torrent");
-            Directory.CreateDirectory (metadataCacheDir);
-            try {
-                File.WriteAllBytes (filePath, torrentInfo.Encode ());
-                var provider = new StreamProvider (Engine, "testDir", MagnetLink, metadataCacheDir);
-                Assert.IsNotNull (provider.Files);
-            } finally {
-                Directory.Delete (metadataCacheDir, true);
-            }
-        }
-
-        [Test]
-        public void DownloadMagnetLink_IncorrectCachedTorrent ()
-        {
-            var magnetLinkOtherInfoHash = new MagnetLink (new InfoHash (new byte[20]), "OtherHash");
-            var metadataCacheDir = Path.Combine (Path.GetTempPath (), "magnetLinkDir");
-            var filePath = Path.Combine (metadataCacheDir, $"{magnetLinkOtherInfoHash.InfoHash.ToHex ()}.torrent");
-            Directory.CreateDirectory (metadataCacheDir);
-            try {
-                // Write the data for one info hash into a torrent for another info hash.
-                File.WriteAllBytes (filePath, torrentInfo.Encode ());
-                var provider = new StreamProvider (Engine, "testDir", magnetLinkOtherInfoHash, metadataCacheDir);
-                Assert.IsNull (provider.Files);
-            } finally {
-                Directory.Delete (metadataCacheDir, true);
-            }
-        }
-
-        [Test]
-        public async Task DownloadSameTorrentTwice()
-        {
-            var provider = new StreamProvider (Engine, "testDir", Torrent);
-            await provider.StartAsync ();
-
-            var provider2 = new StreamProvider (Engine, "testDir", Torrent);
-            Assert.ThrowsAsync<InvalidOperationException> (() => provider2.StartAsync ());
         }
 
         [Test]
         public async Task CreateStream ()
         {
-            var provider = new StreamProvider (Engine, "testDir", Torrent);
-            await provider.StartAsync ();
-            using var stream = await provider.CreateStreamAsync (provider.Files[0], prebuffer: false, CancellationToken.None);
+            var manager = await Engine.AddStreamingAsync (Torrent, "test");
+            manager.LoadFastResume (new FastResume (manager.InfoHash, manager.Bitfield.Clone ().SetAll (true), manager.Bitfield.Clone ().SetAll (false)));
+            PieceWriter.FilesThatExist.AddRange (manager.Files);
+
+            await manager.StartAsync ();
+            await manager.WaitForState (TorrentState.Seeding);
+
+            using var stream = await manager.StreamProvider.CreateStreamAsync (manager.Files[0], prebuffer: false, CancellationToken.None);
             Assert.IsNotNull (stream);
             Assert.AreEqual (0, stream.Position);
-            Assert.AreEqual (provider.Files[0].Length, stream.Length);
+            Assert.AreEqual (manager.Files[0].Length, stream.Length);
         }
 
         [Test]
         public async Task CreateStream_Prebuffer ()
         {
-            var provider = new StreamProvider (Engine, "testDir", Torrent);
-            await provider.StartAsync ();
-            await provider.Manager.WaitForState (TorrentState.Downloading);
-            provider.Manager.Bitfield.SetAll (true); // should not be allowed by public API.
+            var manager = await Engine.AddStreamingAsync (Torrent, "test");
+            manager.LoadFastResume (new FastResume (manager.InfoHash, manager.Bitfield.Clone ().SetAll (true), manager.Bitfield.Clone ().SetAll (false)));
+            PieceWriter.FilesThatExist.AddRange (manager.Files);
 
-            using var stream = await provider.CreateStreamAsync (provider.Files[0], prebuffer: true, CancellationToken.None);
+            await manager.StartAsync ();
+            await manager.WaitForState (TorrentState.Seeding);
+
+            using var stream = await manager.StreamProvider.CreateStreamAsync (manager.Files[0], prebuffer: true, CancellationToken.None).WithTimeout ();
             Assert.IsNotNull (stream);
             Assert.AreEqual (0, stream.Position);
-            Assert.AreEqual (provider.Files[0].Length, stream.Length);
+            Assert.AreEqual (manager.Files[0].Length, stream.Length);
         }
 
         [Test]
         public async Task ReadPastEndOfStream ()
         {
-            var provider = new StreamProvider (Engine, "testDir", Torrent);
-            await provider.StartAsync ();
-            using var stream = await provider.CreateStreamAsync (provider.Files[0], prebuffer: false, CancellationToken.None).WithTimeout ();
+            var manager = await Engine.AddStreamingAsync (Torrent, "testDir");
+            manager.LoadFastResume (new FastResume (manager.InfoHash, manager.Bitfield.Clone ().SetAll (true), manager.Bitfield.Clone ().SetAll (false)));
+            PieceWriter.FilesThatExist.AddRange (manager.Files);
+
+            await manager.StartAsync ();
+            await manager.WaitForState (TorrentState.Seeding);
+
+            using var stream = await manager.StreamProvider.CreateStreamAsync (manager.Files[0], prebuffer: false, CancellationToken.None).WithTimeout ();
             stream.Seek (0, SeekOrigin.End);
             Assert.AreEqual (0, await stream.ReadAsync (new byte[1], 0, 1).WithTimeout ());
         }
@@ -155,12 +119,14 @@ namespace MonoTorrent.Streaming
         [Test]
         public async Task ReadLastByte ()
         {
-            var provider = new StreamProvider (Engine, "testDir", Torrent);
-            await provider.StartAsync ();
-            await provider.Manager.WaitForState (TorrentState.Downloading).WithTimeout ();
-            provider.Manager.Bitfield.SetAll (true); // the public API shouldn't allow this.
+            var manager = await Engine.AddStreamingAsync (Torrent, "testDir");
+            manager.LoadFastResume (new FastResume (manager.InfoHash, manager.Bitfield.Clone ().SetAll (true), manager.Bitfield.Clone ().SetAll (false)));
+            PieceWriter.FilesThatExist.AddRange (manager.Files);
 
-            using var stream = await provider.CreateStreamAsync (provider.Files[0], prebuffer: false, CancellationToken.None).WithTimeout ();
+            await manager.StartAsync ();
+            await manager.WaitForState (TorrentState.Seeding);
+
+            using var stream = await manager.StreamProvider.CreateStreamAsync (manager.Files[0], prebuffer: false, CancellationToken.None).WithTimeout ();
             stream.Seek (-1, SeekOrigin.End);
             Assert.AreEqual (1, await stream.ReadAsync (new byte[1], 0, 1).WithTimeout ());
 
@@ -171,9 +137,14 @@ namespace MonoTorrent.Streaming
         [Test]
         public async Task SeekBeforeStart ()
         {
-            var provider = new StreamProvider (Engine, "testDir", Torrent);
-            await provider.StartAsync ();
-            using var stream = await provider.CreateStreamAsync (provider.Files[0], prebuffer: false, CancellationToken.None).WithTimeout ();
+            var manager = await Engine.AddStreamingAsync (Torrent, "testDir");
+            manager.LoadFastResume (new FastResume (manager.InfoHash, manager.Bitfield.Clone ().SetAll (true), manager.Bitfield.Clone ().SetAll (false)));
+            PieceWriter.FilesThatExist.AddRange (manager.Files);
+
+            await manager.StartAsync ();
+            await manager.WaitForState (TorrentState.Seeding);
+
+            using var stream = await manager.StreamProvider.CreateStreamAsync (manager.Files[0], prebuffer: false, CancellationToken.None).WithTimeout ();
             stream.Seek (-100, SeekOrigin.Begin);
             Assert.AreEqual (0, stream.Position);
         }
@@ -181,156 +152,54 @@ namespace MonoTorrent.Streaming
         [Test]
         public async Task SeekToMiddle ()
         {
-            var provider = new StreamProvider (Engine, "testDir", Torrent);
+            var manager = await Engine.AddStreamingAsync (Torrent, "testDir");
+            manager.LoadFastResume (new FastResume (manager.InfoHash, manager.Bitfield.Clone ().SetAll (true), manager.Bitfield.Clone ().SetAll (false)));
+            PieceWriter.FilesThatExist.AddRange (manager.Files);
 
-            await provider.StartAsync ();
-            await provider.Manager.WaitForState (TorrentState.Downloading);
-            provider.Manager.Bitfield.SetAll (true); // should not be allowed by public API.
+            await manager.StartAsync ();
+            await manager.WaitForState (TorrentState.Seeding);
 
-            using var stream = await provider.CreateStreamAsync (provider.Files[0], prebuffer: false, CancellationToken.None);
+            using var stream = await manager.StreamProvider.CreateStreamAsync (manager.Files[0], prebuffer: false, CancellationToken.None);
             stream.Seek (12345, SeekOrigin.Begin);
-            Assert.AreEqual (provider.Manager.ByteOffsetToPieceIndex (12345), provider.Requester.HighPriorityPieceIndex);
         }
 
         [Test]
         public async Task SeekPastEnd ()
         {
-            var provider = new StreamProvider (Engine, "testDir", Torrent);
-            await provider.StartAsync ();
-            using var stream = await provider.CreateStreamAsync (provider.Files[0], prebuffer: false, CancellationToken.None).WithTimeout ();
+            var manager = await Engine.AddStreamingAsync (Torrent, "testDir");
+            manager.LoadFastResume (new FastResume (manager.InfoHash, manager.Bitfield.Clone ().SetAll (true), manager.Bitfield.Clone ().SetAll (false)));
+            PieceWriter.FilesThatExist.AddRange (manager.Files);
+
+            await manager.StartAsync ();
+            await manager.WaitForState (TorrentState.Seeding);
+
+            using var stream = await manager.StreamProvider.CreateStreamAsync (manager.Files[0], prebuffer: false, CancellationToken.None).WithTimeout ();
             stream.Seek (stream.Length + 100, SeekOrigin.Begin);
             Assert.AreEqual (stream.Length, stream.Position);
         }
 
         [Test]
-        public void CreateStreamBeforeStart ()
+        public async Task CreateStreamBeforeStart ()
         {
-            var provider = new StreamProvider (Engine, "testDir", Torrent);
-            Assert.ThrowsAsync<InvalidOperationException> (() => provider.CreateHttpStreamAsync (provider.Files[0]));
+            var manager = await Engine.AddStreamingAsync (Torrent, "testDir");
+            manager.LoadFastResume (new FastResume (manager.InfoHash, manager.Bitfield.Clone ().SetAll (true), manager.Bitfield.Clone ().SetAll (false)));
+            PieceWriter.FilesThatExist.AddRange (manager.Files);
+
+            Assert.ThrowsAsync<InvalidOperationException> (() => manager.StreamProvider.CreateHttpStreamAsync (manager.Files[0]));
         }
 
         [Test]
         public async Task CreateStreamTwice ()
         {
-            var provider = new StreamProvider (Engine, "testDir", Torrent);
-            await provider.StartAsync ();
-            using var stream = await provider.CreateStreamAsync (provider.Files[0], false, CancellationToken.None);
-            Assert.ThrowsAsync<InvalidOperationException> (() => provider.CreateStreamAsync (provider.Files[0], false, CancellationToken.None));
-        }
+            var manager = await Engine.AddStreamingAsync (Torrent, "testDir");
+            manager.LoadFastResume (new FastResume (manager.InfoHash, manager.Bitfield.Clone ().SetAll (true), manager.Bitfield.Clone ().SetAll (false)));
+            PieceWriter.FilesThatExist.AddRange (manager.Files);
 
-        [Test]
-        public async Task Pause ()
-        {
-            var provider = new StreamProvider (Engine, "testDir", Torrent);
-            await provider.StartAsync ();
-            await provider.PauseAsync ();
-            Assert.IsTrue (provider.Active);
-            Assert.IsTrue (provider.Paused);
-        }
+            await manager.StartAsync ();
+            await manager.WaitForState (TorrentState.Seeding);
 
-        [Test]
-        public async Task PauseThenResume ()
-        {
-            var provider = new StreamProvider (Engine, "testDir", Torrent);
-            await provider.StartAsync ();
-            await provider.PauseAsync ();
-            await provider.ResumeAsync ();
-            Assert.IsTrue (provider.Active);
-            Assert.IsFalse (provider.Paused);
-        }
-
-        [Test]
-        public void PauseTwice ()
-        {
-            var provider = new StreamProvider (Engine, "testDir", Torrent);
-            Assert.ThrowsAsync<InvalidOperationException> (() => provider.PauseAsync ());
-        }
-
-        [Test]
-        public void PauseWithoutStarting ()
-        {
-            var provider = new StreamProvider (Engine, "testDir", Torrent);
-            Assert.ThrowsAsync<InvalidOperationException> (() => provider.PauseAsync ());
-        }
-
-        [Test]
-        [Ignore("delete this? ClientEngine has AddAsync now.")]
-        public async Task StartManagerManually ()
-        {
-            var provider = new StreamProvider (Engine, "testDir", Torrent);
-            // It hasn't been registered with the engine
-            Assert.ThrowsAsync<TorrentException> (() => provider.Manager.StartAsync ());
-            await Engine.AddAsync (provider.Manager.Torrent, "");
-            await provider.Manager.StartAsync ();
-
-            // People should not register and start the manager manually.
-            Assert.ThrowsAsync<TorrentException> (() => provider.StartAsync ());
-        }
-
-        [Test]
-        public async Task StopManagerManually ()
-        {
-            var provider = new StreamProvider (Engine, "testDir", Torrent);
-            await provider.StartAsync ();
-            await provider.Manager.StopAsync ();
-
-            Assert.ThrowsAsync<InvalidOperationException> (() => provider.StopAsync ());
-        }
-
-        [Test]
-        public async Task StartNormally ()
-        {
-            var provider = new StreamProvider (Engine, "testDir", Torrent);
-            Assert.IsEmpty (Engine.Torrents);
-            await provider.StartAsync ();
-            CollectionAssert.Contains (Engine.Torrents, provider.Manager);
-        }
-
-        [Test]
-        public async Task StartTwice ()
-        {
-            var provider = new StreamProvider (Engine, "testDir", Torrent);
-            await provider.StartAsync ();
-            Assert.ThrowsAsync<InvalidOperationException> (() => provider.StartAsync ());
-        }
-
-        [Test]
-        public async Task StopNormally ()
-        {
-            var provider = new StreamProvider (Engine, "testDir", Torrent);
-            await provider.StartAsync ();
-            await provider.StopAsync ();
-            Assert.IsEmpty (Engine.Torrents);
-        }
-
-        [Test]
-        public async Task StopTwice ()
-        {
-            var provider = new StreamProvider (Engine, "testDir", Torrent);
-            await provider.StartAsync ();
-            await provider.StopAsync ();
-            Assert.ThrowsAsync<InvalidOperationException> (() => provider.StopAsync ());
-        }
-
-        [Test]
-        public async Task UsesStreamingPicker ()
-        {
-            var provider = new StreamProvider (Engine, "testDir", Torrent);
-            // FIXME: Reinstate this API in some form!
-            //Assert.IsInstanceOf<StreamingPiecePicker> (provider.Manager.PieceManager.Picker.BasePicker.BasePicker.BasePicker);
-            await provider.StartAsync ();
-            //Assert.IsInstanceOf<StreamingPiecePicker> (provider.Manager.PieceManager.Picker.BasePicker.BasePicker.BasePicker);
-        }
-
-        [Test]
-        public async Task WaitForMetadata_Cancellation ()
-        {
-            var provider = new StreamProvider (Engine, "testDir", MagnetLink, "magnetDir");
-            await provider.StartAsync ();
-
-            var metadataTask = provider.WaitForMetadataAsync ();
-            await provider.StopAsync ();
-            Assert.ThrowsAsync<TaskCanceledException> (() => metadataTask);
+            using var stream = await manager.StreamProvider.CreateStreamAsync (manager.Files[0], false, CancellationToken.None);
+            Assert.ThrowsAsync<InvalidOperationException> (() => manager.StreamProvider.CreateStreamAsync (manager.Files[0], false, CancellationToken.None));
         }
     }
 }

--- a/src/MonoTorrent/MonoTorrent.Client/ClientEngine.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/ClientEngine.cs
@@ -44,6 +44,7 @@ using MonoTorrent.Client.RateLimiters;
 using MonoTorrent.Dht;
 using MonoTorrent.Dht.Listeners;
 using MonoTorrent.Logging;
+using MonoTorrent.Streaming;
 
 namespace MonoTorrent.Client
 {
@@ -253,6 +254,27 @@ namespace MonoTorrent.Client
             return manager;
         }
 #pragma warning restore CS0618 // Type or member is obsolete
+
+        public Task<TorrentManager> AddStreamingAsync (MagnetLink magnetLink, string saveDirectory)
+            => AddStreamingAsync (magnetLink, saveDirectory, new TorrentSettings ());
+
+        public Task<TorrentManager> AddStreamingAsync (MagnetLink magnetLink, string saveDirectory, TorrentSettings settings)
+            => AddStreamingAsync (magnetLink, null, saveDirectory, settings);
+
+        public Task<TorrentManager> AddStreamingAsync (Torrent torrent, string saveDirectory)
+            => AddStreamingAsync (torrent, saveDirectory, new TorrentSettings ());
+
+        public Task<TorrentManager> AddStreamingAsync (Torrent torrent, string saveDirectory, TorrentSettings settings)
+            => AddStreamingAsync (null, torrent, saveDirectory, settings);
+
+        async Task<TorrentManager> AddStreamingAsync (MagnetLink magnetLink, Torrent torrent, string saveDirectory, TorrentSettings settings)
+        {
+            var manager = await AddAsync (magnetLink, torrent, saveDirectory, settings);
+            var picker = new PiecePicking.StreamingPieceRequester ();
+            await manager.ChangePickerAsync (picker);
+            manager.StreamProvider = new StreamProvider (manager, picker);
+            return manager;
+        }
 
         public Task<bool> RemoveAsync (MagnetLink magnetLink)
         {

--- a/src/MonoTorrent/MonoTorrent.Client/ClientEngine.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/ClientEngine.cs
@@ -243,7 +243,7 @@ namespace MonoTorrent.Client
             saveDirectory = string.IsNullOrEmpty (saveDirectory) ? Environment.CurrentDirectory : Path.GetFullPath (saveDirectory);
             TorrentManager manager;
             if (magnetLink != null) {
-                var metadataSaveFilePath = Path.Combine (Path.GetFullPath (Settings.MetadataSaveDirectory ?? Environment.CurrentDirectory), magnetLink.InfoHash.ToHex () + ".torrent");
+                var metadataSaveFilePath = Path.Combine (Settings.MetadataSaveDirectory, magnetLink.InfoHash.ToHex () + ".torrent");
                 manager = new TorrentManager (magnetLink, saveDirectory, settings, metadataSaveFilePath);
                 if (File.Exists (metadataSaveFilePath) && Torrent.TryLoad (metadataSaveFilePath, out Torrent loaded) && loaded.InfoHash == magnetLink.InfoHash)
                     manager.SetMetadata (loaded);

--- a/src/MonoTorrent/MonoTorrent.Client/ClientEngine.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/ClientEngine.cs
@@ -30,6 +30,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -163,7 +164,7 @@ namespace MonoTorrent.Client
         #region Constructors
 
         public ClientEngine ()
-            : this(new EngineSettings ())
+            : this (new EngineSettings ())
         {
 
         }
@@ -223,6 +224,78 @@ namespace MonoTorrent.Client
 
         #region Methods
 
+        public Task<TorrentManager> AddAsync (MagnetLink magnetLink, string saveDirectory)
+            => AddAsync (magnetLink, saveDirectory, new TorrentSettings ());
+
+        public Task<TorrentManager> AddAsync (MagnetLink magnetLink, string saveDirectory, TorrentSettings settings)
+            => AddAsync (magnetLink, null, saveDirectory, settings);
+
+        public Task<TorrentManager> AddAsync (Torrent torrent, string saveDirectory)
+            => AddAsync (torrent, saveDirectory, new TorrentSettings ());
+
+        public Task<TorrentManager> AddAsync (Torrent torrent, string saveDirectory, TorrentSettings settings)
+            => AddAsync (null, torrent, saveDirectory, settings);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+        async Task<TorrentManager> AddAsync (MagnetLink magnetLink, Torrent torrent, string saveDirectory, TorrentSettings settings)
+        {
+            saveDirectory = string.IsNullOrEmpty (saveDirectory) ? Environment.CurrentDirectory : Path.GetFullPath (saveDirectory);
+            TorrentManager manager;
+            if (magnetLink != null) {
+                var metadataSaveFilePath = Path.Combine (Path.GetFullPath (Settings.MetadataSaveDirectory ?? Environment.CurrentDirectory), magnetLink.InfoHash.ToHex () + ".torrent");
+                manager = new TorrentManager (magnetLink, saveDirectory, settings, metadataSaveFilePath);
+                if (File.Exists (metadataSaveFilePath) && Torrent.TryLoad (metadataSaveFilePath, out Torrent loaded) && loaded.InfoHash == magnetLink.InfoHash)
+                    manager.SetMetadata (loaded);
+            } else {
+                manager = new TorrentManager (torrent, saveDirectory, settings);
+            }
+            await Register (manager);
+            return manager;
+        }
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        public Task<bool> RemoveAsync (MagnetLink magnetLink)
+        {
+            magnetLink = magnetLink ?? throw new ArgumentNullException (nameof (magnetLink));
+            return RemoveAsync (magnetLink.InfoHash);
+        }
+
+        public Task<bool> RemoveAsync (Torrent torrent)
+        {
+            torrent = torrent ?? throw new ArgumentNullException (nameof (torrent));
+            return RemoveAsync (torrent.InfoHash);
+        }
+
+        public async Task<bool> RemoveAsync (TorrentManager manager)
+        {
+            CheckDisposed ();
+            Check.Manager (manager);
+
+            await MainLoop;
+            if (manager.Engine != this)
+                throw new TorrentException ("The manager has not been registered with this engine");
+
+            if (manager.State != TorrentState.Stopped)
+                throw new TorrentException ("The manager must be stopped before it can be unregistered");
+
+            allTorrents.Remove (manager);
+            publicTorrents.Remove (manager);
+            ConnectionManager.Remove (manager);
+            listenManager.Remove (manager.InfoHash);
+
+            manager.Engine = null;
+            manager.DownloadLimiters.Remove (downloadLimiters);
+            manager.UploadLimiters.Remove (uploadLimiters);
+            return true;
+        }
+
+        async Task<bool> RemoveAsync (InfoHash infohash)
+        {
+            await MainLoop;
+            var manager = allTorrents.FirstOrDefault (t => t.InfoHash == infohash);
+            return manager == null ? false : await RemoveAsync (manager);
+        }
+
         public async Task ChangePieceWriterAsync (IPieceWriter writer)
         {
             writer = writer ?? throw new ArgumentNullException (nameof (writer));
@@ -263,7 +336,7 @@ namespace MonoTorrent.Client
             if (manager == null)
                 return false;
 
-            return Contains (manager.Torrent);
+            return Contains (manager.InfoHash);
         }
 
         public void Dispose ()
@@ -303,7 +376,7 @@ namespace MonoTorrent.Client
             await manager.StartAsync (metadataOnly: true);
             var data = await metadataCompleted.Task;
             await manager.StopAsync ();
-            await Unregister (manager);
+            await RemoveAsync (manager);
 
             token.ThrowIfCancellationRequested ();
             return data;
@@ -344,8 +417,10 @@ namespace MonoTorrent.Client
             await Task.WhenAll (tasks);
         }
 
+        [Obsolete ("Instead of creating a TorrentManager and invoking 'ClientEngine.Register(TorrentManager)', just invoke 'ClientEngine.AddAsync'.")]
         public async Task Register (TorrentManager manager)
             => await Register (manager, true);
+
 
         async Task Register (TorrentManager manager, bool isPublic)
         {
@@ -484,26 +559,10 @@ namespace MonoTorrent.Client
             await Task.WhenAll (tasks);
         }
 
+        [Obsolete ("Use one of the 'ClientEngine.RemoveAsync(Torrent)' overloads to remove a TorrentManager from the ClientEngine.")]
         public async Task Unregister (TorrentManager manager)
         {
-            CheckDisposed ();
-            Check.Manager (manager);
-
-            await MainLoop;
-            if (manager.Engine != this)
-                throw new TorrentException ("The manager has not been registered with this engine");
-
-            if (manager.State != TorrentState.Stopped)
-                throw new TorrentException ("The manager must be stopped before it can be unregistered");
-
-            allTorrents.Remove (manager);
-            publicTorrents.Remove (manager);
-            ConnectionManager.Remove (manager);
-            listenManager.Remove (manager.InfoHash);
-
-            manager.Engine = null;
-            manager.DownloadLimiters.Remove (downloadLimiters);
-            manager.UploadLimiters.Remove (uploadLimiters);
+            await RemoveAsync (manager);
         }
 
         #endregion

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -292,17 +292,20 @@ namespace MonoTorrent.Client
         #endregion
 
         #region Constructors
+#pragma warning disable CS0618 // Type or member is obsolete
         internal TorrentManager (MagnetLink magnetLink)
             : this (magnetLink, "", new TorrentSettings (), "")
         {
 
         }
+#pragma warning restore CS0618 // Type or member is obsolete
 
         /// <summary>
         /// Creates a new TorrentManager instance.
         /// </summary>
         /// <param name="torrent">The torrent to load in</param>
         /// <param name="savePath">The directory to save downloaded files to</param>
+        [Obsolete ("Instead of creating a TorrentManager and invoking 'ClientEngine.Register(TorrentManager)', just invoke 'ClientEngine.AddAsync'.")]
         public TorrentManager (Torrent torrent, string savePath)
             : this (torrent, savePath, new TorrentSettings ())
         {
@@ -315,6 +318,7 @@ namespace MonoTorrent.Client
         /// <param name="torrent">The torrent to load in</param>
         /// <param name="savePath">The directory to save downloaded files to</param>
         /// <param name="settings">The settings to use for controlling connections</param>
+        [Obsolete("Instead of creating a TorrentManager and invoking 'ClientEngine.Register(TorrentManager)', just invoke 'ClientEngine.AddAsync'.")]
         public TorrentManager (Torrent torrent, string savePath, TorrentSettings settings)
         {
             Check.Torrent (torrent);
@@ -329,6 +333,7 @@ namespace MonoTorrent.Client
         }
 
 
+        [Obsolete("Instead of creating a TorrentManager and invoking 'ClientEngine.Register(TorrentManager)', just invoke 'ClientEngine.AddAsync'.")]
         public TorrentManager (InfoHash infoHash, string savePath, TorrentSettings settings, string torrentSave, IList<IList<string>> announces)
         {
             Check.InfoHash (infoHash);
@@ -344,6 +349,7 @@ namespace MonoTorrent.Client
             Initialise (savePath, announces);
         }
 
+        [Obsolete("Instead of creating a TorrentManager and invoking 'ClientEngine.Register(TorrentManager)', just invoke 'ClientEngine.AddAsync'.")]
         public TorrentManager (MagnetLink magnetLink, string savePath, TorrentSettings settings, string torrentSave)
         {
             Check.MagnetLink (magnetLink);

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -582,7 +582,7 @@ namespace MonoTorrent.Client
 
             // Now we know the torrent name, use it as the base directory name when it's a multi-file torrent
             var savePath = SavePath;
-            if (Torrent.Files.Count > 1 && Settings.CreateSubFolder)
+            if (Torrent.Files.Count > 1 && Settings.CreateContainingDirectory)
                 savePath = Path.Combine (savePath, Torrent.Name);
 
             Files = Torrent.Files.Select (file =>

--- a/src/MonoTorrent/MonoTorrent.Client/Settings/EngineSettings.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Settings/EngineSettings.cs
@@ -143,7 +143,10 @@ namespace MonoTorrent.Client
         /// This is the path where the .torrent metadata will be saved when magnet links are used to start a download.
         /// Defaults to <see langword="null" />
         /// </summary>
-        public string SavePath { get; }
+        public string MetadataSaveDirectory { get; }
+
+        [Obsolete ("Use the 'MetadataSaveDirectory' property instead")]
+        public string SavePath => MetadataSaveDirectory;
 
         public EngineSettings ()
         {
@@ -169,7 +172,7 @@ namespace MonoTorrent.Client
             MaximumOpenFiles = maximumOpenFiles;
             MaximumUploadSpeed = maximumUploadSpeed;
             ReportedAddress = reportedAddress;
-            SavePath = savePath;
+            MetadataSaveDirectory = savePath;
         }
 
         public override bool Equals (object obj)
@@ -193,7 +196,7 @@ namespace MonoTorrent.Client
                    && MaximumOpenFiles == other.MaximumOpenFiles
                    && MaximumUploadSpeed == other.MaximumUploadSpeed
                    && ReportedAddress == other.ReportedAddress
-                   && SavePath == other.SavePath;
+                   && MetadataSaveDirectory == other.MetadataSaveDirectory;
         }
 
         public override int GetHashCode ()
@@ -204,7 +207,7 @@ namespace MonoTorrent.Client
                    MaximumHalfOpenConnections +
                    ListenPort.GetHashCode () +
                    AllowedEncryption.GetHashCode () +
-                   SavePath.GetHashCode ();
+                   MetadataSaveDirectory.GetHashCode ();
         }
     }
 }

--- a/src/MonoTorrent/MonoTorrent.Client/Settings/EngineSettings.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Settings/EngineSettings.cs
@@ -29,8 +29,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
+
+using MonoTorrent.Dht;
 
 namespace MonoTorrent.Client
 {
@@ -64,6 +67,14 @@ namespace MonoTorrent.Client
         /// Defaults to true.
         /// </summary>
         public bool AllowPortForwarding { get; } = true;
+
+        /// <summary>
+        /// The full path to the directory used to cache any data needed by the engine. Typically used to store a
+        /// cache of the DHT table to improve bootstrapping speed, any metadata downloaded
+        /// using a magnet link, or fast resume data for individual torrents.
+        /// Defaults to <see cref="Environment.CurrentDirectory"/>
+        /// </summary>
+        public string CacheDirectory { get; } = Environment.CurrentDirectory;
 
         /// <summary>
         /// If a connection attempt does not complete within the given timeout, it will be cancelled so
@@ -140,20 +151,20 @@ namespace MonoTorrent.Client
         public IPEndPoint ReportedAddress { get; }
 
         /// <summary>
-        /// This is the path where the .torrent metadata will be saved when magnet links are used to start a download.
-        /// Defaults to <see langword="null" />
+        /// This is the full path to a sub-directory of <see cref="CacheDirectory"/>. If a magnet link is used
+        /// to download a torrent, the downloaded metata will be cached here.
         /// </summary>
-        public string MetadataSaveDirectory { get; }
+        public string MetadataSaveDirectory => Path.Combine (CacheDirectory, "metadata");
 
-        [Obsolete ("Use the 'MetadataSaveDirectory' property instead")]
-        public string SavePath => MetadataSaveDirectory;
+        [Obsolete ("Use the 'CacheDirectory' property instead")]
+        public string SavePath => CacheDirectory;
 
         public EngineSettings ()
         {
 
         }
 
-        internal EngineSettings (IList<EncryptionType> allowedEncryption, bool allowHaveSuppression, bool allowLocalPeerDiscovery, bool allowPortForwarding, TimeSpan connectionTimeout, int dhtPort, int diskCacheBytes, int listenPort, int maximumConnections, int maximumDiskReadRate, int maximumDiskWriteRate, int maximumDownloadSpeed, int maximumHalfOpenConnections, int maximumOpenFiles, int maximumUploadSpeed, IPEndPoint reportedAddress, string savePath)
+        internal EngineSettings (IList<EncryptionType> allowedEncryption, bool allowHaveSuppression, bool allowLocalPeerDiscovery, bool allowPortForwarding, string cacheDirectory, TimeSpan connectionTimeout, int dhtPort, int diskCacheBytes, int listenPort, int maximumConnections, int maximumDiskReadRate, int maximumDiskWriteRate, int maximumDownloadSpeed, int maximumHalfOpenConnections, int maximumOpenFiles, int maximumUploadSpeed, IPEndPoint reportedAddress)
         {
             // Make sure this is immutable now
             AllowedEncryption = EncryptionTypes.MakeReadOnly (allowedEncryption);
@@ -162,6 +173,7 @@ namespace MonoTorrent.Client
             AllowPortForwarding = allowPortForwarding;
             DhtPort = dhtPort;
             DiskCacheBytes = diskCacheBytes;
+            CacheDirectory = cacheDirectory;
             ConnectionTimeout = connectionTimeout;
             ListenPort = listenPort;
             MaximumConnections = maximumConnections;
@@ -172,7 +184,6 @@ namespace MonoTorrent.Client
             MaximumOpenFiles = maximumOpenFiles;
             MaximumUploadSpeed = maximumUploadSpeed;
             ReportedAddress = reportedAddress;
-            MetadataSaveDirectory = savePath;
         }
 
         public override bool Equals (object obj)
@@ -181,10 +192,11 @@ namespace MonoTorrent.Client
         public bool Equals (EngineSettings other)
         {
             return other != null
-                   && AllowedEncryption.SequenceEqual(other.AllowedEncryption)
+                   && AllowedEncryption.SequenceEqual (other.AllowedEncryption)
                    && AllowHaveSuppression == other.AllowHaveSuppression
                    && AllowLocalPeerDiscovery == other.AllowLocalPeerDiscovery
                    && AllowPortForwarding == other.AllowPortForwarding
+                   && CacheDirectory == other.CacheDirectory
                    && DhtPort == other.DhtPort
                    && DiskCacheBytes == other.DiskCacheBytes
                    && ListenPort == other.ListenPort
@@ -196,7 +208,7 @@ namespace MonoTorrent.Client
                    && MaximumOpenFiles == other.MaximumOpenFiles
                    && MaximumUploadSpeed == other.MaximumUploadSpeed
                    && ReportedAddress == other.ReportedAddress
-                   && MetadataSaveDirectory == other.MetadataSaveDirectory;
+                   ;
         }
 
         public override int GetHashCode ()
@@ -207,7 +219,7 @@ namespace MonoTorrent.Client
                    MaximumHalfOpenConnections +
                    ListenPort.GetHashCode () +
                    AllowedEncryption.GetHashCode () +
-                   MetadataSaveDirectory.GetHashCode ();
+                   CacheDirectory.GetHashCode ();
         }
     }
 }

--- a/src/MonoTorrent/MonoTorrent.Client/Settings/EngineSettingsBuilder.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Settings/EngineSettingsBuilder.cs
@@ -190,7 +190,13 @@ namespace MonoTorrent.Client
         /// This is the path where the .torrent metadata will be saved when magnet links are used to start a download.
         /// Defaults to <see langword="null" />
         /// </summary>
-        public string SavePath { get; set; }
+        public string MetadataSaveDirectory { get; set; }
+
+        [Obsolete("use 'MetadataSaveDirectory' instead")]
+        public string SavePath {
+            get => MetadataSaveDirectory;
+            set => MetadataSaveDirectory = value;
+        }
 
         public EngineSettingsBuilder ()
             : this (new EngineSettings ())
@@ -217,7 +223,7 @@ namespace MonoTorrent.Client
             MaximumOpenFiles = settings.MaximumOpenFiles;
             MaximumUploadSpeed = settings.MaximumUploadSpeed;
             ReportedAddress = settings.ReportedAddress;
-            SavePath = settings.SavePath;
+            MetadataSaveDirectory = settings.MetadataSaveDirectory;
         }
 
         public EngineSettings ToSettings ()
@@ -246,7 +252,7 @@ namespace MonoTorrent.Client
                 maximumOpenFiles: MaximumOpenFiles,
                 maximumUploadSpeed: MaximumUploadSpeed,
                 reportedAddress: ReportedAddress,
-                savePath: SavePath
+                savePath: MetadataSaveDirectory
             );
         }
         static int CheckPort (int value)

--- a/src/MonoTorrent/MonoTorrent.Client/Settings/EngineSettingsBuilder.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Settings/EngineSettingsBuilder.cs
@@ -29,8 +29,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
+
+using MonoTorrent.Dht;
 
 namespace MonoTorrent.Client
 {
@@ -75,6 +78,16 @@ namespace MonoTorrent.Client
         /// Defaults to true.
         /// </summary>
         public bool AllowPortForwarding { get; set; }
+
+        /// <summary>
+        /// The directory used to cache any data needed by the engine. Typically used to store a
+        /// cache of the DHT table to improve bootstrapping speed, any metadata downloaded
+        /// using a magnet link, or fast resume data for individual torrents.
+        /// When <see cref="ToSettings"/> is invoked the value will be converted to a full path
+        /// if it is not already a full path, or will be replaced with
+        /// <see cref="Environment.CurrentDirectory"/> if the value is null or empty.
+        /// </summary>
+        public string CacheDirectory { get; set; }
 
         /// <summary>
         /// If a connection attempt does not complete within the given timeout, it will be cancelled so
@@ -186,16 +199,10 @@ namespace MonoTorrent.Client
         /// </summary>
         public IPEndPoint ReportedAddress { get; set; }
 
-        /// <summary>
-        /// This is the path where the .torrent metadata will be saved when magnet links are used to start a download.
-        /// Defaults to <see langword="null" />
-        /// </summary>
-        public string MetadataSaveDirectory { get; set; }
-
-        [Obsolete("use 'MetadataSaveDirectory' instead")]
+        [Obsolete("use 'CacheDirectory' instead")]
         public string SavePath {
-            get => MetadataSaveDirectory;
-            set => MetadataSaveDirectory = value;
+            get => CacheDirectory;
+            set => CacheDirectory = value;
         }
 
         public EngineSettingsBuilder ()
@@ -211,6 +218,7 @@ namespace MonoTorrent.Client
             AllowHaveSuppression = settings.AllowHaveSuppression;
             AllowLocalPeerDiscovery = settings.AllowLocalPeerDiscovery;
             AllowPortForwarding = settings.AllowPortForwarding;
+            CacheDirectory = settings.CacheDirectory;
             ConnectionTimeout = settings.ConnectionTimeout;
             DhtPort = settings.DhtPort;
             DiskCacheBytes = settings.DiskCacheBytes;
@@ -223,7 +231,6 @@ namespace MonoTorrent.Client
             MaximumOpenFiles = settings.MaximumOpenFiles;
             MaximumUploadSpeed = settings.MaximumUploadSpeed;
             ReportedAddress = settings.ReportedAddress;
-            MetadataSaveDirectory = settings.MetadataSaveDirectory;
         }
 
         public EngineSettings ToSettings ()
@@ -240,6 +247,7 @@ namespace MonoTorrent.Client
                 allowHaveSuppression: AllowHaveSuppression,
                 allowLocalPeerDiscovery: AllowLocalPeerDiscovery,
                 allowPortForwarding: AllowPortForwarding,
+                cacheDirectory: string.IsNullOrEmpty (CacheDirectory) ? Environment.CurrentDirectory : Path.GetFullPath (CacheDirectory),
                 connectionTimeout: ConnectionTimeout,
                 dhtPort: DhtPort,
                 diskCacheBytes: diskCacheBytes,
@@ -251,10 +259,10 @@ namespace MonoTorrent.Client
                 maximumHalfOpenConnections: MaximumHalfOpenConnections,
                 maximumOpenFiles: MaximumOpenFiles,
                 maximumUploadSpeed: MaximumUploadSpeed,
-                reportedAddress: ReportedAddress,
-                savePath: MetadataSaveDirectory
+                reportedAddress: ReportedAddress
             );
         }
+
         static int CheckPort (int value)
         {
             if (value < -1 || value > ushort.MaxValue)

--- a/src/MonoTorrent/MonoTorrent.Client/Settings/TorrentSettings.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Settings/TorrentSettings.cs
@@ -54,6 +54,13 @@ namespace MonoTorrent.Client
         public bool AllowPeerExchange { get; } = true;
 
         /// <summary>
+        /// If set to true all files in a multi-file torrent will be placed inside a containing directory.
+        /// The directory name will be derived from <see cref="MagnetLink.Name"/> or <see cref="Torrent.Name"/>.
+        /// Defaults to <see langword="true"/>
+        /// </summary>
+        public bool CreateContainingDirectory { get; } = true;
+
+        /// <summary>
         /// The maximum number of concurrent open connections for this torrent. Defaults to 60.
         /// </summary>
         public int MaximumConnections { get; } = 60;
@@ -101,28 +108,26 @@ namespace MonoTorrent.Client
         /// </summary>
         internal TimeSpan TimeToWaitUntilIdle => TimeSpan.FromMinutes (10);
 
-        /// <summary>
-        /// If set to false then root folder will be not created for multi-files torrents
-        /// </summary>
-        public bool CreateSubFolder { get; } = true;
+        [Obsolete ("Use 'CreateContainingDirectory' instead")]
+        public bool CreateSubFolder => CreateContainingDirectory;
 
         public TorrentSettings ()
         {
 
         }
 
-        internal TorrentSettings (bool allowDht, bool allowInitialSeeding, bool allowPeerExchange, int maximumConnections, int maximumDownloadSpeed, int maximumUploadSpeed, int uploadSlots, TimeSpan webSeedDelay, int webSeedSpeedTrigger, bool createSubFolder)
+        internal TorrentSettings (bool allowDht, bool allowInitialSeeding, bool allowPeerExchange, int maximumConnections, int maximumDownloadSpeed, int maximumUploadSpeed, int uploadSlots, TimeSpan webSeedDelay, int webSeedSpeedTrigger, bool createContainingDirectory)
         {
             AllowDht = allowDht;
             AllowInitialSeeding = allowInitialSeeding;
             AllowPeerExchange = allowPeerExchange;
+            CreateContainingDirectory = createContainingDirectory;
             MaximumConnections = maximumConnections;
             MaximumDownloadSpeed = maximumDownloadSpeed;
             MaximumUploadSpeed = maximumUploadSpeed;
             UploadSlots = uploadSlots;
             WebSeedDelay = webSeedDelay;
             WebSeedSpeedTrigger = webSeedSpeedTrigger;
-            CreateSubFolder = createSubFolder;
         }
 
         public override bool Equals (object obj)
@@ -134,13 +139,13 @@ namespace MonoTorrent.Client
                 && AllowDht == other.AllowDht
                 && AllowInitialSeeding == other.AllowInitialSeeding
                 && AllowPeerExchange == other.AllowPeerExchange
+                && CreateContainingDirectory == other.CreateContainingDirectory
                 && MaximumConnections == other.MaximumConnections
                 && MaximumDownloadSpeed == other.MaximumDownloadSpeed
                 && MaximumUploadSpeed == other.MaximumUploadSpeed
                 && UploadSlots == other.UploadSlots
                 && WebSeedDelay == other.WebSeedDelay
-                && WebSeedSpeedTrigger == other.WebSeedSpeedTrigger
-                && CreateSubFolder == other.CreateSubFolder;
+                && WebSeedSpeedTrigger == other.WebSeedSpeedTrigger;
         }
 
         public override int GetHashCode ()

--- a/src/MonoTorrent/MonoTorrent.Client/Settings/TorrentSettingsBuilder.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Settings/TorrentSettingsBuilder.cs
@@ -58,6 +58,19 @@ namespace MonoTorrent.Client
         public bool AllowPeerExchange { get; set; }
 
         /// <summary>
+        /// If set to true all files in a multi-file torrent will be placed inside a containing directory.
+        /// The directory name will be derived from <see cref="MagnetLink.Name"/> or <see cref="Torrent.Name"/>.
+        /// Defaults to <see langword="true"/>
+        /// </summary>
+        public bool CreateContainingDirectory { get; set; }
+
+        [Obsolete ("Use 'CreateContainingDirectory' instead.")]
+        public bool CreateSubFolder {
+            get => CreateContainingDirectory;
+            set => CreateContainingDirectory = value;
+        }
+
+        /// <summary>
         /// The maximum number of concurrent open connections for this torrent. Defaults to 60.
         /// </summary>
         public int MaximumConnections {
@@ -99,11 +112,6 @@ namespace MonoTorrent.Client
         /// </summary>
         public int WebSeedSpeedTrigger { get; set; }
 
-        /// <summary>
-        /// If set to false then root folder will be not created for multi-files torrents, otherwise all files will be placed inside a root folder named <see cref="TorrentManager.Name"/>. Defaults to true.
-        /// </summary>
-        public bool CreateSubFolder { get; set; }
-
         public TorrentSettingsBuilder ()
             : this (new TorrentSettings ())
         {
@@ -115,13 +123,13 @@ namespace MonoTorrent.Client
             AllowDht = settings.AllowDht;
             AllowInitialSeeding = settings.AllowInitialSeeding;
             AllowPeerExchange = settings.AllowPeerExchange;
+            CreateContainingDirectory = settings.CreateContainingDirectory;
             MaximumConnections = settings.MaximumConnections;
             MaximumDownloadSpeed = settings.MaximumDownloadSpeed;
             MaximumUploadSpeed = settings.MaximumUploadSpeed;
             UploadSlots = settings.UploadSlots;
             WebSeedDelay = settings.WebSeedDelay;
             WebSeedSpeedTrigger = settings.WebSeedSpeedTrigger;
-            CreateSubFolder = settings.CreateSubFolder;
         }
 
         public TorrentSettings ToSettings ()
@@ -136,7 +144,7 @@ namespace MonoTorrent.Client
                 UploadSlots,
                 WebSeedDelay,
                 WebSeedSpeedTrigger,
-                CreateSubFolder
+                CreateContainingDirectory
             );
         }
 

--- a/src/MonoTorrent/MonoTorrent.Streaming/StreamProvider.cs
+++ b/src/MonoTorrent/MonoTorrent.Streaming/StreamProvider.cs
@@ -43,156 +43,15 @@ namespace MonoTorrent.Streaming
     public class StreamProvider
     {
         LocalStream ActiveStream { get; set; }
-        ClientEngine Engine { get; }
-        internal StreamingPieceRequester Requester { get; }
-
-        /// <summary>
-        /// Returns true when the <see cref="StreamProvider"/> has been started.
-        /// </summary>
-        public bool Active { get; private set; }
-
-        /// <summary>
-        /// Can be used to cancel pending operations when StopAsync is invoked.
-        /// </summary>
         CancellationTokenSource Cancellation { get; set; }
+        TorrentManager Manager { get; }
+        StreamingPieceRequester PieceRequester { get; }
 
-        /// <summary>
-        /// Returns true when the <see cref="StreamProvider"/> has been paused.
-        /// </summary>
-        public bool Paused { get; private set; }
-
-        /// <summary>
-        /// If the <see cref="StreamProvider"/> was created using a <see cref="Torrent"/> then
-        /// the files will be available immediately. Otherwise the files will be available as soon
-        /// as the metadata has been downloaded. The <see cref="Task"/> returned by <see cref="WaitForMetadataAsync()"/>
-        /// will complete after this has been set to the list of files.
-        /// </summary>
-        public IList<ITorrentFileInfo> Files {
-            get; private set;
-        }
-        /// <summary>
-        /// The underlying <see cref="TorrentManager"/> used to download the data.
-        /// It is safe to attach to events, retrieve state and also change any of
-        /// the settings associated with this TorrentManager. You should never
-        /// call StartAsync, StopAsync, PauseAsync or similar life-cycle methods,
-        /// nor should you attempt to register this with a <see cref="ClientEngine"/>.
-        /// </summary>
-        public TorrentManager Manager { get; }
-
-        /// <summary>
-        /// Creates a StreamProvider for the given <see cref="Torrent"/> so that files
-        /// contained within the torrent can be accessed as they are downloading.
-        /// </summary>
-        /// <param name="engine">The engine used to host the download.</param>
-        /// <param name="saveDirectory">The directory where the torrents data will be saved</param>
-        /// <param name="torrent">The torrent to download</param>
-        public StreamProvider (ClientEngine engine, string saveDirectory, Torrent torrent)
+        internal StreamProvider (TorrentManager manager, StreamingPieceRequester pieceRequester)
         {
-            Engine = engine;
-            Manager = new TorrentManager (torrent, saveDirectory);
-            Manager.ChangePicker (Requester = new StreamingPieceRequester ());
-            Files = Manager.Files;
-        }
-
-        /// <summary>
-        /// Creates a StreamProvider for the given <see cref="MagnetLink"/> so that files
-        /// contained within the torrent can be accessed as they are downloading.
-        /// </summary>
-        /// <param name="engine">The engine used to host the download.</param>
-        /// <param name="saveDirectory">The directory where the torrents data will be saved</param>
-        /// <param name="magnetLink">The MagnetLink to download</param>
-        /// <param name="metadataSaveDirectory">The directory where the metadata will be saved. The
-        /// filename will be constucted by appending '.torrent' to the value returned by <see cref="InfoHash.ToHex ()"/>
-        /// </param>
-        public StreamProvider (ClientEngine engine, string saveDirectory, MagnetLink magnetLink, string metadataSaveDirectory)
-        {
-            Engine = engine;
-            var path = Path.Combine (metadataSaveDirectory, $"{magnetLink.InfoHash.ToHex ()}.torrent");
-            Manager = new TorrentManager (magnetLink, saveDirectory, new TorrentSettings (), path);
-            Manager.ChangePicker (Requester = new StreamingPieceRequester ());
-
-            // If the metadata for this MagnetLink has been downloaded/cached already, we will synchronously
-            // load it here and will have access to the list of Files. Otherwise we need to wait.
-            if (Manager.HasMetadata)
-                Files = Manager.Files;
-        }
-
-        /// <summary>
-        /// Registers <see cref="Manager"/> with the <see cref="ClientEngine"/>
-        /// and calls <see cref="TorrentManager.StartAsync()"/>.
-        /// </summary>
-        /// <returns></returns>
-        public async Task StartAsync ()
-        {
-            if (Active)
-                throw new InvalidOperationException ("The StreamProvider has already been started.");
-
-            if (Manager.Engine != null)
-                throw new InvalidOperationException ("The TorrentManager has already been registered with the ClientEngine. This should not occur.");
-
-            if (Engine.Contains (Manager.InfoHash)) {
-                throw new InvalidOperationException (
-                    "This Torrent/MagnetLink is already being downloaded by the ClientEngine. You must choose to either " +
-                    "stream the torrent using StreamProvider or to download it normally with the ClientEngine.");
-            }
-
             Cancellation = new CancellationTokenSource ();
-            await Engine.Register (Manager);
-            await Manager.StartAsync ();
-            Active = true;
-        }
-
-        /// <summary>
-        /// Calls <see cref="TorrentManager.PauseAsync()"/> to pause Hashing, Seeding or Downloading.
-        /// </summary>
-        /// <returns></returns>
-        public async Task PauseAsync ()
-        {
-            if (!Active)
-                throw new InvalidOperationException ("The StreamProvider can only be Paused if it is Active.");
-            if (Paused)
-                throw new InvalidOperationException ("The StreamProvider cannot be Paused again as it is already paused.");
-
-            await Manager.PauseAsync ();
-            Paused = true;
-        }
-
-        /// <summary>
-        /// Calls <see cref="TorrentManager.StartAsync()"/> to resume Hashing, Seeding or Downloading.
-        /// </summary>
-        /// <returns></returns>
-        public async Task ResumeAsync ()
-        {
-            if (!Paused)
-                throw new InvalidOperationException ("The StreamProvider cannot be resumed as it is not currently paused.");
-
-            await Manager.StartAsync ();
-            Paused = false;
-        }
-
-        /// <summary>
-        /// Calls <see cref="TorrentManager.StopAsync()"/> on <see cref="Manager"/> and unregisters
-        /// it from the <see cref="ClientEngine"/>. This will dispose the stream returned by the
-        /// most recent invocation of <see cref="CreateHttpStreamAsync(ITorrentFileInfo)"/> or
-        /// <see cref="CreateStreamAsync(ITorrentFileInfo)"/>.
-        /// </summary>
-        /// <returns></returns>
-        public async Task StopAsync ()
-        {
-            if (!Active)
-                throw new InvalidOperationException ("The StreamProvider can only be stopped if it is Active");
-
-            if (Manager.State == TorrentState.Stopped) {
-                throw new InvalidOperationException (
-                    "The TorrentManager associated with this StreamProvider has already been stopped. " +
-                    "It is an error to directly call StopAsync, PauseAsync or StartAsync on the TorrentManager.");
-            }
-
-            Cancellation.Cancel ();
-            await Manager.StopAsync ();
-            await Engine.RemoveAsync (Manager);
-            ActiveStream.SafeDispose ();
-            Active = false;
+            Manager = manager;
+            PieceRequester = pieceRequester;
         }
 
         /// <summary>
@@ -226,22 +85,34 @@ namespace MonoTorrent.Streaming
         /// </summary>
         /// <param name="file">The file to open</param>
         /// <param name="prebuffer">True if the first and last piece should be downloaded before the Stream is created.</param>
+        /// <returns></returns>
+        public Task<Stream> CreateStreamAsync (ITorrentFileInfo file, bool prebuffer)
+            => CreateStreamAsync (file, prebuffer, CancellationToken.None);
+
+        /// <summary>
+        /// Creates a <see cref="Stream"/> which can be used to access the given <see cref="TorrentFile"/>
+        /// while it is downloading. This stream is seekable and readable. The first and last pieces of
+        /// this file will be buffered before the stream is created if <paramref name="prebuffer"/> is
+        /// set to true. Finally, this stream must be disposed before another stream can be created.
+        /// </summary>
+        /// <param name="file">The file to open</param>
+        /// <param name="prebuffer">True if the first and last piece should be downloaded before the Stream is created.</param>
         /// <param name="token">The cancellation token.</param>
         /// <returns></returns>
         public async Task<Stream> CreateStreamAsync (ITorrentFileInfo file, bool prebuffer, CancellationToken token)
         {
             if (file == null)
                 throw new ArgumentNullException (nameof (file));
-            if (Files == null)
+            if (Manager.Files == null)
                 throw new InvalidOperationException ("The metadata for this torrent has not been downloaded. You must call WaitForMetadataAsync before creating a stream.");
+            if (Manager.State == TorrentState.Stopped || Manager.State == TorrentState.Stopping || Manager.State == TorrentState.Starting)
+                throw new InvalidOperationException ($"The torrent state was {Manager.State}. StreamProvider cannot be used unless the torrent manager has been successfully started.");
             if (!Manager.Files.Contains (file))
                 throw new ArgumentException ("The TorrentFile is not from this TorrentManager", nameof (file));
-            if (!Active)
-                throw new InvalidOperationException ("You must call StartAsync before creating a stream.");
             if (ActiveStream != null && !ActiveStream.Disposed)
                 throw new InvalidOperationException ("You must Dispose the previous stream before creating a new one.");
 
-            ActiveStream = new LocalStream (Manager, file, Requester);
+            ActiveStream = new LocalStream (Manager, file, PieceRequester);
 
             var tcs = CancellationTokenSource.CreateLinkedTokenSource (Cancellation.Token, token);
             if (prebuffer) {
@@ -284,6 +155,17 @@ namespace MonoTorrent.Streaming
         /// </summary>
         /// <param name="file">The file to open</param>
         /// <param name="prebuffer">True if the first and last piece should be downloaded before the Stream is created.</param>
+        /// <returns></returns>
+        public Task<IUriStream> CreateHttpStreamAsync (ITorrentFileInfo file, bool prebuffer)
+            => CreateHttpStreamAsync (file, prebuffer, CancellationToken.None);
+
+        /// <summary>
+        /// Creates a <see cref="Stream"/> which can be used to access the given <see cref="TorrentFile"/>
+        /// while it is downloading. This stream is seekable and readable. This stream must be disposed
+        /// before another stream can be created.
+        /// </summary>
+        /// <param name="file">The file to open</param>
+        /// <param name="prebuffer">True if the first and last piece should be downloaded before the Stream is created.</param>
         /// <param name="token">The cancellation token</param>
         /// <returns></returns>
         public async Task<IUriStream> CreateHttpStreamAsync (ITorrentFileInfo file, bool prebuffer, CancellationToken token)
@@ -291,60 +173,6 @@ namespace MonoTorrent.Streaming
             var stream = await CreateStreamAsync (file, prebuffer, token);
             var httpStreamer = new HttpStream (stream);
             return httpStreamer;
-        }
-
-        /// <summary>
-        /// If the <see cref="StreamProvider"/> was created using a MagnetLink, the <see cref="Task"/>
-        /// returned by this method will complete when the <see cref="Files"/> property is non-null. If
-        /// the <see cref="StreamProvider"/> was created using a <see cref="Torrent"/> instance then
-        /// this will return a completed task as <see cref="Files"/> will already be non-null.
-        /// This operation will be cancelled if <see cref="StopAsync"/> is invoked.
-        /// </summary>
-        public async Task WaitForMetadataAsync ()
-            => await WaitForMetadataAsync (CancellationToken.None);
-
-        /// <summary>
-        /// If the <see cref="StreamProvider"/> was created using a MagnetLink, the <see cref="Task"/>
-        /// returned by this method will complete when the <see cref="Files"/> property is non-null. If
-        /// the <see cref="StreamProvider"/> was created using a <see cref="Torrent"/> instance then
-        /// this will return a completed task as <see cref="Files"/> will already be non-null.
-        /// This operation will be cancelled if <see cref="StopAsync"/> is invoked.
-        /// </summary>
-        /// <param name="token">The cancellation token</param>
-        /// <returns></returns>
-        public async Task WaitForMetadataAsync (CancellationToken token)
-        {
-            if (!Active)
-                throw new InvalidOperationException ("You must call StartAsync first.");
-
-            if (Files != null)
-                return;
-
-            // Proxy to the main thread so there's no race condition
-            // between the metadata downloading and us attaching the
-            // EventHandler.
-            await ClientEngine.MainLoop;
-            token.ThrowIfCancellationRequested ();
-
-            if (Manager.HasMetadata) {
-                Files = Manager.Files;
-                return;
-            }
-
-            // Cancel if the user call StopAsync or if they cancel the token they passed in
-            var cts = CancellationTokenSource.CreateLinkedTokenSource (token, Cancellation.Token);
-
-            var tcs = new TaskCompletionSource<bool> ();
-            using var reg = cts.Token.Register (() => tcs.TrySetCanceled ());
-            EventHandler<byte[]> metadataReceivedHandler = (o, e) => tcs.TrySetResult (true);
-            Manager.MetadataReceived += metadataReceivedHandler;
-            try {
-                await tcs.Task;
-            } finally {
-                Manager.MetadataReceived -= metadataReceivedHandler;
-            }
-
-            Files = Manager.Files ?? throw new InvalidOperationException ("Internal error: The list of files should not be null after metadata has been received");
         }
     }
 }

--- a/src/MonoTorrent/MonoTorrent.Streaming/StreamProvider.cs
+++ b/src/MonoTorrent/MonoTorrent.Streaming/StreamProvider.cs
@@ -190,7 +190,7 @@ namespace MonoTorrent.Streaming
 
             Cancellation.Cancel ();
             await Manager.StopAsync ();
-            await Engine.Unregister (Manager);
+            await Engine.RemoveAsync (Manager);
             ActiveStream.SafeDispose ();
             Active = false;
         }

--- a/src/SampleClient/StressTest.cs
+++ b/src/SampleClient/StressTest.cs
@@ -107,7 +107,7 @@ namespace SampleClient
             var metadata = await creator.CreateAsync (new TorrentFileSource (DataDir));
 
             // Set up the seeder
-            await seeder.Register (new TorrentManager (Torrent.Load (metadata), DataDir, new TorrentSettingsBuilder { UploadSlots = 20 }.ToSettings ()));
+            await seeder.AddAsync (Torrent.Load (metadata), DataDir, new TorrentSettingsBuilder { UploadSlots = 20 }.ToSettings ());
             using (var fileStream = File.OpenRead (Path.Combine (DataDir, "file.data"))) {
                 while (fileStream.Position < fileStream.Length) {
                     var dataRead = new byte[16 * 1024];
@@ -123,10 +123,10 @@ namespace SampleClient
 
             List<Task> tasks = new List<Task> ();
             for (int i = 0; i < downloaders.Length; i++) {
-                await downloaders[i].Register (new TorrentManager (
+                await downloaders[i].AddAsync (
                     Torrent.Load (metadata),
                     Path.Combine (DataDir, "Downloader" + i)
-                ));
+                );
 
                 tasks.Add (RepeatDownload (downloaders[i]));
             }

--- a/src/SampleClient/main.cs
+++ b/src/SampleClient/main.cs
@@ -68,7 +68,7 @@ namespace SampleClient
             // downloadsPath - this is the path where we will save all the files to
             // port - this is the port we listen for connections on
             EngineSettings engineSettings = new EngineSettingsBuilder {
-                SavePath = downloadsPath,
+                MetadataSaveDirectory = downloadsPath,
                 ListenPort = port,
                 DhtPort = port,
                 DiskCacheBytes = 5 * 1024 * 1024,
@@ -99,8 +99,8 @@ namespace SampleClient
             await engine.DhtEngine.StartAsync (nodes);
 
             // If the SavePath does not exist, we want to create it.
-            if (!Directory.Exists (engine.Settings.SavePath))
-                Directory.CreateDirectory (engine.Settings.SavePath);
+            if (!Directory.Exists (engine.Settings.MetadataSaveDirectory))
+                Directory.CreateDirectory (engine.Settings.MetadataSaveDirectory);
 
             // If the torrentsPath does not exist, we want to create it
             if (!Directory.Exists (torrentsPath))

--- a/src/SampleClient/main.cs
+++ b/src/SampleClient/main.cs
@@ -68,7 +68,7 @@ namespace SampleClient
             // downloadsPath - this is the path where we will save all the files to
             // port - this is the port we listen for connections on
             EngineSettings engineSettings = new EngineSettingsBuilder {
-                MetadataSaveDirectory = downloadsPath,
+                CacheDirectory = "cache",
                 ListenPort = port,
                 DhtPort = port,
                 DiskCacheBytes = 5 * 1024 * 1024,
@@ -97,10 +97,6 @@ namespace SampleClient
             // complete. This is because it can take up to 2 minutes to bootstrap, depending
             // on how many nodes time out when they are contacted.
             await engine.DhtEngine.StartAsync (nodes);
-
-            // If the SavePath does not exist, we want to create it.
-            if (!Directory.Exists (engine.Settings.MetadataSaveDirectory))
-                Directory.CreateDirectory (engine.Settings.MetadataSaveDirectory);
 
             // If the torrentsPath does not exist, we want to create it
             if (!Directory.Exists (torrentsPath))

--- a/src/SampleClient/main.cs
+++ b/src/SampleClient/main.cs
@@ -126,12 +126,12 @@ namespace SampleClient
                         Console.WriteLine (e.Message);
                         continue;
                     }
+
+                    var manager = await engine.AddAsync (torrent, downloadsPath, torrentDefaults);
                     // When any preprocessing has been completed, you create a TorrentManager
                     // which you then register with the engine.
-                    TorrentManager manager = new TorrentManager (torrent, downloadsPath, torrentDefaults);
                     if (fastResume.ContainsKey (torrent.InfoHash.ToHex ()))
                         manager.LoadFastResume (new FastResume ((BEncodedDictionary) fastResume[torrent.InfoHash.ToHex ()]));
-                    await engine.Register (manager);
 
                     // Store the torrent manager in our list so we can access it later
                     torrents.Add (manager);


### PR DESCRIPTION
Some simplifications to the API.

Rather than manually creating a torrent manager, then registering it, we can make this a single API call: `ClientEngine.AddAsync`

Similarly, rather than creating a StreamingProvider to set up a torrent for streaming access, you can now just call `ClientEngine.AddStreamingAsync`. This will populate the `TorrentManager.StreamProvider` property and you'll be able to get access to the files within the torrent while the torrent is actively downloading. 

As always, if you use `TorrentManager.StreamProvider` to create a stream you can treat it like a normal FileStream. If you call ReadAsync, SeekAsync, etc, the engine will automatically download the data required to fulfill your Read or Seek request.