### PR TITLE
[core] Add support for automatically saving/loading FastResume

### DIFF
--- a/src/MonoTorrent.Tests/Client/TestRig.cs
+++ b/src/MonoTorrent.Tests/Client/TestRig.cs
@@ -397,8 +397,9 @@ namespace MonoTorrent.Client
             LocalPeerDiscoveryFactory.Creator = port => new ManualLocalPeerListener ();
             Dht.Listeners.DhtListenerFactory.Creator = endpoint => new Dht.Listeners.NullDhtListener ();
             Engine = new ClientEngine (new EngineSettingsBuilder {
+                AutomaticFastResume = false,
                 CacheDirectory = cacheDir,
-                ListenPort = 12345
+                ListenPort = 12345,
             }.ToSettings ());
             if (Directory.Exists (Engine.Settings.MetadataSaveDirectory))
                 Directory.Delete (Engine.Settings.MetadataSaveDirectory, true);

--- a/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/DownloadModeTests.cs
+++ b/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/DownloadModeTests.cs
@@ -134,7 +134,7 @@ namespace MonoTorrent.Client.Modes
             id.SupportsLTMessages = true;
 
             var torrent = TestRig.CreatePrivate ();
-            using var engine = new ClientEngine ();
+            using var engine = new ClientEngine (EngineSettingsBuilder.CreateForTests ());
             var manager = await engine.AddAsync (torrent, "");
 
             manager.Mode = new DownloadMode (manager, DiskManager, ConnectionManager, Settings);
@@ -155,7 +155,7 @@ namespace MonoTorrent.Client.Modes
         public async Task AddPeers_Tracker_Private ()
         {
             var torrent = TestRig.CreatePrivate ();
-            using var engine = new ClientEngine ();
+            using var engine = new ClientEngine (EngineSettingsBuilder.CreateForTests ());
             var manager = await engine.AddAsync (torrent, "");
 
             manager.SetTrackerManager (TrackerManager);
@@ -238,7 +238,7 @@ namespace MonoTorrent.Client.Modes
         public async Task EmptyPeerId_PrivateTorrent ()
         {
             var torrent = TestRig.CreatePrivate ();
-            using var engine = new ClientEngine ();
+            using var engine = new ClientEngine (EngineSettingsBuilder.CreateForTests ());
             var manager = await engine.AddAsync (torrent, "");
 
             manager.Mode = new DownloadMode (manager, DiskManager, ConnectionManager, Settings);
@@ -266,7 +266,7 @@ namespace MonoTorrent.Client.Modes
         public async Task MismatchedPeerId_PrivateTorrent ()
         {
             var torrent = TestRig.CreatePrivate ();
-            using var engine = new ClientEngine ();
+            using var engine = new ClientEngine (EngineSettingsBuilder.CreateForTests ());
             var manager = await engine.AddAsync (torrent, "");
 
             manager.Mode = new DownloadMode (manager, DiskManager, ConnectionManager, Settings);

--- a/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/HashingModeTests.cs
+++ b/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/HashingModeTests.cs
@@ -171,11 +171,11 @@ namespace MonoTorrent.Client.Modes
         }
 
         [Test]
-        public void SaveLoadFastResume ()
+        public async Task SaveLoadFastResume ()
         {
+            await Manager.HashCheckAsync (false);
             Manager.Bitfield.SetAll (true).Set (0, false);
             Manager.UnhashedPieces.SetAll (false).Set (0, true);
-            Manager.HashChecked = true;
 
             var origUnhashed = Manager.UnhashedPieces.Clone ();
             var origBitfield = Manager.Bitfield.Clone ();

--- a/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/MetadataModeTests.cs
+++ b/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/MetadataModeTests.cs
@@ -61,7 +61,9 @@ namespace MonoTorrent.Client.Modes
             rig = multiFile ? TestRig.CreateMultiFile (32768, metadataMode) : TestRig.CreateSingleFile (1024 * 1024 * 1024, 32768, metadataMode);
             rig.RecreateManager ().Wait ();
 
-            rig.Manager.HashChecked = true;
+            // Mark the torrent as hash check complete with no data downloaded
+            if (rig.Manager.HasMetadata)
+                rig.Manager.LoadFastResume (new FastResume (rig.Manager.InfoHash, rig.Manager.Bitfield.Clone ().SetAll (false), rig.Manager.Bitfield.Clone ().SetAll (false)));
             await rig.Manager.StartAsync (metadataOnly);
             rig.AddConnection (pair.Outgoing);
 

--- a/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/StartingModeTests.cs
+++ b/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/StartingModeTests.cs
@@ -120,7 +120,7 @@ namespace MonoTorrent.Client.Modes
             Manager.ModeChanged += (oldMode, newMode) => modeChanged.Add (newMode);
 
             var mode = new StartingMode (Manager, DiskManager, ConnectionManager, Settings);
-            Manager.HashChecked = true;
+            Manager.LoadFastResume (new FastResume (Manager.InfoHash, Manager.Bitfield.Clone ().SetAll (false), Manager.Bitfield.Clone ().SetAll (false)));
             Manager.Mode = mode;
             await mode.WaitForStartingToComplete ();
 
@@ -136,7 +136,7 @@ namespace MonoTorrent.Client.Modes
             Manager.ModeChanged += (oldMode, newMode) => modeChanged.Add (newMode);
 
             var mode = new StartingMode (Manager, DiskManager, ConnectionManager, Settings);
-            Manager.HashChecked = false;
+            Assert.IsFalse (Manager.HashChecked);
             Manager.Mode = mode;
             await mode.WaitForStartingToComplete ();
 

--- a/src/MonoTorrent.Tests/Streaming/StreamProviderTests.cs
+++ b/src/MonoTorrent.Tests/Streaming/StreamProviderTests.cs
@@ -53,8 +53,7 @@ namespace MonoTorrent.Streaming
         [SetUp]
         public void Setup ()
         {
-            LocalPeerDiscoveryFactory.Creator = port => new ManualLocalPeerListener ();
-            Engine = new ClientEngine ();
+            Engine = new ClientEngine (EngineSettingsBuilder.CreateForTests ());
 
             PieceWriter = new TestWriter ();
             Engine.DiskManager.ChangePieceWriter (PieceWriter);

--- a/src/MonoTorrent.Tests/TempDir.cs
+++ b/src/MonoTorrent.Tests/TempDir.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MonoTorrent
+{
+    static class TempDir
+    {
+        public readonly struct Releaser : IDisposable
+        {
+            public string Path { get; }
+
+            public Releaser (string path)
+                => Path = path;
+
+            public void Dispose ()
+            {
+                Directory.Delete (Path, true);
+            }
+        }
+
+        public static Releaser Create ()
+        {
+            var tmp = Path.GetTempFileName ();
+            var tmpDir = tmp + "_dir";
+            Directory.CreateDirectory (tmpDir);
+            File.Delete (tmp);
+            return new Releaser (tmpDir);
+        }
+    }
+}

--- a/src/MonoTorrent/MonoTorrent.Client/ClientEngine.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/ClientEngine.cs
@@ -243,12 +243,15 @@ namespace MonoTorrent.Client
             saveDirectory = string.IsNullOrEmpty (saveDirectory) ? Environment.CurrentDirectory : Path.GetFullPath (saveDirectory);
             TorrentManager manager;
             if (magnetLink != null) {
-                var metadataSaveFilePath = Path.Combine (Settings.MetadataSaveDirectory, magnetLink.InfoHash.ToHex () + ".torrent");
+                var metadataSaveFilePath = Settings.GetMetadataPath (magnetLink.InfoHash);
                 manager = new TorrentManager (magnetLink, saveDirectory, settings, metadataSaveFilePath);
             } else {
                 manager = new TorrentManager (torrent, saveDirectory, settings);
             }
+
             await Register (manager);
+            await manager.MaybeLoadFastResumeAsync ();
+
             return manager;
         }
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/src/MonoTorrent/MonoTorrent.Client/FastResume/FastResume.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/FastResume/FastResume.cs
@@ -29,6 +29,7 @@
 
 using System;
 using System.IO;
+using System.Threading.Tasks;
 
 using MonoTorrent.BEncoding;
 
@@ -130,6 +131,21 @@ namespace MonoTorrent.Client
         {
             byte[] data = Encode ().Encode ();
             s.Write (data, 0, data.Length);
+        }
+
+        public static bool TryLoad (string fastResumeFilePath, out FastResume fastResume)
+        {
+            try {
+                if (File.Exists (fastResumeFilePath)) {
+                    var data = (BEncodedDictionary) BEncodedDictionary.Decode (File.ReadAllBytes (fastResumeFilePath));
+                    fastResume = new FastResume (data);
+                } else {
+                    fastResume = null;
+                }
+            } catch {
+                fastResume = null;
+            }
+            return fastResume != null;
         }
     }
 }

--- a/src/MonoTorrent/MonoTorrent.Client/Modes/DownloadMode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/DownloadMode.cs
@@ -27,6 +27,7 @@
 //
 
 
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/MonoTorrent/MonoTorrent.Client/Modes/HashingMode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/HashingMode.cs
@@ -27,6 +27,7 @@
 //
 
 
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -80,6 +81,10 @@ namespace MonoTorrent.Client.Modes
 
             int piecesHashed = 0;
             Manager.HashFails = 0;
+
+            // Delete any existing fast resume data. We will need to recreate it after hashing completes.
+            await Manager.MaybeDeleteFastResumeAsync ();
+
             if (await DiskManager.CheckAnyFilesExistAsync (Manager)) {
                 Cancellation.Token.ThrowIfCancellationRequested ();
                 for (int index = 0; index < Manager.Torrent.Pieces.Count; index++) {

--- a/src/MonoTorrent/MonoTorrent.Client/Modes/StartingMode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/StartingMode.cs
@@ -95,6 +95,13 @@ namespace MonoTorrent.Client.Modes
 
             SendAnnounces ();
 
+            // Save the fast resume data before updating the current mode. This ensures the on-disk data has
+            // either been refreshed or deleted before we make a user-visible change to the state of the torrent.
+            if (Manager.Complete)
+                await Manager.MaybeWriteFastResumeAsync ();
+            else
+                await Manager.MaybeDeleteFastResumeAsync ();
+
             if (Manager.Complete && Manager.Settings.AllowInitialSeeding && ClientEngine.SupportsInitialSeed) {
                 Manager.Mode = new InitialSeedingMode (Manager, DiskManager, ConnectionManager, Settings);
             } else {
@@ -122,15 +129,21 @@ namespace MonoTorrent.Client.Modes
 
         async Task VerifyHashState ()
         {
+            // If we do not have metadata or the torrent needs a hash check, fast exit.
+            if (!Manager.HasMetadata || !Manager.HashChecked)
+                return;
+
             // FIXME: I should really just ensure that zero length files always exist on disk. If the first file is
             // a zero length file and someone deletes it after the first piece has been written to disk, it will
             // never be recreated. If the downloaded data requires this file to exist, we have an issue.
-            if (Manager.HasMetadata) {
-                foreach (ITorrentFileInfo file in Manager.Files)
-                    if (!file.BitField.AllFalse && Manager.HashChecked && file.Length > 0)
-                        Manager.HashChecked &= await DiskManager.CheckFileExistsAsync (file);
+            foreach (ITorrentFileInfo file in Manager.Files) {
+                if (!file.BitField.AllFalse && file.Length > 0) {
+                    if (!await DiskManager.CheckFileExistsAsync (file)) {
+                        Manager.SetNeedsHashCheck ();
+                        break;
+                    }
+                }
             }
         }
-
     }
 }

--- a/src/MonoTorrent/MonoTorrent.Client/Settings/EngineSettingsBuilder.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Settings/EngineSettingsBuilder.cs
@@ -42,6 +42,22 @@ namespace MonoTorrent.Client
     /// </summary>
     public class EngineSettingsBuilder
     {
+        internal static EngineSettings CreateForTests (
+            bool allowLocalPeerDiscovery = false,
+            bool allowPortForwarding = false,
+            bool automaticFastResume = false,
+            int dhtPort = -1,
+            int listenPort = -1)
+        {
+            return new EngineSettingsBuilder {
+                AllowLocalPeerDiscovery = allowLocalPeerDiscovery,
+                AllowPortForwarding = allowPortForwarding,
+                AutomaticFastResume = automaticFastResume,
+                DhtPort = dhtPort,
+                ListenPort = listenPort,
+            }.ToSettings ();
+        }
+
         TimeSpan connectionTimeout;
         int dhtPort;
         int diskCacheBytes;
@@ -69,15 +85,22 @@ namespace MonoTorrent.Client
         public bool AllowHaveSuppression { get; set; }
 
         /// <summary>
-        /// True if the engine should use LocalPeerDiscovery to search for local peers. Defaults to true.
+        /// True if the engine should use LocalPeerDiscovery to search for local peers. Defaults to <see langword="true"/>.
         /// </summary>
         public bool AllowLocalPeerDiscovery { get; set; }
 
         /// <summary>
         /// True if the engine should automatically forward ports using any compatible UPnP or NAT-PMP device.
-        /// Defaults to true.
+        /// Defaults to <see langword="true"/>.
         /// </summary>
         public bool AllowPortForwarding { get; set; }
+
+        /// <summary>
+        /// If set to true FastResume data will be implicitly saved after <see cref="TorrentManager.StopAsync()"/> is invoked,
+        /// and will be implicitly loaded before the <see cref="TorrentManager"/> is returned by <see cref="ClientEngine.AddAsync"/>
+        /// Defaults to <see langword="true"/>.
+        /// </summary>
+        public bool AutomaticFastResume { get; set; }
 
         /// <summary>
         /// The directory used to cache any data needed by the engine. Typically used to store a
@@ -218,6 +241,7 @@ namespace MonoTorrent.Client
             AllowHaveSuppression = settings.AllowHaveSuppression;
             AllowLocalPeerDiscovery = settings.AllowLocalPeerDiscovery;
             AllowPortForwarding = settings.AllowPortForwarding;
+            AutomaticFastResume = settings.AutomaticFastResume;
             CacheDirectory = settings.CacheDirectory;
             ConnectionTimeout = settings.ConnectionTimeout;
             DhtPort = settings.DhtPort;
@@ -247,6 +271,7 @@ namespace MonoTorrent.Client
                 allowHaveSuppression: AllowHaveSuppression,
                 allowLocalPeerDiscovery: AllowLocalPeerDiscovery,
                 allowPortForwarding: AllowPortForwarding,
+                automaticFastResume: AutomaticFastResume,
                 cacheDirectory: string.IsNullOrEmpty (CacheDirectory) ? Environment.CurrentDirectory : Path.GetFullPath (CacheDirectory),
                 connectionTimeout: ConnectionTimeout,
                 dhtPort: DhtPort,

--- a/src/SampleClient/MagnetLinkStreaming.cs
+++ b/src/SampleClient/MagnetLinkStreaming.cs
@@ -16,7 +16,7 @@ namespace SampleClient
 
         public async Task DownloadAsync (MagnetLink link)
         {
-            var engine = new ClientEngine ();
+            using var engine = new ClientEngine ();
             var manager = await engine.AddStreamingAsync (link, "downloads");
 
             var times = new List<(string message, TimeSpan time)> ();


### PR DESCRIPTION
The engine will now automatically save/load/delete fast resume
based on heuristics.

If a TorrentManager is loaded into the ClientEngine using the
new `AddAsync` or `AddStreamingAsync` methods then any
existing fast resume data will be implicitly loaded.

If a TorrentManager is started and it enters the *downloading*
mode, i.e. the only mode which mutates the torrent's state,
then any existing fast resume data will be implicitly deleted.

If a TorrentManager enters the 'Stopped' mode, and an error did
not occur, then new fast resume data will be saved to disk.

Implements most of https://github.com/alanmcgovern/monotorrent/issues/400