### PR TITLE
[core] Auto save/restore dht nodes too

### DIFF
--- a/src/MonoTorrent/MonoTorrent.Client/ClientEngine.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/ClientEngine.cs
@@ -488,7 +488,7 @@ namespace MonoTorrent.Client
             DhtEngine.StateChanged += DhtEngineStateChanged;
             DhtEngine.PeersFound += DhtEnginePeersFound;
             if (IsRunning)
-                await DhtEngine.StartAsync ();
+                await DhtEngine.StartAsync (await MaybeLoadDhtNodes ());
         }
 
         void RegisterLocalPeerDiscovery (ILocalPeerDiscovery localPeerDiscovery)
@@ -630,7 +630,7 @@ namespace MonoTorrent.Client
 
                 Listener.Start ();
                 LocalPeerDiscovery.Start ();
-                await DhtEngine.StartAsync ();
+                await DhtEngine.StartAsync (await MaybeLoadDhtNodes ());
 
                 if (Listener is ISocketListener socketListener)
                     await PortForwarder.RegisterMappingAsync (new Mapping (Protocol.Tcp, socketListener.EndPoint.Port));
@@ -650,10 +650,35 @@ namespace MonoTorrent.Client
             if (!IsRunning) {
                 Listener.Stop ();
                 LocalPeerDiscovery.Stop ();
+
+                await MaybeSaveDhtNodes ();
                 await DhtEngine.StopAsync ();
                 await PortForwarder.UnregisterMappingAsync (new Mapping (Protocol.Tcp, Settings.ListenPort), CancellationToken.None);
                 await PortForwarder.UnregisterMappingAsync (new Mapping (Protocol.Udp, Settings.DhtPort), CancellationToken.None);
             }
+        }
+
+        async ReusableTasks.ReusableTask<byte[]> MaybeLoadDhtNodes ()
+        {
+            if (Settings.DhtPort == -1)
+                return null;
+
+            var savePath = Settings.GetDhtNodeCacheFilePath ();
+            return await Task.Run (() => File.Exists (savePath) ? File.ReadAllBytes (savePath) : null);
+        }
+
+        async ReusableTasks.ReusableTask MaybeSaveDhtNodes ()
+        {
+            if (Settings.DhtPort == -1)
+                return;
+
+            var nodes = await DhtEngine.SaveNodesAsync ();
+            await Task.Run (() => {
+                var savePath = Settings.GetDhtNodeCacheFilePath ();
+                var parentDir = Path.GetDirectoryName (savePath);
+                Directory.CreateDirectory (parentDir);
+                File.WriteAllBytes (savePath, nodes);
+            });
         }
 
         public async Task UpdateSettingsAsync (EngineSettings settings)

--- a/src/MonoTorrent/MonoTorrent.Client/Settings/EngineSettings.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Settings/EngineSettings.cs
@@ -204,11 +204,14 @@ namespace MonoTorrent.Client
             ReportedAddress = reportedAddress;
         }
 
-        internal string GetMetadataPath (InfoHash infoHash)
-            => Path.Combine (MetadataSaveDirectory, infoHash.ToHex () + ".torrent");
+        internal string GetDhtNodeCacheFilePath ()
+            => Path.Combine (CacheDirectory, "dht_nodes.cache");
 
         internal string GetFastResumePath (InfoHash infoHash)
             => Path.Combine (FastResumeSaveDirectory, $"{infoHash.ToHex ()}.fresume");
+
+        internal string GetMetadataPath (InfoHash infoHash)
+            => Path.Combine (MetadataSaveDirectory, infoHash.ToHex () + ".torrent");
 
         public override bool Equals (object obj)
             => Equals (obj as EngineSettings);


### PR DESCRIPTION
If the DhtEngine is implicitly managed by the engine then
it will now also implicitly manage saving/restore the list
of nodes when the DhtEngine is started/stopped.