### PR TITLE
COR Policies added to HttpStream 

### DIFF
--- a/src/MonoTorrent/MonoTorrent.Streaming/HttpStream.cs
+++ b/src/MonoTorrent/MonoTorrent.Streaming/HttpStream.cs
@@ -50,17 +50,14 @@ namespace MonoTorrent.Streaming
 
         public Uri Uri { get; }
         
-        public HttpStream (Stream stream, Uri serverUri)
+        public HttpStream (Stream stream)
         {
             // Set up a HTTP listener for VLC/UWP to connect to.
             Uri = new Uri ($"http://127.0.0.1:5555/{Guid.NewGuid ()}/");
 
             Listener = new HttpListener ();
             Listener.Prefixes.Add (Uri.ToString ());
-            if (!string.IsNullOrEmpty (serverUri.ToString ())) {
-                Listener.Prefixes.Add (serverUri.ToString ()); //-- this should allow the NodeJS Server to obtain {Uri} content without CORS Policy issue.
-            }
-
+            
             Listener.Start ();
 
             Cancellation = new CancellationTokenSource ();
@@ -132,6 +129,8 @@ namespace MonoTorrent.Streaming
             var buffer = new byte[64 * 1024];
             context.Response.SendChunked = true;
             context.Response.AppendHeader ("Content-Range", $"bytes {firstByte}-{lastByte}");
+            context.Response.AppendHeader ("Access-Control-Allow-Origin", "*"); //-- should allow CORS from another domain.
+            
             context.Response.StatusCode = (int) HttpStatusCode.PartialContent;
             context.Response.ContentLength64 = lastByte - firstByte + 1;
             Debug.WriteLine ($"Requested {firstByte} -> {lastByte}. Length: {context.Response.ContentLength64}");

--- a/src/MonoTorrent/MonoTorrent.Streaming/HttpStream.cs
+++ b/src/MonoTorrent/MonoTorrent.Streaming/HttpStream.cs
@@ -49,14 +49,18 @@ namespace MonoTorrent.Streaming
         Stream Stream { get; }
 
         public Uri Uri { get; }
-
-        public HttpStream (Stream stream)
+        
+        public HttpStream (Stream stream, Uri serverUri)
         {
             // Set up a HTTP listener for VLC/UWP to connect to.
             Uri = new Uri ($"http://127.0.0.1:5555/{Guid.NewGuid ()}/");
 
             Listener = new HttpListener ();
             Listener.Prefixes.Add (Uri.ToString ());
+            if (!string.IsNullOrEmpty (serverUri.ToString ())) {
+                Listener.Prefixes.Add (serverUri.ToString ()); //-- this should allow the NodeJS Server to obtain {Uri} content without CORS Policy issue.
+            }
+
             Listener.Start ();
 
             Cancellation = new CancellationTokenSource ();

--- a/src/MonoTorrent/MonoTorrent.Streaming/HttpStream.cs
+++ b/src/MonoTorrent/MonoTorrent.Streaming/HttpStream.cs
@@ -129,9 +129,15 @@ namespace MonoTorrent.Streaming
             var buffer = new byte[64 * 1024];
             context.Response.SendChunked = true;
             context.Response.AppendHeader ("Content-Range", $"bytes {firstByte}-{lastByte}");
-            context.Response.AppendHeader ("Access-Control-Allow-Origin", "*"); //-- should allow CORS from another domain.
             
-            context.Response.StatusCode = (int) HttpStatusCode.PartialContent;
+			//--- CORS Policy Declined goes away. A lot of SocketExceptions and MonoTorrent.Tracker Exceptions happen. When reverting to original Pre-release 132 Nupackage. No exceptions thrown.
+			//--- HTML5 Player uses HLS.JS and does something, enables play button. When going to Url obtained from CreateHttpStreamAsync, Download Failed - No File. 
+			//--- NodeJS Express Server CORS enabled is: 127.0.0.1:8888 
+			context.Response.AppendHeader ("Access-Control-Allow-Origin", "*"); //-- should allow CORS from another domain.
+            context.Response.AppendHeader ("Access-Control-Allow-Headers", "Content-Type,x-requested-with");
+            context.Response.AppendHeader ("Access-Control-Allow-Methods", "GET,POST,PUT,HEAD,DELETE,OPTIONS");
+            
+			context.Response.StatusCode = (int) HttpStatusCode.PartialContent;
             context.Response.ContentLength64 = lastByte - firstByte + 1;
             Debug.WriteLine ($"Requested {firstByte} -> {lastByte}. Length: {context.Response.ContentLength64}");
             while (firstByte <= lastByte) {

--- a/src/MonoTorrent/MonoTorrent.Streaming/StreamProvider.cs
+++ b/src/MonoTorrent/MonoTorrent.Streaming/StreamProvider.cs
@@ -167,7 +167,6 @@ namespace MonoTorrent.Streaming
         /// </summary>
         /// <param name="file">The file to open</param>
         /// <param name="prebuffer">True if the first and last piece should be downloaded before the Stream is created.</param>
-        /// <param name="serverUri">Points to another server requesting stream's content without CORS Policy Issue.</param>
         /// <param name="token">The cancellation token</param>
         /// <returns></returns>
         

--- a/src/MonoTorrent/MonoTorrent.Streaming/StreamProvider.cs
+++ b/src/MonoTorrent/MonoTorrent.Streaming/StreamProvider.cs
@@ -135,7 +135,7 @@ namespace MonoTorrent.Streaming
         /// <param name="file">The file to open</param>
         /// <returns></returns>
         public Task<IUriStream> CreateHttpStreamAsync (ITorrentFileInfo file)
-            => CreateHttpStreamAsync (file, prebuffer: true, CancellationToken.None);
+            => CreateHttpStreamAsync (file, prebuffer: true, new Uri (""), CancellationToken.None);
 
         /// <summary>
         /// Creates a <see cref="Stream"/> which can be used to access the given <see cref="TorrentFile"/>
@@ -146,7 +146,7 @@ namespace MonoTorrent.Streaming
         /// <param name="token">The cancellation token</param>
         /// <returns></returns>
         public Task<IUriStream> CreateHttpStreamAsync (ITorrentFileInfo file, CancellationToken token)
-            => CreateHttpStreamAsync (file, prebuffer: true, token);
+            => CreateHttpStreamAsync (file, prebuffer: true, new Uri (""), token);
 
         /// <summary>
         /// Creates a <see cref="Stream"/> which can be used to access the given <see cref="TorrentFile"/>
@@ -157,8 +157,10 @@ namespace MonoTorrent.Streaming
         /// <param name="prebuffer">True if the first and last piece should be downloaded before the Stream is created.</param>
         /// <returns></returns>
         public Task<IUriStream> CreateHttpStreamAsync (ITorrentFileInfo file, bool prebuffer)
-            => CreateHttpStreamAsync (file, prebuffer, CancellationToken.None);
+            => CreateHttpStreamAsync (file, prebuffer, new Uri (""), CancellationToken.None);
 
+        public Task<IUriStream> CreateHttpStreamAsync (ITorrentFileInfo file, bool prebuffer, Uri serverUri) =>
+            CreateHttpStreamAsync (file, prebuffer, serverUri, CancellationToken.None);
         /// <summary>
         /// Creates a <see cref="Stream"/> which can be used to access the given <see cref="TorrentFile"/>
         /// while it is downloading. This stream is seekable and readable. This stream must be disposed
@@ -166,12 +168,14 @@ namespace MonoTorrent.Streaming
         /// </summary>
         /// <param name="file">The file to open</param>
         /// <param name="prebuffer">True if the first and last piece should be downloaded before the Stream is created.</param>
+        /// <param name="serverUri">Points to another server requesting stream's content without CORS Policy Issue.</param>
         /// <param name="token">The cancellation token</param>
         /// <returns></returns>
-        public async Task<IUriStream> CreateHttpStreamAsync (ITorrentFileInfo file, bool prebuffer, CancellationToken token)
+        
+        public async Task<IUriStream> CreateHttpStreamAsync (ITorrentFileInfo file, bool prebuffer, Uri serverUri, CancellationToken token)
         {
             var stream = await CreateStreamAsync (file, prebuffer, token);
-            var httpStreamer = new HttpStream (stream);
+            var httpStreamer = new HttpStream (stream, serverUri);
             return httpStreamer;
         }
     }

--- a/src/MonoTorrent/MonoTorrent.Streaming/StreamProvider.cs
+++ b/src/MonoTorrent/MonoTorrent.Streaming/StreamProvider.cs
@@ -135,7 +135,7 @@ namespace MonoTorrent.Streaming
         /// <param name="file">The file to open</param>
         /// <returns></returns>
         public Task<IUriStream> CreateHttpStreamAsync (ITorrentFileInfo file)
-            => CreateHttpStreamAsync (file, prebuffer: true, new Uri (""), CancellationToken.None);
+            => CreateHttpStreamAsync (file, prebuffer: true, CancellationToken.None);
 
         /// <summary>
         /// Creates a <see cref="Stream"/> which can be used to access the given <see cref="TorrentFile"/>
@@ -146,7 +146,7 @@ namespace MonoTorrent.Streaming
         /// <param name="token">The cancellation token</param>
         /// <returns></returns>
         public Task<IUriStream> CreateHttpStreamAsync (ITorrentFileInfo file, CancellationToken token)
-            => CreateHttpStreamAsync (file, prebuffer: true, new Uri (""), token);
+            => CreateHttpStreamAsync (file, prebuffer: true, token);
 
         /// <summary>
         /// Creates a <see cref="Stream"/> which can be used to access the given <see cref="TorrentFile"/>
@@ -157,10 +157,9 @@ namespace MonoTorrent.Streaming
         /// <param name="prebuffer">True if the first and last piece should be downloaded before the Stream is created.</param>
         /// <returns></returns>
         public Task<IUriStream> CreateHttpStreamAsync (ITorrentFileInfo file, bool prebuffer)
-            => CreateHttpStreamAsync (file, prebuffer, new Uri (""), CancellationToken.None);
+            => CreateHttpStreamAsync (file, prebuffer, CancellationToken.None);
 
-        public Task<IUriStream> CreateHttpStreamAsync (ITorrentFileInfo file, bool prebuffer, Uri serverUri) =>
-            CreateHttpStreamAsync (file, prebuffer, serverUri, CancellationToken.None);
+
         /// <summary>
         /// Creates a <see cref="Stream"/> which can be used to access the given <see cref="TorrentFile"/>
         /// while it is downloading. This stream is seekable and readable. This stream must be disposed
@@ -172,10 +171,10 @@ namespace MonoTorrent.Streaming
         /// <param name="token">The cancellation token</param>
         /// <returns></returns>
         
-        public async Task<IUriStream> CreateHttpStreamAsync (ITorrentFileInfo file, bool prebuffer, Uri serverUri, CancellationToken token)
+        public async Task<IUriStream> CreateHttpStreamAsync (ITorrentFileInfo file, bool prebuffer, CancellationToken token)
         {
             var stream = await CreateStreamAsync (file, prebuffer, token);
-            var httpStreamer = new HttpStream (stream, serverUri);
+            var httpStreamer = new HttpStream (stream);
             return httpStreamer;
         }
     }


### PR DESCRIPTION
The following changes add the ability to have CORS enabled on httplistener. So far, CORS Policy declined message goes away for HTML5 video player by viewing under Chrome. May need more work.