### PR TITLE
[core] Add a fast path when no files exist

### DIFF
--- a/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/HashingModeTests.cs
+++ b/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/HashingModeTests.cs
@@ -155,7 +155,7 @@ namespace MonoTorrent.Client.Modes
             Manager.PieceHashed += (o, e) => {
                 lock (args) {
                     args.Add (e);
-                    if (args.Count == Manager.Torrent.Pieces.Count)
+                    if (args.Count == Manager.Torrent.Pieces.Count || e.PieceIndex == null)
                         tcs.SetResult (true);
                 }
             };
@@ -163,7 +163,7 @@ namespace MonoTorrent.Client.Modes
             await Manager.HashCheckAsync (false);
             await tcs.Task.WithTimeout ("hashing");
 
-            args.Sort ((l, r) => l.PieceIndex.CompareTo (r.PieceIndex));
+            args.Sort ((l, r) => l.PieceIndex.Value.CompareTo (r.PieceIndex.Value));
             for (int i = 1; i < args.Count; i++)
                 Assert.Greater (args[i].Progress, args[i - 1].Progress, "#1." + i);
             Assert.Greater (args.First ().Progress, 0, "#2");

--- a/src/MonoTorrent/MonoTorrent.Client/EventArgs/PieceHashedEventArgs.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/EventArgs/PieceHashedEventArgs.cs
@@ -35,9 +35,11 @@ namespace MonoTorrent.Client
     public sealed class PieceHashedEventArgs : TorrentEventArgs
     {
         /// <summary>
-        /// The index of the piece which was hashed
+        /// Returns null if all pieces in the torrent failed the hashcheck. This can
+        /// occur when none of the files are available on disk and the engine skips
+        /// hash checking. Otherwise this is the index of the piece which was hashed.
         /// </summary>
-        public int PieceIndex { get; }
+        public int? PieceIndex { get; }
 
         /// <summary>
         /// The value of whether the piece passed or failed the hash check
@@ -59,13 +61,13 @@ namespace MonoTorrent.Client
         /// <param name="manager">The <see cref="TorrentManager"/> whose piece was hashed</param>
         /// <param name="pieceIndex">The index of the piece that was hashed</param>
         /// <param name="hashPassed">True if the piece passed the hashcheck, false otherwise</param>
-        internal PieceHashedEventArgs (TorrentManager manager, int pieceIndex, bool hashPassed)
+        internal PieceHashedEventArgs (TorrentManager manager, int? pieceIndex, bool hashPassed)
             : this (manager, pieceIndex, hashPassed, 1, 1)
         {
 
         }
 
-        internal PieceHashedEventArgs (TorrentManager manager, int pieceIndex, bool hashPassed, int piecesHashed, int totalToHash)
+        internal PieceHashedEventArgs (TorrentManager manager, int? pieceIndex, bool hashPassed, int piecesHashed, int totalToHash)
             : base (manager)
         {
             PieceIndex = pieceIndex;

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/ITorrentFileInfo.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/ITorrentFileInfo.cs
@@ -1,5 +1,5 @@
 ﻿//
-// IFile.cs
+// ITorrentFileInfo.cs
 //
 // Authors:
 //   Alan McGovern alan.mcgovern@gmail.com

--- a/src/MonoTorrent/MonoTorrent.Client/Modes/HashingMode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/HashingMode.cs
@@ -109,9 +109,7 @@ namespace MonoTorrent.Client.Modes
                 }
             } else {
                 await PausedCompletionSource.Task;
-
-                for (int i = 0; i < Manager.Torrent.Pieces.Count; i++)
-                    Manager.OnPieceHashed (i, false, ++piecesHashed, Manager.Torrent.Pieces.Count);
+                Manager.OnPieceHashed (null, false, Manager.Torrent.Pieces.Count, Manager.Torrent.Pieces.Count);
             }
         }
 


### PR DESCRIPTION
This can be a bit faster than binary searching over all files
every time we emit a fake 'piece hashed' event indicating
data which *does not exist* has 'failed' a hash check.