### PR TITLE
[core] Use a proper way to change file priority

### DIFF
--- a/src/MonoTorrent.Tests/Client/PieceManagerTests.cs
+++ b/src/MonoTorrent.Tests/Client/PieceManagerTests.cs
@@ -30,6 +30,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 using MonoTorrent.Client.Messages.Standard;
 
@@ -84,10 +85,10 @@ namespace MonoTorrent.Client.PiecePicking
 
 
         [Test]
-        public void RequestInEndgame_AllDoNotDownload ()
+        public async Task RequestInEndgame_AllDoNotDownload ()
         {
             foreach (var file in torrentManager.Files)
-                file.Priority = Priority.DoNotDownload;
+                await torrentManager.SetFilePriorityAsync (file, Priority.DoNotDownload);
 
             torrentManager.Bitfield.SetAll (true).Set (0, false);
             peers[0].BitField.SetAll (true);

--- a/src/MonoTorrent.Tests/Client/PriorityPickerTests.cs
+++ b/src/MonoTorrent.Tests/Client/PriorityPickerTests.cs
@@ -40,14 +40,16 @@ namespace MonoTorrent.Client.PiecePicking
     {
         class TestTorrentData : ITorrentData
         {
-            public IList<ITorrentFileInfo> Files { get; set; }
+            IList<ITorrentFileInfo> ITorrentData.Files => new List<ITorrentFileInfo> (Files);
+
+            public IList<TorrentFileInfo> Files { get; set; }
             public int PieceLength { get; set; }
             public int Pieces => (int) Math.Ceiling ((double) Size / PieceLength);
             public long Size { get; set; }
 
             public void SetAll (Priority priority)
             {
-                foreach (var file in Files)
+                foreach (TorrentFileInfo file in Files)
                     file.Priority = priority;
             }
         }

--- a/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/DownloadModeTests.cs
+++ b/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/DownloadModeTests.cs
@@ -330,8 +330,8 @@ namespace MonoTorrent.Client.Modes
                 Manager.OnPieceHashed (i, true);
 
             foreach (var file in Manager.Files)
-                file.Priority = Priority.DoNotDownload;
-            Manager.Files.Last ().Priority = Priority.Normal;
+                await Manager.SetFilePriorityAsync (file, Priority.DoNotDownload);
+            await Manager.SetFilePriorityAsync (Manager.Files.Last (), Priority.Normal);
 
             var mode = new DownloadMode (Manager, DiskManager, ConnectionManager, Settings);
             Manager.Mode = mode;
@@ -358,7 +358,7 @@ namespace MonoTorrent.Client.Modes
         public async Task PartialProgress_NoneDownloaded_AllDoNotDownload ()
         {
             foreach (var file in Manager.Files)
-                file.Priority = Priority.DoNotDownload;
+                await Manager.SetFilePriorityAsync (file, Priority.DoNotDownload);
 
             var mode = new DownloadMode (Manager, DiskManager, ConnectionManager, Settings);
             Manager.Mode = mode;
@@ -375,8 +375,8 @@ namespace MonoTorrent.Client.Modes
             Manager.OnPieceHashed (0, true);
 
             foreach (var file in Manager.Files)
-                file.Priority = Priority.DoNotDownload;
-            Manager.Files.First ().Priority = Priority.Normal;
+                await Manager.SetFilePriorityAsync (file, Priority.DoNotDownload);
+            await Manager.SetFilePriorityAsync (Manager.Files.First (), Priority.Normal);
 
             var mode = new DownloadMode (Manager, DiskManager, ConnectionManager, Settings);
             Manager.Mode = mode;
@@ -396,8 +396,8 @@ namespace MonoTorrent.Client.Modes
             Manager.OnPieceHashed (Manager.Torrent.Pieces.Count - 1, true);
 
             foreach (var file in Manager.Files)
-                file.Priority = Priority.DoNotDownload;
-            lastFile.Priority = Priority.Normal;
+                await Manager.SetFilePriorityAsync (file, Priority.DoNotDownload);
+            await Manager.SetFilePriorityAsync (lastFile, Priority.Normal);
 
             var mode = new DownloadMode (Manager, DiskManager, ConnectionManager, Settings);
             Manager.Mode = mode;
@@ -414,8 +414,8 @@ namespace MonoTorrent.Client.Modes
             Manager.OnPieceHashed (0, true);
 
             foreach (var file in Manager.Files)
-                file.Priority = Priority.DoNotDownload;
-            Manager.Files.First ().Priority = Priority.Normal;
+                await Manager.SetFilePriorityAsync (file, Priority.DoNotDownload);
+            await Manager.SetFilePriorityAsync (Manager.Files.First (), Priority.Normal);
 
             var mode = new DownloadMode (Manager, DiskManager, ConnectionManager, Settings);
             Manager.Mode = mode;
@@ -428,7 +428,7 @@ namespace MonoTorrent.Client.Modes
                 oldStateTask.SetResult (e.OldState);
                 newStateTask.SetResult (e.NewState);
             };
-            Manager.Files.Skip (1).First ().Priority = Priority.Normal;
+            await Manager.SetFilePriorityAsync (Manager.Files.Skip (1).First (), Priority.Normal);
             await mode.UpdateSeedingDownloadingState ().WithTimeout ();
 
             var oldState = await oldStateTask.Task.WithTimeout ();
@@ -450,7 +450,7 @@ namespace MonoTorrent.Client.Modes
             Manager.OnPieceHashed (0, true);
 
             foreach (var file in Manager.Files)
-                file.Priority = Priority.DoNotDownload;
+                await Manager.SetFilePriorityAsync (file, Priority.DoNotDownload);
 
             var mode = new DownloadMode (Manager, DiskManager, ConnectionManager, Settings);
             Manager.Mode = mode;
@@ -466,8 +466,8 @@ namespace MonoTorrent.Client.Modes
             Manager.OnPieceHashed (0, true);
 
             foreach (var file in Manager.Files)
-                file.Priority = Priority.DoNotDownload;
-            Manager.Files.Last ().Priority = Priority.Normal;
+                await Manager.SetFilePriorityAsync (file, Priority.DoNotDownload);
+            await Manager.SetFilePriorityAsync (Manager.Files.Last (), Priority.Normal);
 
             var mode = new DownloadMode (Manager, DiskManager, ConnectionManager, Settings);
             Manager.Mode = mode;

--- a/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/HashingModeTests.cs
+++ b/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/HashingModeTests.cs
@@ -192,7 +192,7 @@ namespace MonoTorrent.Client.Modes
 
             foreach (var f in Manager.Files) {
                 PieceWriter.FilesThatExist.Add (f);
-                f.Priority = Priority.DoNotDownload;
+                await Manager.SetFilePriorityAsync (f, Priority.DoNotDownload);
                 f.BitField.SetAll (true);
             }
 
@@ -223,7 +223,7 @@ namespace MonoTorrent.Client.Modes
 
             foreach (var f in Manager.Files) {
                 PieceWriter.FilesThatExist.Add (f);
-                f.Priority = Priority.DoNotDownload;
+                await Manager.SetFilePriorityAsync (f, Priority.DoNotDownload);
             }
 
             var hashingMode = new HashingMode (Manager, DiskManager, ConnectionManager, Settings);
@@ -237,7 +237,7 @@ namespace MonoTorrent.Client.Modes
 
             Manager.Mode = new DownloadMode (Manager, DiskManager, ConnectionManager, Settings);
             foreach (var file in Manager.Files) {
-                file.Priority = Priority.Normal;
+                await Manager.SetFilePriorityAsync (file, Priority.Normal);
                 await Manager.Mode.TryHashPendingFilesAsync ();
                 for (int i = file.StartPieceIndex; i <= file.EndPieceIndex; i++)
                     Assert.IsFalse (Manager.UnhashedPieces[i], "#2." + i);
@@ -254,7 +254,7 @@ namespace MonoTorrent.Client.Modes
         }
 
         [Test]
-        public void StopWhileHashingPendingFiles ()
+        public async Task StopWhileHashingPendingFiles ()
         {
             var pieceHashCount = 0;
             DiskManager.GetHashAsyncOverride = (manager, index) => {
@@ -268,11 +268,11 @@ namespace MonoTorrent.Client.Modes
             Manager.Bitfield.SetAll (true);
 
             foreach (var f in Manager.Files)
-                f.Priority = Priority.DoNotDownload;
+                await Manager.SetFilePriorityAsync (f, Priority.DoNotDownload);
 
             Manager.Mode = new DownloadMode (Manager, DiskManager, ConnectionManager, Settings);
             foreach (var file in Manager.Files)
-                file.Priority = Priority.Normal;
+                await Manager.SetFilePriorityAsync (file, Priority.Normal);
 
             Assert.ThrowsAsync<OperationCanceledException> (async () => await Manager.Mode.TryHashPendingFilesAsync (), "#1");
             Assert.AreEqual (3, pieceHashCount, "#2");
@@ -311,7 +311,7 @@ namespace MonoTorrent.Client.Modes
 
             foreach (var f in Manager.Files.Skip (1)) {
                 PieceWriter.FilesThatExist.Add (f);
-                f.Priority = Priority.DoNotDownload;
+                await Manager.SetFilePriorityAsync (f, Priority.DoNotDownload);
             }
 
             var hashingMode = new HashingMode (Manager, DiskManager, ConnectionManager, Settings);

--- a/src/MonoTorrent/MonoTorrent.Client.PiecePicking/PriorityPicker.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.PiecePicking/PriorityPicker.cs
@@ -153,17 +153,17 @@ namespace MonoTorrent.Client.PiecePicking
 
             // At least one file is not set to DoNotDownload
             temp.SetAll (false);
-            temp.SetTrue (files[0].File.GetSelector ());
+            temp.SetTrue ((files[0].File.StartPieceIndex, files[0].File.EndPieceIndex));
             allPrioritisedPieces.From (temp);
             for (int i = 1; i < files.Count && files[i].Priority != Priority.DoNotDownload; i++) {
-                allPrioritisedPieces.SetTrue (files[i].File.GetSelector ());
+                allPrioritisedPieces.SetTrue ((files[i].File.StartPieceIndex, files[i].File.EndPieceIndex));
 
                 if (files[i].Priority == files[i - 1].Priority) {
-                    temp.SetTrue (files[i].File.GetSelector ());
+                    temp.SetTrue ((files[i].File.StartPieceIndex, files[i].File.EndPieceIndex));
                 } else if (!temp.AllFalse) {
                     prioritised.Add (temp.Clone ());
                     temp.SetAll (false);
-                    temp.SetTrue (files[i].File.GetSelector ());
+                    temp.SetTrue ((files[i].File.StartPieceIndex, files[i].File.EndPieceIndex));
                 }
             }
 

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/ITorrentFileInfo.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/ITorrentFileInfo.cs
@@ -37,10 +37,17 @@ namespace MonoTorrent.Client
     {
         // FIXME: make BitField readonly.
         BitField BitField { get; }
-        string FullPath { get; }
-        Priority Priority { get; set; }
 
-        (int startPiece, int endPiece) GetSelector ();
+        /// <summary>
+        /// The full path to the file on disk. Can be modified by calling <see cref="TorrentManager.MoveFileAsync(ITorrentFileInfo, string)" />
+        /// or <see cref="TorrentManager.MoveFilesAsync(string, bool)"/>.
+        /// </summary>
+        string FullPath { get; }
+
+        /// <summary>
+        /// The priority of the file when downloading. Can be modified by calling <see cref="TorrentManager.SetFilePriorityAsync(ITorrentFileInfo, Priority)"/>
+        /// </summary>
+        Priority Priority { get; }
     }
 
     public static class ITorrentFileInfoExtensions

--- a/src/MonoTorrent/MonoTorrent.Client/Modes/DownloadMode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/DownloadMode.cs
@@ -50,7 +50,6 @@ namespace MonoTorrent.Client.Modes
             } else {
                 state = TorrentState.Downloading;
 
-                UpdatePartialProgress ();
                 if (Manager.PartialProgressSelector.TrueCount > 0) {
                     // If some files are marked as DoNotDownload and we have downloaded all downloadable files, mark the torrent as 'seeding'.
                     // Otherwise if we have not downloaded all downloadable files, set the state to Downloading.
@@ -89,8 +88,6 @@ namespace MonoTorrent.Client.Modes
 
         internal async Task UpdateSeedingDownloadingState ()
         {
-            UpdatePartialProgress ();
-
             //If download is fully complete, set state to 'Seeding' and send an announce to the tracker.
             if (Manager.Complete && state == TorrentState.Downloading) {
                 state = TorrentState.Seeding;

--- a/src/MonoTorrent/MonoTorrent.Client/Modes/HashingMode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/HashingMode.cs
@@ -76,9 +76,6 @@ namespace MonoTorrent.Client.Modes
             if (!Manager.HasMetadata)
                 throw new TorrentException ("A hash check cannot be performed if TorrentManager.HasMetadata is false.");
 
-            // Ensure the partial progress selector is up to date before we start hashing
-            UpdatePartialProgress ();
-
             int piecesHashed = 0;
             Manager.HashFails = 0;
 

--- a/src/MonoTorrent/MonoTorrent.Client/Modes/Mode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/Mode.cs
@@ -51,7 +51,6 @@ namespace MonoTorrent.Client.Modes
         static readonly Logger logger = Logger.Create ();
 
         bool hashingPendingFiles;
-        BitField PartialProgressUpdater;
 
         protected CancellationTokenSource Cancellation { get; }
         protected ConnectionManager ConnectionManager { get; }
@@ -697,25 +696,6 @@ namespace MonoTorrent.Client.Modes
             } finally {
                 hashingPendingFiles = false;
             }
-        }
-
-        internal void UpdatePartialProgress ()
-        {
-            if (PartialProgressUpdater == null || PartialProgressUpdater.Length != Manager.Bitfield.Length)
-                PartialProgressUpdater = new BitField (Manager.Bitfield.Length);
-
-            if (Manager.HasMetadata) {
-                if (Manager.Files.All (t => t.Priority != Priority.DoNotDownload)) {
-                    PartialProgressUpdater.SetAll (true);
-                } else {
-                    PartialProgressUpdater.SetAll (false);
-                    foreach (var file in Manager.Files.Where (t => t.Priority != Priority.DoNotDownload))
-                        PartialProgressUpdater.SetTrue ((file.StartPieceIndex, file.EndPieceIndex));
-                }
-            } else {
-                PartialProgressUpdater.SetAll (false);
-            }
-            Manager.PartialProgressSelector.From (PartialProgressUpdater);
         }
 
         void SendHaveMessagesToAll ()

--- a/src/MonoTorrent/MonoTorrent/TorrentCreator.cs
+++ b/src/MonoTorrent/MonoTorrent/TorrentCreator.cs
@@ -70,20 +70,15 @@ namespace MonoTorrent
 
             public Priority Priority {
                 get => throw new NotImplementedException ();
-                set => throw new NotImplementedException ();
             }
-
-            public int StartPieceIndex => throw new NotImplementedException ();
 
             public long OffsetInTorrent => throw new NotImplementedException ();
 
-            public int EndPieceIndex => throw new NotImplementedException ();
+            public int StartPieceIndex => throw new NotImplementedException ();
 
-            public (int startPiece, int endPiece) GetSelector ()
-            {
-                throw new NotImplementedException ();
-            }
+            public int EndPieceIndex => throw new NotImplementedException ();
         }
+
         const int BlockSize = 16 * 1024;  // 16kB
         const int SmallestPieceSize = 2 * BlockSize;  // 32kB
         const int LargestPieceSize = 512 * BlockSize;  // 8MB


### PR DESCRIPTION
Don't allow people to set this directly via public API.
It's much more efficient for the library to handle updates
via an async method.

Firstly, it removes the race condition where the user could
be trying to update the priority while monotorrent is accesing
it. Accesses to this property have always had to be carefully
made as the value could change immediately after it was
read. Now these concerns are eliminated.

Secondly, it provides a convenient place to update some
state in the library. For example calculating partial progress,
and also when updating the priority based piece picker.