### PR TITLE
[core] Remove a parameter from IPieceRequester

### DIFF
--- a/src/MonoTorrent/MonoTorrent.Client.PiecePicking/IPieceRequester.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.PiecePicking/IPieceRequester.cs
@@ -53,16 +53,14 @@ namespace MonoTorrent.Client.PiecePicking
         /// Should enqueue piece requests for any peer who is has capacity.
         /// </summary>
         /// <param name="peers"></param>
-        /// <param name="bitfield"></param>
-        void AddRequests (IReadOnlyList<IPeerWithMessaging> peers, BitField bitfield);
+        void AddRequests (IReadOnlyList<IPeerWithMessaging> peers);
 
         /// <summary>
         /// Attempts to enqueue more requests for the specified peer.
         /// </summary>
         /// <param name="peer"></param>
         /// <param name="peers"></param>
-        /// <param name="bitfield"></param>
-        void AddRequests (IPeerWithMessaging peer, IReadOnlyList<IPeerWithMessaging> peers, BitField bitfield);
+        void AddRequests (IPeerWithMessaging peer, IReadOnlyList<IPeerWithMessaging> peers);
 
         /// <summary>
         /// 

--- a/src/MonoTorrent/MonoTorrent.Client.PiecePicking/StandardPieceRequester.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.PiecePicking/StandardPieceRequester.cs
@@ -33,6 +33,8 @@ namespace MonoTorrent.Client.PiecePicking
 {
     class StandardPieceRequester : IPieceRequester
     {
+        IReadOnlyList<BitField> IgnorableBitfields { get; set; }
+        BitField Temp { get; set; }
         ITorrentData TorrentData { get; set; }
 
         public bool InEndgameMode { get; private set; }
@@ -40,27 +42,37 @@ namespace MonoTorrent.Client.PiecePicking
 
         public void Initialise (ITorrentData torrentData, IReadOnlyList<BitField> ignoringBitfields)
         {
+            IgnorableBitfields = ignoringBitfields;
             TorrentData = torrentData;
+
+            Temp = new BitField (TorrentData.PieceCount ());
 
             IPiecePicker picker = new StandardPicker ();
             picker = new RandomisedPicker (picker);
             picker = new RarestFirstPicker (picker);
-            picker = new PriorityPicker (picker);
+            Picker = new PriorityPicker (picker);
 
-            Picker = IgnoringPicker.Wrap (picker, ignoringBitfields);
             Picker.Initialise (torrentData);
         }
 
-        public void AddRequests (IReadOnlyList<IPeerWithMessaging> peers, BitField bitfield)
+        BitField ApplyIgnorables (BitField primary)
+        {
+            Temp.From (primary);
+            for (int i = 0; i < IgnorableBitfields.Count; i++)
+                Temp.NAnd (IgnorableBitfields[i]);
+            return Temp;
+        }
+
+        public void AddRequests (IReadOnlyList<IPeerWithMessaging> peers)
         {
             for (int i = 0; i < peers.Count; i++) {
                 var peer = peers[i];
                 if (peer.SuggestedPieces.Count > 0 || (!peer.IsChoking && peer.AmRequestingPiecesCount == 0))
-                    AddRequests (peer, peers, bitfield);
+                    AddRequests (peer, peers);
             }
         }
 
-        public void AddRequests (IPeerWithMessaging peer, IReadOnlyList<IPeerWithMessaging> allPeers, BitField bitfield)
+        public void AddRequests (IPeerWithMessaging peer, IReadOnlyList<IPeerWithMessaging> allPeers)
         {
             int maxRequests = peer.MaxPendingRequests;
 
@@ -84,8 +96,10 @@ namespace MonoTorrent.Client.PiecePicking
 
             // FIXME: Would it be easier if RequestManager called PickPiece(AllowedFastPieces[0]) or something along those lines?
             if (!peer.IsChoking || (peer.SupportsFastPeer && peer.IsAllowedFastPieces.Count > 0)) {
+                BitField filtered = null;
                 while (peer.AmRequestingPiecesCount < maxRequests) {
-                    IList<BlockInfo> request = Picker.PickPiece (peer, peer.BitField, allPeers, count, 0, TorrentData.PieceCount () - 1);
+                    filtered ??= ApplyIgnorables (peer.BitField);
+                    IList<BlockInfo> request = Picker.PickPiece (peer, filtered, allPeers, count, 0, TorrentData.PieceCount () - 1);
                     if (request != null && request.Count > 0)
                         peer.EnqueueRequests (request);
                     else
@@ -100,9 +114,7 @@ namespace MonoTorrent.Client.PiecePicking
                     // endgame mode. Every block has been requested at least once at this point.
                     if (request == null && (InEndgameMode || peer.IsSeeder)) {
                         request = Picker.ContinueAnyExistingRequest (peer, 0, TorrentData.PieceCount () - 1, 2);
-                        // FIXME: What if the picker is choosing to not allocate pieces? Then it's not endgame mode.
-                        // This should be deterministic, not a heuristic?
-                        InEndgameMode |= request != null && (TorrentData.PieceCount () - bitfield.TrueCount) < 10;
+                        InEndgameMode |= request != null;
                     }
 
                     if (request != null)

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/PieceManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/PieceManager.cs
@@ -87,24 +87,23 @@ namespace MonoTorrent.Client
             if (!Initialised || Manager.Complete)
                 return false;
 
-            // If the peer is a seeder, then he is definately interesting
-            if ((id.Peer.IsSeeder = id.BitField.AllTrue))
-                return true;
+            // FIXME: Move this elsewhere?
+            id.Peer.IsSeeder = id.BitField.AllTrue;
 
-            // Otherwise we need to do a full check
+            // If the peer is a seeder it may still be un-interesting if some files are marked as 'DoNotDownload'
             return Requester.Picker.IsInteresting (id, id.BitField);
         }
 
         internal void AddPieceRequests (PeerId id)
         {
             if (Initialised)
-                Requester.AddRequests (id, Manager.Peers.ConnectedPeers, Manager.Bitfield);
+                Requester.AddRequests (id, Manager.Peers.ConnectedPeers);
         }
 
         internal void AddPieceRequests (List<PeerId> peers)
         {
             if (Initialised)
-                Requester.AddRequests (peers, Manager.Bitfield);
+                Requester.AddRequests (peers);
         }
 
         internal void ChangePicker (IPieceRequester requester)


### PR DESCRIPTION
This parameter is unnecessary, and is also confusing. IPieceRequester
can calculate the correct bitfield to pass to the IPiecePicker impl
by starting with the pieces the peer actually has, and the removing
each piece in the 'ignoring' bitfields.