### PR TITLE
 [core] Add a mutable bitfield to the public API

### DIFF
--- a/src/MonoTorrent.Tests/Client/FastResumeTests.cs
+++ b/src/MonoTorrent.Tests/Client/FastResumeTests.cs
@@ -45,32 +45,32 @@ namespace MonoTorrent.Client
         [Test]
         public void AllHashed_AllDownloaded ()
         {
-            var unhashedPieces = new BitField (10).SetAll (false);
-            var downloaded = new BitField (10).SetAll (true);
+            var unhashedPieces = new MutableBitField (10).SetAll (false);
+            var downloaded = new MutableBitField (10).SetAll (true);
             Assert.DoesNotThrow (() => new FastResume (InfoHash, downloaded, unhashedPieces), "#1");
         }
 
         [Test]
         public void AllHashed_NothingDownloaded ()
         {
-            var unhashedPieces = new BitField (10).SetAll (false);
-            var downloaded = new BitField (10).SetAll (false);
+            var unhashedPieces = new MutableBitField (10).SetAll (false);
+            var downloaded = new MutableBitField (10).SetAll (false);
             Assert.DoesNotThrow (() => new FastResume (InfoHash, downloaded, unhashedPieces), "#1");
         }
 
         [Test]
         public void NoneHashed_NothingDownloaded ()
         {
-            var unhashedPieces = new BitField (10).SetAll (true);
-            var downloaded = new BitField (10).SetAll (false);
+            var unhashedPieces = new MutableBitField (10).SetAll (true);
+            var downloaded = new MutableBitField (10).SetAll (false);
             Assert.DoesNotThrow (() => new FastResume (InfoHash, downloaded, unhashedPieces), "#1");
         }
 
         [Test]
         public void NoneHashed_AllDownloaded ()
         {
-            var unhashedPieces = new BitField (10).SetAll (true);
-            var downloaded = new BitField (10).SetAll (true);
+            var unhashedPieces = new MutableBitField (10).SetAll (true);
+            var downloaded = new MutableBitField (10).SetAll (true);
             Assert.Throws<ArgumentException> (() => new FastResume (InfoHash, downloaded, unhashedPieces), "#1");
         }
 
@@ -80,7 +80,7 @@ namespace MonoTorrent.Client
             var v1Data = new BEncodedDictionary {
                 { FastResume.VersionKey, (BEncodedNumber)1 },
                 { FastResume.InfoHashKey, new BEncodedString(InfoHash.Hash) },
-                { FastResume.BitfieldKey, new BEncodedString(new BitField (10).SetAll (true).ToByteArray ()) },
+                { FastResume.BitfieldKey, new BEncodedString(new MutableBitField (10).SetAll (true).ToByteArray ()) },
                 { FastResume.BitfieldLengthKey, (BEncodedNumber)10 },
             };
 
@@ -97,9 +97,9 @@ namespace MonoTorrent.Client
             var v1Data = new BEncodedDictionary {
                 { FastResume.VersionKey, (BEncodedNumber)1 },
                 { FastResume.InfoHashKey, new BEncodedString(InfoHash.Hash) },
-                { FastResume.BitfieldKey, new BEncodedString(new BitField (10).SetAll (false).Set (0, true).ToByteArray ()) },
+                { FastResume.BitfieldKey, new BEncodedString(new MutableBitField (10).SetAll (false).Set (0, true).ToByteArray ()) },
                 { FastResume.BitfieldLengthKey, (BEncodedNumber)10 },
-                { FastResume.UnhashedPiecesKey, new BEncodedString (new BitField (10).SetAll (true).Set (0, false).ToByteArray ()) },
+                { FastResume.UnhashedPiecesKey, new BEncodedString (new MutableBitField (10).SetAll (true).Set (0, false).ToByteArray ()) },
             };
 
             // If this is a v1 FastResume data then it comes from a version of MonoTorrent which always
@@ -121,7 +121,7 @@ namespace MonoTorrent.Client
             var torrent = TestRig.CreatePrivate ();
             var path = engine.Settings.GetFastResumePath (torrent.InfoHash);
             Directory.CreateDirectory (Path.GetDirectoryName (path));
-            File.WriteAllBytes (path, new FastResume (InfoHash, new BitField (torrent.Pieces.Count).SetAll (false), new BitField (torrent.Pieces.Count)).Encode ());
+            File.WriteAllBytes (path, new FastResume (InfoHash, new MutableBitField (torrent.Pieces.Count).SetAll (false), new MutableBitField (torrent.Pieces.Count)).Encode ());
             var manager = await engine.AddAsync (torrent, "savedir");
             Assert.IsFalse (manager.HashChecked);
             await manager.StartAsync ();
@@ -141,7 +141,7 @@ namespace MonoTorrent.Client
             var torrent = TestRig.CreatePrivate ();
             var path = engine.Settings.GetFastResumePath (torrent.InfoHash);
             Directory.CreateDirectory (Path.GetDirectoryName (path));
-            File.WriteAllBytes (path, new FastResume (torrent.InfoHash, new BitField (torrent.Pieces.Count).SetAll (false), new BitField (torrent.Pieces.Count)).Encode ());
+            File.WriteAllBytes (path, new FastResume (torrent.InfoHash, new MutableBitField (torrent.Pieces.Count).SetAll (false), new MutableBitField (torrent.Pieces.Count)).Encode ());
             var manager = await engine.AddAsync (torrent, "savedir");
             Assert.IsTrue (manager.HashChecked);
             await manager.StartAsync ();
@@ -161,7 +161,7 @@ namespace MonoTorrent.Client
             var torrent = TestRig.CreatePrivate ();
             var path = engine.Settings.GetFastResumePath (torrent.InfoHash);
             Directory.CreateDirectory (Path.GetDirectoryName (path));
-            File.WriteAllBytes (path, new FastResume (torrent.InfoHash, new BitField (torrent.Pieces.Count).SetAll (true), new BitField (torrent.Pieces.Count)).Encode ());
+            File.WriteAllBytes (path, new FastResume (torrent.InfoHash, new MutableBitField (torrent.Pieces.Count).SetAll (true), new BitField (torrent.Pieces.Count)).Encode ());
             var manager = await engine.AddAsync (torrent, "savedir");
             Assert.IsTrue (manager.HashChecked);
             await manager.StartAsync ();
@@ -185,7 +185,7 @@ namespace MonoTorrent.Client
             var torrent = TestRig.CreatePrivate ();
             var path = engine.Settings.GetFastResumePath (torrent.InfoHash);
             Directory.CreateDirectory (Path.GetDirectoryName (path));
-            File.WriteAllBytes (path, new FastResume (torrent.InfoHash, new BitField (torrent.Pieces.Count).SetAll (true), new BitField (torrent.Pieces.Count)).Encode ());
+            File.WriteAllBytes (path, new FastResume (torrent.InfoHash, new MutableBitField (torrent.Pieces.Count).SetAll (true), new MutableBitField (torrent.Pieces.Count)).Encode ());
             var manager = await engine.AddAsync (torrent, "savedir");
             await engine.ChangePieceWriterAsync (new TestWriter {
                 FilesThatExist = new System.Collections.Generic.List<ITorrentFileInfo> (manager.Files)

--- a/src/MonoTorrent.Tests/Client/InitialSeedUnchokerTests.cs
+++ b/src/MonoTorrent.Tests/Client/InitialSeedUnchokerTests.cs
@@ -89,7 +89,7 @@ namespace MonoTorrent.Client
         [Test]
         public void Advertise3 ()
         {
-            peer.BitField.SetTrue (1).SetTrue (3).SetTrue (5).SetTrue (7);
+            peer.MutableBitField.SetTrue (1).SetTrue (3).SetTrue (5).SetTrue (7);
 
             unchoker.UnchokeReview ();
             Assert.AreEqual (unchoker.MaxAdvertised, peer.MessageQueue.QueueLength, "#2");
@@ -114,9 +114,9 @@ namespace MonoTorrent.Client
             peers.ForEach (unchoker.PeerConnected);
             peers.Add (this.peer);
 
-            peers[0].BitField.SetTrue (0).SetTrue (7).SetTrue (14);
-            peers[1].BitField.SetTrue (2).SetTrue (6).SetTrue (10);
-            peers[2].BitField.SetTrue (5).SetTrue (9).SetTrue (12);
+            peers[0].MutableBitField.SetTrue (0).SetTrue (7).SetTrue (14);
+            peers[1].MutableBitField.SetTrue (2).SetTrue (6).SetTrue (10);
+            peers[2].MutableBitField.SetTrue (5).SetTrue (9).SetTrue (12);
 
             unchoker.UnchokeReview ();
 
@@ -135,7 +135,7 @@ namespace MonoTorrent.Client
             Assert.AreEqual (unchoker.MaxAdvertised, peer.MessageQueue.QueueLength, "#2");
             for (int i = 0; i < unchoker.MaxAdvertised; i++)
                 Assert.AreEqual (i, ((HaveMessage) peer.MessageQueue.TryDequeue ()).PieceIndex, "#3." + i);
-            peer.BitField.SetTrue (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+            peer.MutableBitField.SetTrue ((0, 10));
             unchoker.UnchokeReview ();
             Assert.AreEqual (unchoker.MaxAdvertised, peer.MessageQueue.QueueLength, "#4");
             for (int i = 0; i < unchoker.MaxAdvertised; i++)
@@ -253,10 +253,10 @@ namespace MonoTorrent.Client
         [Test]
         public void ConnectDisconnect ()
         {
-            PeerId a = new PeerId (new Peer (new string ('a', 20), new Uri ("ipv4://127.0.0.5:5353")), NullConnection.Incoming, rig.Manager.Bitfield?.Clone ().SetAll (false));
-            PeerId b = new PeerId (new Peer (new string ('b', 20), new Uri ("ipv4://127.0.0.5:5354")), NullConnection.Incoming, rig.Manager.Bitfield?.Clone ().SetAll (false));
-            PeerId c = new PeerId (new Peer (new string ('c', 20), new Uri ("ipv4://127.0.0.5:5355")), NullConnection.Incoming, rig.Manager.Bitfield?.Clone ().SetAll (false));
-            PeerId d = new PeerId (new Peer (new string ('d', 20), new Uri ("ipv4://127.0.0.5:5356")), NullConnection.Incoming, rig.Manager.Bitfield?.Clone ().SetAll (false));
+            PeerId a = new PeerId (new Peer (new string ('a', 20), new Uri ("ipv4://127.0.0.5:5353")), NullConnection.Incoming, new MutableBitField (rig.Manager.PieceCount ()));
+            PeerId b = new PeerId (new Peer (new string ('b', 20), new Uri ("ipv4://127.0.0.5:5354")), NullConnection.Incoming, new MutableBitField (rig.Manager.PieceCount ()));
+            PeerId c = new PeerId (new Peer (new string ('c', 20), new Uri ("ipv4://127.0.0.5:5355")), NullConnection.Incoming, new MutableBitField (rig.Manager.PieceCount ()));
+            PeerId d = new PeerId (new Peer (new string ('d', 20), new Uri ("ipv4://127.0.0.5:5356")), NullConnection.Incoming, new MutableBitField (rig.Manager.PieceCount ()));
 
             unchoker.PeerDisconnected (a);
             Assert.AreEqual (1, unchoker.PeerCount, "#1");

--- a/src/MonoTorrent.Tests/Client/PieceManagerTests.cs
+++ b/src/MonoTorrent.Tests/Client/PieceManagerTests.cs
@@ -70,7 +70,7 @@ namespace MonoTorrent.Client.PiecePicking
             peers = new List<PeerId> ();
 
             torrentManager = TestRig.CreateSingleFileManager (torrentData.Size, torrentData.PieceLength);
-            torrentManager.LoadFastResume (new FastResume (torrentManager.InfoHash, new BitField (pieceCount).SetAll (true), new BitField (pieceCount).SetAll (false)));
+            torrentManager.LoadFastResume (new FastResume (torrentManager.InfoHash, new MutableBitField (pieceCount).SetAll (true), new MutableBitField (pieceCount).SetAll (false)));
 
             manager = new PieceManager (torrentManager);
             manager.Initialise ();
@@ -90,8 +90,8 @@ namespace MonoTorrent.Client.PiecePicking
             foreach (var file in torrentManager.Files)
                 await torrentManager.SetFilePriorityAsync (file, Priority.DoNotDownload);
 
-            torrentManager.Bitfield.SetAll (true).Set (0, false);
-            peers[0].BitField.SetAll (true);
+            torrentManager.MutableBitField.SetAll (true).Set (0, false);
+            peers[0].MutableBitField.SetAll (true);
             peers[0].IsChoking = false;
 
             manager.AddPieceRequests (peers[0]);
@@ -102,8 +102,8 @@ namespace MonoTorrent.Client.PiecePicking
         [Test]
         public void RequestWhenSeeder ()
         {
-            torrentManager.Bitfield.SetAll (true);
-            peers[0].BitField.SetAll (true);
+            torrentManager.MutableBitField.SetAll (true);
+            peers[0].MutableBitField.SetAll (true);
             peers[0].IsChoking = false;
 
             manager.AddPieceRequests (peers[0]);

--- a/src/MonoTorrent.Tests/Client/PiecePickerFilterChecker.cs
+++ b/src/MonoTorrent.Tests/Client/PiecePickerFilterChecker.cs
@@ -64,7 +64,7 @@ namespace MonoTorrent.Client.PiecePicking
 
         public override IList<BlockInfo> PickPiece (IPeer peer, BitField available, IReadOnlyList<IPeer> otherPeers, int count, int startIndex, int endIndex)
         {
-            Picks.Add ((peer, available.Clone (), new List<IPeer> (otherPeers).AsReadOnly (), count, startIndex, endIndex));
+            Picks.Add ((peer, new BitField (available), new List<IPeer> (otherPeers).AsReadOnly (), count, startIndex, endIndex));
             return Next == null ? null : Next.PickPiece (peer, available, otherPeers, count, startIndex, endIndex);
         }
     }

--- a/src/MonoTorrent.Tests/Client/PriorityPickerTests.cs
+++ b/src/MonoTorrent.Tests/Client/PriorityPickerTests.cs
@@ -58,11 +58,11 @@ namespace MonoTorrent.Client.PiecePicking
         List<PeerId> peers;
         PriorityPicker picker;
 
-        BitField singleBitfield;
+        MutableBitField singleBitfield;
         TestTorrentData singleFile;
         PeerId singlePeer;
 
-        BitField multiBitfield;
+        MutableBitField multiBitfield;
         TestTorrentData multiFile;
         PeerId multiPeer;
 
@@ -70,11 +70,11 @@ namespace MonoTorrent.Client.PiecePicking
         public void Setup ()
         {
             singleFile = CreateSingleFile ();
-            singleBitfield = new BitField (singleFile.PieceCount ()).SetAll (true);
+            singleBitfield = new MutableBitField (singleFile.PieceCount ()).SetAll (true);
             singlePeer = PeerId.CreateNull (singleBitfield.Length);
 
             multiFile = CreateMultiFile ();
-            multiBitfield = new BitField (multiFile.PieceCount ()).SetAll (true);
+            multiBitfield = new MutableBitField (multiFile.PieceCount ()).SetAll (true);
             multiPeer = PeerId.CreateNull (multiBitfield.Length);
 
             checker = new PiecePickerFilterChecker ();
@@ -194,7 +194,7 @@ namespace MonoTorrent.Client.PiecePicking
             Assert.AreEqual (5, checker.Picks.Count, "#1");
 
             // Make sure every downloadable file is available
-            var bf = new BitField (multiBitfield.Length);
+            var bf = new MutableBitField (multiBitfield.Length);
             foreach (var file in multiFile.Files.Where (t => t.Priority != Priority.DoNotDownload)) {
                 Assert.IsTrue (picker.IsInteresting (multiPeer, bf.SetAll (false).Set (file.StartPieceIndex, true)), "#2");
                 Assert.IsTrue (picker.IsInteresting (multiPeer, bf.SetAll (false).Set (file.EndPieceIndex, true)), "#3");
@@ -205,20 +205,20 @@ namespace MonoTorrent.Client.PiecePicking
             Assert.IsFalse (picker.IsInteresting (multiPeer, bf.SetAll (false).Set (multiFile.Files[1].StartPieceIndex + 1, true)), "#4");
             Assert.IsFalse (picker.IsInteresting (multiPeer, bf.SetAll (false).Set (multiFile.Files[1].EndPieceIndex - 1, true)), "#5");
 
-            bf = new BitField (multiBitfield.Length).SetTrue (multiFile.Files[2].GetSelector ());
+            bf = new MutableBitField (multiBitfield.Length).SetTrue (multiFile.Files[2].GetSelector ());
             Assert.AreEqual (bf, checker.Picks[0].available, "#6");
 
-            bf = new BitField (multiBitfield.Length).SetTrue (multiFile.Files[3].GetSelector ())
+            bf = new MutableBitField (multiBitfield.Length).SetTrue (multiFile.Files[3].GetSelector ())
                 .SetTrue (multiFile.Files[7].GetSelector ());
             Assert.AreEqual (bf, checker.Picks[1].available, "#7");
 
-            bf = new BitField (multiBitfield.Length).SetTrue (multiFile.Files[0].GetSelector ());
+            bf = new MutableBitField (multiBitfield.Length).SetTrue (multiFile.Files[0].GetSelector ());
             Assert.AreEqual (bf, checker.Picks[2].available, "#8");
 
-            bf = new BitField (multiBitfield.Length).SetTrue (multiFile.Files[5].GetSelector ());
+            bf = new MutableBitField (multiBitfield.Length).SetTrue (multiFile.Files[5].GetSelector ());
             Assert.AreEqual (bf, checker.Picks[3].available, "#9");
 
-            bf = new BitField (multiBitfield.Length).SetTrue (multiFile.Files[4].GetSelector ());
+            bf = new MutableBitField (multiBitfield.Length).SetTrue (multiFile.Files[4].GetSelector ());
             Assert.AreEqual (bf, checker.Picks[4].available, "#10");
         }
 
@@ -249,9 +249,9 @@ namespace MonoTorrent.Client.PiecePicking
             picker.PickPiece (multiPeer, multiBitfield, new List<PeerId> (), 1, 0, multiBitfield.Length - 1);
             Assert.AreEqual (2, checker.Picks.Count, "#1");
             Assert.IsTrue (picker.IsInteresting (multiPeer, multiBitfield), "#2");
-            Assert.AreEqual (new BitField (multiBitfield.Length).SetTrue (multiFile.Files[1].GetSelector ()), checker.Picks[0].available, "#3");
+            Assert.AreEqual (new MutableBitField (multiBitfield.Length).SetTrue (multiFile.Files[1].GetSelector ()), checker.Picks[0].available, "#3");
 
-            var bf = new BitField (multiBitfield.Length);
+            var bf = new MutableBitField (multiBitfield.Length);
             foreach (var v in multiFile.Files.Except (new[] { multiFile.Files[1] }))
                 bf.SetTrue (v.GetSelector ());
 

--- a/src/MonoTorrent.Tests/Client/RandomisedPickerTests.cs
+++ b/src/MonoTorrent.Tests/Client/RandomisedPickerTests.cs
@@ -60,7 +60,7 @@ namespace MonoTorrent.Client.PiecePicking
         public void Pick ()
         {
             // Pretend only the 1st piece is available.
-            var onePiece = seeder.BitField.Clone ().SetAll (false).Set (0, true);
+            var onePiece = new MutableBitField (seeder.BitField.Length).Set (0, true);
             var piece = picker.PickPiece (seeder, onePiece, new List<PeerId> ()).Value;
 
             // We should pick a random midpoint and select a piece starting from there.
@@ -78,7 +78,7 @@ namespace MonoTorrent.Client.PiecePicking
         [Test]
         public void SinglePieceBitfield ()
         {
-            picker.PickPiece (seeder, new BitField (1).SetAll (true), new List<PeerId> ());
+            picker.PickPiece (seeder, new MutableBitField (1).SetAll (true), new List<PeerId> ());
 
             Assert.AreEqual (1, checker.Picks.Count, "#1");
             Assert.AreEqual (0, checker.Picks[0].startIndex, "#2");
@@ -98,7 +98,7 @@ namespace MonoTorrent.Client.PiecePicking
         [Test]
         public void TwoPieceRange ()
         {
-            var onePiece = seeder.BitField.Clone ().SetAll (false).Set (0, true);
+            var onePiece = new MutableBitField (seeder.BitField.Length).Set (0, true);
             picker.PickPiece (seeder, onePiece, new List<PeerId> (), 1, 12, 14);
 
             Assert.AreEqual (2, checker.Picks.Count, "#1");

--- a/src/MonoTorrent.Tests/Client/TestRig.cs
+++ b/src/MonoTorrent.Tests/Client/TestRig.cs
@@ -347,7 +347,7 @@ namespace MonoTorrent.Client
             for (int i = 0; i < 20; i++)
                 sb.Append ((char) Random.Next ('a', 'z'));
             Peer peer = new Peer (sb.ToString (), new Uri ($"ipv4://127.0.0.1:{(port++)}"));
-            PeerId id = new PeerId (peer, NullConnection.Incoming, Manager.Bitfield?.Clone ().SetAll (false));
+            PeerId id = new PeerId (peer, NullConnection.Incoming, new MutableBitField (Manager.PieceCount ()).SetAll (false));
             id.SupportsFastPeer = supportsFastPeer;
             id.MessageQueue.SetReady ();
             if (processingQueue)

--- a/src/MonoTorrent.Tests/Client/TestWebSeed.cs
+++ b/src/MonoTorrent.Tests/Client/TestWebSeed.cs
@@ -97,10 +97,9 @@ namespace MonoTorrent.Client
             connection.Manager = rig.Manager;
             rig.Manager.UnhashedPieces.SetAll (false);
 
-            id = new PeerId (new Peer ("this is my id", connection.Uri), connection, rig.Manager.Bitfield?.Clone ().SetAll (false));
+            id = new PeerId (new Peer ("this is my id", connection.Uri), connection, new MutableBitField (rig.Manager.PieceCount ()).SetAll (true));
             id.IsChoking = false;
             id.AmInterested = true;
-            id.BitField.SetAll (true);
             id.MaxPendingRequests = numberOfPieces;
             id.MessageQueue.SetReady ();
 
@@ -369,10 +368,9 @@ namespace MonoTorrent.Client
             connection.Manager = rig.Manager;
             rig.Manager.UnhashedPieces.SetAll (false);
 
-            id = new PeerId (new Peer ("this is my id", connection.Uri), id.Connection, rig.Manager.Bitfield?.Clone ().SetAll (false));
+            id = new PeerId (new Peer ("this is my id", connection.Uri), id.Connection, new MutableBitField (rig.Manager.PieceCount ()).SetAll (true));
             id.IsChoking = false;
             id.AmInterested = true;
-            id.BitField.SetAll (true);
             id.MaxPendingRequests = numberOfPieces;
             id.MessageQueue.SetReady ();
 

--- a/src/MonoTorrent.Tests/Common/BitFieldTest.cs
+++ b/src/MonoTorrent.Tests/Common/BitFieldTest.cs
@@ -39,7 +39,7 @@ namespace MonoTorrent.Common
     [TestFixture]
     public class BitFieldTest
     {
-        BitField bf;
+        MutableBitField bf;
         bool[] initalValues;
         byte[] initialByteValues;
         bool[] secondValues;
@@ -51,13 +51,14 @@ namespace MonoTorrent.Common
             initalValues = new[] { true, false, true, false, true, false, true, true, true, false, false, true };
             secondValues = new[] { true, true, false, false, true, false, true, false, true, false, false, true };
             initialByteValues = new byte[] { 171, 144 };
-            bf = new BitField (initalValues);
+            bf = new MutableBitField (initalValues);
         }
 
         [Test]
         public void Constructor_Null ()
         {
-            Assert.Throws<ArgumentNullException> (() => new BitField (null));
+            Assert.Throws<ArgumentNullException> (() => new BitField ((BitField) null));
+            Assert.Throws<ArgumentNullException> (() => new BitField ((bool[]) null));
             Assert.Throws<ArgumentNullException> (() => new BitField (null, 2));
 
         }
@@ -94,7 +95,7 @@ namespace MonoTorrent.Common
             for (byte i = 8; i > 0; i /= 2) {
                 try {
                     initialByteValues[1] += i;
-                    bf = new BitField (initialByteValues, initalValues.Length);
+                    bf = new MutableBitField (initialByteValues, initalValues.Length);
                     Assert.Fail ("The bitfield was corrupt but decoded correctly: Loop {0}", i);
                 } catch (MessageException) { initialByteValues[1] -= i; }
             }
@@ -113,7 +114,7 @@ namespace MonoTorrent.Common
         [Test]
         public void FirstTrue_2 ()
         {
-            BitField b = new BitField (1025);
+            var b = new MutableBitField (1025);
             b[1024] = true;
             Assert.AreEqual (1024, b.FirstTrue (0, b.Length - 1));
         }
@@ -213,7 +214,7 @@ namespace MonoTorrent.Common
         [Test]
         public void Clone ()
         {
-            BitField clone = (BitField) ((ICloneable) bf).Clone ();
+            BitField clone = new BitField (bf);
             Assert.AreEqual (bf, clone);
             Assert.IsTrue (bf.Equals (clone));
             Assert.AreEqual (bf.GetHashCode (), clone.GetHashCode ());
@@ -229,7 +230,7 @@ namespace MonoTorrent.Common
         [Test]
         public void LargeBitfield ()
         {
-            BitField bf = new BitField (1000);
+            var bf = new MutableBitField (1000);
             bf.SetAll (true);
             Assert.AreEqual (1000, bf.TrueCount);
         }
@@ -280,8 +281,8 @@ namespace MonoTorrent.Common
             r.NextBytes (b);
 
             for (int i = 1; i < a.Length * 8; i++) {
-                BitField first = new BitField (a, i);
-                BitField second = new BitField (b, i);
+                var first = new MutableBitField (a, i);
+                var second = new MutableBitField (b, i);
 
                 first.And (second);
             }
@@ -290,7 +291,7 @@ namespace MonoTorrent.Common
         [Test]
         public void And_DifferentLength ()
         {
-            Assert.Throws<ArgumentException> (() => new BitField (10).And (new BitField (3)));
+            Assert.Throws<ArgumentException> (() => new MutableBitField (10).And (new MutableBitField (3)));
         }
 
         [Test]
@@ -303,8 +304,8 @@ namespace MonoTorrent.Common
         [Test]
         public void Equals_False ()
         {
-            var bf = new BitField (10).SetAll (true);
-            var other = bf.Clone ().Set (5, false);
+            var bf = new MutableBitField (10).SetAll (true);
+            var other = new MutableBitField (bf).Set (5, false);
             Assert.IsFalse (bf.Equals (other));
             Assert.IsFalse (bf.Equals (null));
             Assert.IsFalse (bf.Equals (new BitField (5)));
@@ -335,8 +336,8 @@ namespace MonoTorrent.Common
         [Test]
         public void Set_OutOfRange ()
         {
-            Assert.Throws<ArgumentOutOfRangeException> (() => new BitField (10).Set (-1, true));
-            Assert.Throws<ArgumentOutOfRangeException> (() => new BitField (10).Set (10, true));
+            Assert.Throws<ArgumentOutOfRangeException> (() => new MutableBitField (10).Set (-1, true));
+            Assert.Throws<ArgumentOutOfRangeException> (() => new MutableBitField (10).Set (10, true));
         }
 
         [Test]
@@ -352,7 +353,7 @@ namespace MonoTorrent.Common
         [Test]
         public void Xor ()
         {
-            BitField bf2 = new BitField (secondValues);
+            MutableBitField bf2 = new MutableBitField (secondValues);
             bf.Xor (bf2);
 
             Assert.AreEqual (new BitField (secondValues), bf2, "#1: bf2 should be unmodified");
@@ -370,17 +371,17 @@ namespace MonoTorrent.Common
         [Test]
         public void From ()
         {
-            BitField b = new BitField (31);
+            MutableBitField b = new MutableBitField (31);
             b.SetAll (true);
             Assert.AreEqual (31, b.TrueCount, "#1");
             Assert.IsTrue (b.AllTrue, "#1b");
 
-            b = new BitField (32);
+            b = new MutableBitField (32);
             b.SetAll (true);
             Assert.AreEqual (32, b.TrueCount, "#2");
             Assert.IsTrue (b.AllTrue, "#2b");
 
-            b = new BitField (33);
+            b = new MutableBitField (33);
             b.SetAll (true);
             Assert.AreEqual (33, b.TrueCount, "#3");
             Assert.IsTrue (b.AllTrue, "#3b");

--- a/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/DownloadModeTests.cs
+++ b/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/DownloadModeTests.cs
@@ -68,7 +68,7 @@ namespace MonoTorrent.Client.Modes
             };
             Manager = TestRig.CreateMultiFileManager (fileSizes, Piece.BlockSize * 2);
             Manager.SetTrackerManager (TrackerManager);
-            Peer = new PeerId (new Peer ("", new Uri ("ipv4://123.123.123.123:12345"), EncryptionTypes.All), conn.Outgoing, Manager.Bitfield?.Clone ().SetAll (false));
+            Peer = new PeerId (new Peer ("", new Uri ("ipv4://123.123.123.123:12345"), EncryptionTypes.All), conn.Outgoing, new MutableBitField (Manager.PieceCount ()));
         }
 
         [TearDown]
@@ -192,9 +192,9 @@ namespace MonoTorrent.Client.Modes
         public async Task AnnounceWhenComplete ()
         {
             await TrackerManager.AddTrackerAsync (new Uri ("http://1.1.1.1"));
-            Manager.LoadFastResume (new FastResume (Manager.InfoHash, Manager.Bitfield.Clone ().SetAll (true), Manager.Bitfield.Clone ().SetAll (false)));
+            Manager.LoadFastResume (new FastResume (Manager.InfoHash, new MutableBitField (Manager.PieceCount ()).SetAll (true), new MutableBitField (Manager.PieceCount ())));
 
-            Manager.Bitfield[0] = false;
+            Manager.MutableBitField[0] = false;
             var mode = new DownloadMode (Manager, DiskManager, ConnectionManager, Settings);
             Manager.Mode = mode;
 
@@ -202,7 +202,7 @@ namespace MonoTorrent.Client.Modes
             Assert.AreEqual (TorrentState.Downloading, Manager.State, "#0b");
             Assert.AreEqual (TorrentEvent.None, TrackerManager.Announces[0].Item2, "#0");
 
-            Manager.Bitfield[0] = true;
+            Manager.MutableBitField[0] = true;
             TrackerManager.Announces.Clear ();
             mode.Tick (0);
             Assert.AreEqual (TorrentState.Seeding, Manager.State, "#0c");
@@ -300,7 +300,7 @@ namespace MonoTorrent.Client.Modes
         [Test]
         public async Task PauseSeeding ()
         {
-            Manager.LoadFastResume (new FastResume (Manager.InfoHash, Manager.Bitfield.Clone ().SetAll (true), Manager.Bitfield.Clone ().SetAll (false)));
+            Manager.LoadFastResume (new FastResume (Manager.InfoHash, new MutableBitField (Manager.PieceCount ()).SetAll (true), new MutableBitField (Manager.PieceCount ())));
             Manager.Mode = new DownloadMode (Manager, DiskManager, ConnectionManager, Settings);
 
             Assert.AreEqual (TorrentState.Seeding, Manager.State);

--- a/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/InitialSeedingModeTest.cs
+++ b/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/InitialSeedingModeTest.cs
@@ -49,7 +49,7 @@ namespace MonoTorrent.Client.Modes
         public void Setup ()
         {
             Rig = TestRig.CreateSingleFile (Piece.BlockSize * 20, Piece.BlockSize * 2);
-            Rig.Manager.Bitfield.Not ();
+            Rig.Manager.MutableBitField.Not ();
             Rig.Manager.UnhashedPieces.SetAll (false);
             Rig.Manager.Mode = new InitialSeedingMode (Rig.Manager, Rig.Engine.DiskManager, Rig.Engine.ConnectionManager, Rig.Engine.Settings);
         }
@@ -67,7 +67,7 @@ namespace MonoTorrent.Client.Modes
             Rig.Manager.Peers.ConnectedPeers.Add (Rig.CreatePeer (true, false));
 
             var peer = Rig.CreatePeer (true);
-            peer.BitField.SetAll (true);
+            peer.MutableBitField.SetAll (true);
             Mode.HandlePeerConnected (peer);
             Mode.Tick (0);
 

--- a/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/MetadataModeTests.cs
+++ b/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/MetadataModeTests.cs
@@ -63,12 +63,12 @@ namespace MonoTorrent.Client.Modes
 
             // Mark the torrent as hash check complete with no data downloaded
             if (rig.Manager.HasMetadata)
-                rig.Manager.LoadFastResume (new FastResume (rig.Manager.InfoHash, rig.Manager.Bitfield.Clone ().SetAll (false), rig.Manager.Bitfield.Clone ().SetAll (false)));
+                rig.Manager.LoadFastResume (new FastResume (rig.Manager.InfoHash, new MutableBitField (rig.Manager.PieceCount ()), new MutableBitField (rig.Manager.PieceCount ())));
             await rig.Manager.StartAsync (metadataOnly);
             rig.AddConnection (pair.Outgoing);
 
             var connection = pair.Incoming;
-            PeerId id = new PeerId (new Peer ("", connection.Uri), connection, rig.Manager.Bitfield?.Clone ().SetAll (false));
+            PeerId id = new PeerId (new Peer ("", connection.Uri), connection, new MutableBitField (rig.Manager.PieceCount ()));
 
             var result = await EncryptorFactory.CheckIncomingConnectionAsync (id.Connection, id.Peer.AllowedEncryption, new[] { rig.Manager.InfoHash });
             decryptor = id.Decryptor = result.Decryptor;

--- a/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/StartingModeTests.cs
+++ b/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/StartingModeTests.cs
@@ -120,7 +120,7 @@ namespace MonoTorrent.Client.Modes
             Manager.ModeChanged += (oldMode, newMode) => modeChanged.Add (newMode);
 
             var mode = new StartingMode (Manager, DiskManager, ConnectionManager, Settings);
-            Manager.LoadFastResume (new FastResume (Manager.InfoHash, Manager.Bitfield.Clone ().SetAll (false), Manager.Bitfield.Clone ().SetAll (false)));
+            Manager.LoadFastResume (new FastResume (Manager.InfoHash, new MutableBitField (Manager.PieceCount ()), new MutableBitField (Manager.PieceCount ())));
             Manager.Mode = mode;
             await mode.WaitForStartingToComplete ();
 
@@ -149,7 +149,7 @@ namespace MonoTorrent.Client.Modes
         [Test]
         public async Task FastResume_NoneExist ()
         {
-            var bf = Manager.Bitfield.Clone ().SetAll (true);
+            var bf = new MutableBitField (Manager.PieceCount ()).SetAll (true);
             Manager.LoadFastResume (new FastResume (Manager.InfoHash, bf, Manager.UnhashedPieces.SetAll (false)));
 
             Assert.IsTrue (Manager.Bitfield.AllTrue, "#1");
@@ -172,7 +172,7 @@ namespace MonoTorrent.Client.Modes
                 Manager.Files [0],
                 Manager.Files [2],
             });
-            var bf = Manager.Bitfield.Clone ().SetAll (true);
+            var bf = new MutableBitField (Manager.PieceCount ()).SetAll (true);
             Manager.LoadFastResume (new FastResume (Manager.InfoHash, bf, Manager.UnhashedPieces.SetAll (false)));
 
             Assert.IsTrue (Manager.Bitfield.AllTrue, "#1");

--- a/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/StoppedModeTests.cs
+++ b/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/StoppedModeTests.cs
@@ -63,7 +63,7 @@ namespace MonoTorrent.Client.Modes
             };
             Manager = TestRig.CreateMultiFileManager (fileSizes, Piece.BlockSize * 2);
             Manager.SetTrackerManager (TrackerManager);
-            Peer = new PeerId (new Peer ("", new Uri ("ipv4://123.123.123.123:12345"), EncryptionTypes.All), conn.Outgoing, Manager.Bitfield?.Clone ().SetAll (false));
+            Peer = new PeerId (new Peer ("", new Uri ("ipv4://123.123.123.123:12345"), EncryptionTypes.All), conn.Outgoing, new MutableBitField (Manager.PieceCount ()));
         }
 
         [TearDown]

--- a/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/StoppingModeTests.cs
+++ b/src/MonoTorrent.Tests/MonoTorrent.Client.Modes/StoppingModeTests.cs
@@ -65,7 +65,7 @@ namespace MonoTorrent.Client.Modes
             };
             Manager = TestRig.CreateMultiFileManager (fileSizes, Piece.BlockSize * 2);
             Manager.SetTrackerManager (TrackerManager);
-            Peer = new PeerId (new Peer ("", new Uri ("ipv4://123.123.123.123:5555"), EncryptionTypes.All), conn.Outgoing, Manager.Bitfield?.Clone ().SetAll (false));
+            Peer = new PeerId (new Peer ("", new Uri ("ipv4://123.123.123.123:5555"), EncryptionTypes.All), conn.Outgoing, new MutableBitField (Manager.PieceCount ()));
         }
 
         [TearDown]

--- a/src/MonoTorrent.Tests/Streaming/StreamProviderTests.cs
+++ b/src/MonoTorrent.Tests/Streaming/StreamProviderTests.cs
@@ -72,7 +72,7 @@ namespace MonoTorrent.Streaming
         public async Task CreateStream ()
         {
             var manager = await Engine.AddStreamingAsync (Torrent, "test");
-            manager.LoadFastResume (new FastResume (manager.InfoHash, manager.Bitfield.Clone ().SetAll (true), manager.Bitfield.Clone ().SetAll (false)));
+            manager.LoadFastResume (new FastResume (manager.InfoHash, new MutableBitField (manager.PieceCount ()).SetAll (true), new MutableBitField (manager.PieceCount ())));
             PieceWriter.FilesThatExist.AddRange (manager.Files);
 
             await manager.StartAsync ();
@@ -88,7 +88,7 @@ namespace MonoTorrent.Streaming
         public async Task CreateStream_Prebuffer ()
         {
             var manager = await Engine.AddStreamingAsync (Torrent, "test");
-            manager.LoadFastResume (new FastResume (manager.InfoHash, manager.Bitfield.Clone ().SetAll (true), manager.Bitfield.Clone ().SetAll (false)));
+            manager.LoadFastResume (new FastResume (manager.InfoHash, new MutableBitField (manager.PieceCount ()).SetAll (true), new MutableBitField (manager.PieceCount ())));
             PieceWriter.FilesThatExist.AddRange (manager.Files);
 
             await manager.StartAsync ();
@@ -104,7 +104,7 @@ namespace MonoTorrent.Streaming
         public async Task ReadPastEndOfStream ()
         {
             var manager = await Engine.AddStreamingAsync (Torrent, "testDir");
-            manager.LoadFastResume (new FastResume (manager.InfoHash, manager.Bitfield.Clone ().SetAll (true), manager.Bitfield.Clone ().SetAll (false)));
+            manager.LoadFastResume (new FastResume (manager.InfoHash, new MutableBitField (manager.PieceCount ()).SetAll (true), new MutableBitField (manager.PieceCount ())));
             PieceWriter.FilesThatExist.AddRange (manager.Files);
 
             await manager.StartAsync ();
@@ -119,7 +119,7 @@ namespace MonoTorrent.Streaming
         public async Task ReadLastByte ()
         {
             var manager = await Engine.AddStreamingAsync (Torrent, "testDir");
-            manager.LoadFastResume (new FastResume (manager.InfoHash, manager.Bitfield.Clone ().SetAll (true), manager.Bitfield.Clone ().SetAll (false)));
+            manager.LoadFastResume (new FastResume (manager.InfoHash, new MutableBitField (manager.PieceCount ()).SetAll (true), new MutableBitField (manager.PieceCount ())));
             PieceWriter.FilesThatExist.AddRange (manager.Files);
 
             await manager.StartAsync ();
@@ -137,7 +137,7 @@ namespace MonoTorrent.Streaming
         public async Task SeekBeforeStart ()
         {
             var manager = await Engine.AddStreamingAsync (Torrent, "testDir");
-            manager.LoadFastResume (new FastResume (manager.InfoHash, manager.Bitfield.Clone ().SetAll (true), manager.Bitfield.Clone ().SetAll (false)));
+            manager.LoadFastResume (new FastResume (manager.InfoHash, new MutableBitField (manager.PieceCount ()).SetAll (true), new MutableBitField (manager.PieceCount ())));
             PieceWriter.FilesThatExist.AddRange (manager.Files);
 
             await manager.StartAsync ();
@@ -152,7 +152,7 @@ namespace MonoTorrent.Streaming
         public async Task SeekToMiddle ()
         {
             var manager = await Engine.AddStreamingAsync (Torrent, "testDir");
-            manager.LoadFastResume (new FastResume (manager.InfoHash, manager.Bitfield.Clone ().SetAll (true), manager.Bitfield.Clone ().SetAll (false)));
+            manager.LoadFastResume (new FastResume (manager.InfoHash, new MutableBitField (manager.PieceCount ()).SetAll (true), new MutableBitField (manager.PieceCount ())));
             PieceWriter.FilesThatExist.AddRange (manager.Files);
 
             await manager.StartAsync ();
@@ -166,7 +166,7 @@ namespace MonoTorrent.Streaming
         public async Task SeekPastEnd ()
         {
             var manager = await Engine.AddStreamingAsync (Torrent, "testDir");
-            manager.LoadFastResume (new FastResume (manager.InfoHash, manager.Bitfield.Clone ().SetAll (true), manager.Bitfield.Clone ().SetAll (false)));
+            manager.LoadFastResume (new FastResume (manager.InfoHash, new MutableBitField (manager.PieceCount ()).SetAll (true), new MutableBitField (manager.PieceCount ())));
             PieceWriter.FilesThatExist.AddRange (manager.Files);
 
             await manager.StartAsync ();
@@ -181,7 +181,7 @@ namespace MonoTorrent.Streaming
         public async Task CreateStreamBeforeStart ()
         {
             var manager = await Engine.AddStreamingAsync (Torrent, "testDir");
-            manager.LoadFastResume (new FastResume (manager.InfoHash, manager.Bitfield.Clone ().SetAll (true), manager.Bitfield.Clone ().SetAll (false)));
+            manager.LoadFastResume (new FastResume (manager.InfoHash, new MutableBitField (manager.PieceCount ()).SetAll (true), new MutableBitField (manager.PieceCount ())));
             PieceWriter.FilesThatExist.AddRange (manager.Files);
 
             Assert.ThrowsAsync<InvalidOperationException> (() => manager.StreamProvider.CreateHttpStreamAsync (manager.Files[0]));
@@ -191,7 +191,7 @@ namespace MonoTorrent.Streaming
         public async Task CreateStreamTwice ()
         {
             var manager = await Engine.AddStreamingAsync (Torrent, "testDir");
-            manager.LoadFastResume (new FastResume (manager.InfoHash, manager.Bitfield.Clone ().SetAll (true), manager.Bitfield.Clone ().SetAll (false)));
+            manager.LoadFastResume (new FastResume (manager.InfoHash, new MutableBitField (manager.PieceCount ()).SetAll (true), new MutableBitField (manager.PieceCount ())));
             PieceWriter.FilesThatExist.AddRange (manager.Files);
 
             await manager.StartAsync ();

--- a/src/MonoTorrent/MonoTorrent.Client.Connections/PeerId.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Connections/PeerId.cs
@@ -78,7 +78,7 @@ namespace MonoTorrent.Client
                 IsChoking = isChoking,
                 AmChoking = true,
                 AmInterested = amInterested,
-                BitField = new BitField (bitfieldLength).SetAll (seeder),
+                MutableBitField = new MutableBitField (bitfieldLength).SetAll (seeder)
             };
             peer.MessageQueue.SetReady ();
             peer.MessageQueue.BeginProcessing (force: true);
@@ -111,7 +111,8 @@ namespace MonoTorrent.Client
         public bool AmChoking { get; internal set; }
         public bool AmInterested { get; internal set; }
         public int AmRequestingPiecesCount { get; internal set; }
-        public BitField BitField { get; internal set; }
+        public BitField BitField => MutableBitField;
+        internal MutableBitField MutableBitField { get; private set; }
         public Software ClientApp { get; internal set; }
 
         public Direction ConnectionDirection => Connection.IsIncoming ? Direction.Incoming : Direction.Outgoing;
@@ -198,14 +199,12 @@ namespace MonoTorrent.Client
             InitializeTyrant ();
         }
 
-        internal PeerId (Peer peer, IConnection connection, BitField bitfield)
+        internal PeerId (Peer peer, IConnection connection, MutableBitField bitfield)
             : this (peer)
         {
-            if (connection == null)
-                throw new ArgumentNullException (nameof (connection));
-            Connection = connection;
+            Connection = connection ?? throw new ArgumentNullException (nameof (connection));
             Peer = peer ?? throw new ArgumentNullException (nameof (peer));
-            BitField = bitfield;
+            MutableBitField = bitfield;
         }
 
         #endregion

--- a/src/MonoTorrent/MonoTorrent.Client.Messages/BitfieldMessage.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.Messages/BitfieldMessage.cs
@@ -56,7 +56,7 @@ namespace MonoTorrent.Client.Messages.Standard
         /// <param name="length">The length of the bitfield</param>
         public BitfieldMessage (int length)
         {
-            BitField = new BitField (length);
+            BitField = new MutableBitField (length);
         }
 
 
@@ -75,7 +75,7 @@ namespace MonoTorrent.Client.Messages.Standard
 
         public override void Decode (byte[] buffer, int offset, int length)
         {
-            BitField?.FromArray (buffer, offset);
+            ((MutableBitField) BitField)?.From (buffer, offset);
         }
 
         public override int Encode (byte[] buffer, int offset)

--- a/src/MonoTorrent/MonoTorrent.Client.PiecePicking/IgnoringPicker.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.PiecePicking/IgnoringPicker.cs
@@ -34,7 +34,7 @@ namespace MonoTorrent.Client.PiecePicking
     public class IgnoringPicker : PiecePickerFilter
     {
         readonly BitField Bitfield;
-        readonly BitField Temp;
+        readonly MutableBitField Temp;
 
         public static IPiecePicker Wrap(IPiecePicker picker, IEnumerable<BitField> ignoringBitfields)
         {
@@ -48,7 +48,7 @@ namespace MonoTorrent.Client.PiecePicking
             : base (picker)
         {
             Bitfield = bitfield;
-            Temp = new BitField (bitfield.Length);
+            Temp = new MutableBitField (bitfield.Length);
         }
 
         public override bool IsInteresting (IPeer peer, BitField bitfield)

--- a/src/MonoTorrent/MonoTorrent.Client.PiecePicking/PriorityPicker.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.PiecePicking/PriorityPicker.cs
@@ -62,8 +62,8 @@ namespace MonoTorrent.Client.PiecePicking
         readonly List<Files> files = new List<Files> ();
         readonly List<BitField> prioritised = new List<BitField> ();
 
-        BitField allPrioritisedPieces;
-        BitField temp;
+        MutableBitField allPrioritisedPieces;
+        MutableBitField temp;
 
         public PriorityPicker (IPiecePicker picker)
             : base (picker)
@@ -75,8 +75,8 @@ namespace MonoTorrent.Client.PiecePicking
         {
             base.Initialise (torrentData);
 
-            allPrioritisedPieces = new BitField (torrentData.PieceCount ());
-            temp = new BitField (torrentData.PieceCount ());
+            allPrioritisedPieces = new MutableBitField (torrentData.PieceCount ());
+            temp = new MutableBitField (torrentData.PieceCount ());
 
             files.Clear ();
             for (int i = 0; i < torrentData.Files.Count; i++)
@@ -161,14 +161,14 @@ namespace MonoTorrent.Client.PiecePicking
                 if (files[i].Priority == files[i - 1].Priority) {
                     temp.SetTrue ((files[i].File.StartPieceIndex, files[i].File.EndPieceIndex));
                 } else if (!temp.AllFalse) {
-                    prioritised.Add (temp.Clone ());
+                    prioritised.Add (new MutableBitField (temp));
                     temp.SetAll (false);
                     temp.SetTrue ((files[i].File.StartPieceIndex, files[i].File.EndPieceIndex));
                 }
             }
 
             if (!temp.AllFalse)
-                prioritised.Add (temp.Clone ());
+                prioritised.Add (new MutableBitField (temp));
         }
 
         bool ShouldRebuildSelectors ()

--- a/src/MonoTorrent/MonoTorrent.Client.PiecePicking/StandardPieceRequester.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.PiecePicking/StandardPieceRequester.cs
@@ -34,7 +34,7 @@ namespace MonoTorrent.Client.PiecePicking
     class StandardPieceRequester : IPieceRequester
     {
         IReadOnlyList<BitField> IgnorableBitfields { get; set; }
-        BitField Temp { get; set; }
+        MutableBitField Temp { get; set; }
         ITorrentData TorrentData { get; set; }
 
         public bool InEndgameMode { get; private set; }
@@ -45,7 +45,7 @@ namespace MonoTorrent.Client.PiecePicking
             IgnorableBitfields = ignoringBitfields;
             TorrentData = torrentData;
 
-            Temp = new BitField (TorrentData.PieceCount ());
+            Temp = new MutableBitField (TorrentData.PieceCount ());
 
             IPiecePicker picker = new StandardPicker ();
             picker = new RandomisedPicker (picker);

--- a/src/MonoTorrent/MonoTorrent.Client.PiecePicking/StreamingPieceRequester.cs
+++ b/src/MonoTorrent/MonoTorrent.Client.PiecePicking/StreamingPieceRequester.cs
@@ -62,13 +62,13 @@ namespace MonoTorrent.Client.PiecePicking
 
         internal int LowPriorityCount => HighPriorityCount * 2;
 
-        BitField Temp { get; set; }
+        MutableBitField Temp { get; set; }
 
         public void Initialise (ITorrentData torrentData, IReadOnlyList<BitField> ignoringBitfields)
         {
             TorrentData = torrentData;
             IgnoringBitfields = ignoringBitfields;
-            Temp = new BitField (TorrentData.PieceCount ());
+            Temp = new MutableBitField (TorrentData.PieceCount ());
 
             var standardPicker = new StandardPicker ();
 
@@ -182,7 +182,7 @@ namespace MonoTorrent.Client.PiecePicking
             // only be made to pieces which *can* be requested? Why not!
             // FIXME add a test for this.
             if (!peer.IsChoking || (peer.SupportsFastPeer && peer.IsAllowedFastPieces.Count > 0)) {
-                BitField filtered = null;
+                MutableBitField filtered = null;
                 while (peer.AmRequestingPiecesCount < maxRequests) {
                     filtered ??= GenerateAlreadyHaves ().Not ().And (peer.BitField);
                     IList<BlockInfo> request = PriorityPick (peer, filtered, allPeers, preferredRequestAmount, 0, TorrentData.PieceCount () - 1);
@@ -204,7 +204,7 @@ namespace MonoTorrent.Client.PiecePicking
             }
         }
 
-        BitField GenerateAlreadyHaves ()
+        MutableBitField GenerateAlreadyHaves ()
         {
             Temp.From (IgnoringBitfields [0]);
             for (int i = 1; i < IgnoringBitfields.Count; i++)

--- a/src/MonoTorrent/MonoTorrent.Client/FastResume/FastResume.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/FastResume/FastResume.cs
@@ -58,8 +58,8 @@ namespace MonoTorrent.Client
         internal FastResume (InfoHash infoHash, BitField bitfield, BitField unhashedPieces)
         {
             Infohash = infoHash ?? throw new ArgumentNullException (nameof (infoHash));
-            Bitfield = bitfield?.Clone () ?? throw new ArgumentNullException (nameof (bitfield));
-            UnhashedPieces = unhashedPieces?.Clone () ?? throw new ArgumentNullException (nameof (UnhashedPieces));
+            Bitfield = new BitField (bitfield);
+            UnhashedPieces = new BitField (unhashedPieces);
 
             for (int i = 0; i < Bitfield.Length; i++) {
                 if (bitfield[i] && unhashedPieces[i])
@@ -76,15 +76,15 @@ namespace MonoTorrent.Client
 
             Infohash = new InfoHash (((BEncodedString) dict[InfoHashKey]).TextBytes);
 
-            Bitfield = new BitField ((int) ((BEncodedNumber) dict[BitfieldLengthKey]).Number);
             byte[] data = ((BEncodedString) dict[BitfieldKey]).TextBytes;
-            Bitfield.FromArray (data, 0);
+            Bitfield = new BitField (data, (int) ((BEncodedNumber) dict[BitfieldLengthKey]).Number);
 
-            UnhashedPieces = new BitField (Bitfield.Length);
             // If we're loading up an older version of the FastResume data then we
             if (dict.ContainsKey (UnhashedPiecesKey)) {
                 data = ((BEncodedString) dict[UnhashedPiecesKey]).TextBytes;
-                UnhashedPieces.FromArray (data, 0);
+                UnhashedPieces = new BitField (data, Bitfield.Length);
+            } else {
+                UnhashedPieces = new BitField (Bitfield.Length);
             }
         }
 

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/ConnectionManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/ConnectionManager.cs
@@ -154,7 +154,7 @@ namespace MonoTorrent.Client
                     connection.Dispose ();
                     manager.RaiseConnectionAttemptFailed (new ConnectionAttemptFailedEventArgs (peer, ConnectionFailureReason.Unreachable, manager));
                 } else {
-                    var id = new PeerId (peer, connection, manager.Bitfield?.Clone ().SetAll (false));
+                    var id = new PeerId (peer, connection, new MutableBitField (manager.Bitfield.Length).SetAll (false));
                     id.LastMessageReceived.Restart ();
                     id.LastMessageSent.Restart ();
 

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/ListenManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/ListenManager.cs
@@ -92,7 +92,7 @@ namespace MonoTorrent.Client
                 }
 
                 if (!e.Connection.IsIncoming) {
-                    var id = new PeerId (e.Peer, e.Connection, e.TorrentManager.Bitfield?.Clone ().SetAll (false));
+                    var id = new PeerId (e.Peer, e.Connection, new MutableBitField (e.TorrentManager.Bitfield.Length).SetAll (false));
                     id.LastMessageSent.Restart ();
                     id.LastMessageReceived.Restart ();
 
@@ -136,7 +136,7 @@ namespace MonoTorrent.Client
                 return false;
 
             peer.PeerId = message.PeerId;
-            var id = new PeerId (peer, connection, man.Bitfield?.Clone ().SetAll (false)) {
+            var id = new PeerId (peer, connection, new MutableBitField (man.Bitfield.Length).SetAll (false)) {
                 Decryptor = decryptor,
                 Encryptor = encryptor
             };

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/PieceManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/PieceManager.cs
@@ -53,7 +53,7 @@ namespace MonoTorrent.Client
         bool Initialised { get; set; }
         TorrentManager Manager { get; }
         IPieceRequester Requester { get; set; }
-        BitField PendingHashCheckPieces { get; set; }
+        MutableBitField PendingHashCheckPieces { get; set; }
 
         /// <summary>
         /// Returns true when every block has been requested at least once.
@@ -63,7 +63,7 @@ namespace MonoTorrent.Client
         internal PieceManager (TorrentManager manager)
         {
             Manager = manager;
-            PendingHashCheckPieces = new BitField (1);
+            PendingHashCheckPieces = new MutableBitField (1);
             Requester = new StandardPieceRequester ();
         }
 
@@ -118,7 +118,7 @@ namespace MonoTorrent.Client
         {
             if (Manager.HasMetadata) {
                 Initialised = true;
-                PendingHashCheckPieces = new BitField (Manager.Bitfield.Length);
+                PendingHashCheckPieces = new MutableBitField (Manager.Bitfield.Length);
 
                 var ignorableBitfieds = new[] {
                     Manager.Bitfield,

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentFileInfo.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentFileInfo.cs
@@ -62,7 +62,7 @@ namespace MonoTorrent.Client
         {
             TorrentFile = torrentFile;
             FullPath = fullPath;
-            BitField = new BitField (torrentFile.EndPieceIndex - torrentFile.StartPieceIndex + 1);
+            BitField = new MutableBitField (torrentFile.EndPieceIndex - torrentFile.StartPieceIndex + 1);
         }
 
         public (int startPiece, int endPiece) GetSelector ()

--- a/src/MonoTorrent/MonoTorrent.Client/Modes/InitialSeedingMode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/InitialSeedingMode.cs
@@ -45,7 +45,7 @@ namespace MonoTorrent.Client.Modes
         {
             unchoker = new InitialSeedUnchoker (manager);
             manager.chokeUnchoker = unchoker;
-            zero = new BitField (manager.Bitfield.Length);
+            zero = new MutableBitField (manager.Bitfield.Length);
         }
 
         protected override void AppendBitfieldMessage (PeerId id, MessageBundle bundle)

--- a/src/MonoTorrent/MonoTorrent.Client/Modes/MetadataMode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/MetadataMode.cs
@@ -48,7 +48,7 @@ namespace MonoTorrent.Client.Modes
     {
         static readonly Logger logger = Logger.Create ();
 
-        BitField bitField;
+        MutableBitField bitField;
         static readonly TimeSpan timeout = TimeSpan.FromSeconds (10);
         PeerId currentId;
         string savePath;
@@ -287,7 +287,7 @@ namespace MonoTorrent.Client.Modes
                     if (size > 0)
                         size = 1;
                     size += metadataSize / LTMetadata.BlockSize;
-                    bitField = new BitField (size);
+                    bitField = new MutableBitField (size);
                 }
 
                 // We only create the Stream if the remote peer has sent the metadata size key in their handshake.

--- a/src/MonoTorrent/MonoTorrent.Client/Modes/Mode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/Mode.cs
@@ -245,14 +245,14 @@ namespace MonoTorrent.Client.Modes
 
         protected virtual void HandleHaveNoneMessage (PeerId id, HaveNoneMessage message)
         {
-            id.BitField.SetAll (false);
+            id.MutableBitField.SetAll (false);
             id.Peer.IsSeeder = false;
             SetAmInterestedStatus (id, false);
         }
 
         protected virtual void HandleHaveAllMessage (PeerId id, HaveAllMessage message)
         {
-            id.BitField.SetAll (true);
+            id.MutableBitField.SetAll (true);
             id.Peer.IsSeeder = true;
             SetAmInterestedStatus (id, Manager.PieceManager.IsInteresting (id));
         }
@@ -267,7 +267,7 @@ namespace MonoTorrent.Client.Modes
 
         protected virtual void HandleBitfieldMessage (PeerId id, BitfieldMessage message)
         {
-            id.BitField = message.BitField;
+            id.MutableBitField.From (message.BitField);
             id.Peer.IsSeeder = (id.BitField.AllTrue);
 
             SetAmInterestedStatus (id, Manager.PieceManager.IsInteresting (id));
@@ -432,7 +432,7 @@ namespace MonoTorrent.Client.Modes
             id.HaveMessageEstimatedDownloadedBytes += Manager.Torrent.PieceLength;
 
             // First set the peers bitfield to true for that piece
-            id.BitField[message.PieceIndex] = true;
+            id.MutableBitField[message.PieceIndex] = true;
 
             // Fastcheck to see if a peer is a seeder or not
             id.Peer.IsSeeder = id.BitField.AllTrue;
@@ -607,8 +607,7 @@ namespace MonoTorrent.Client.Modes
                         continue;
                     connection.Manager = Manager;
 
-                    var id = new PeerId (peer, connection, Manager.Bitfield.Clone ().SetAll (true));
-                    id.BitField.SetAll (true);
+                    var id = new PeerId (peer, connection, new MutableBitField (Manager.Bitfield.Length).SetAll (true));
                     id.Encryptor = PlainTextEncryption.Instance;
                     id.Decryptor = PlainTextEncryption.Instance;
                     id.IsChoking = false;

--- a/src/MonoTorrent/MonoTorrent.Client/Unchokers/InitialSeedUnchoker.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Unchokers/InitialSeedUnchoker.cs
@@ -38,7 +38,7 @@ namespace MonoTorrent.Client
     {
         public DateTime LastChoked;
         public PeerId Peer;
-        public BitField CurrentPieces;
+        public MutableBitField CurrentPieces;
         public int SharedPieces;
         public DateTime LastUnchoked;
         public int TotalPieces;
@@ -49,7 +49,7 @@ namespace MonoTorrent.Client
         {
             LastChoked = DateTime.Now;
             Peer = peer;
-            CurrentPieces = new BitField (peer.BitField.Length);
+            CurrentPieces = new MutableBitField (peer.BitField.Length);
         }
     }
 
@@ -73,9 +73,9 @@ namespace MonoTorrent.Client
     class InitialSeedUnchoker : Unchoker
     {
         readonly List<SeededPiece> advertisedPieces;
-        readonly BitField bitfield;
+        readonly MutableBitField bitfield;
         readonly List<ChokeData> peers;
-        readonly BitField temp;
+        readonly MutableBitField temp;
 
         bool PendingUnchoke => peers.Exists (d => d.Peer.AmChoking && d.Peer.IsInterested);
 
@@ -89,9 +89,9 @@ namespace MonoTorrent.Client
             : base (manager)
         {
             advertisedPieces = new List<SeededPiece> ();
-            bitfield = new BitField (manager.Bitfield.Length);
+            bitfield = new MutableBitField (manager.Bitfield.Length);
             peers = new List<ChokeData> ();
-            temp = new BitField (bitfield.Length);
+            temp = new MutableBitField (bitfield.Length);
         }
 
         public override void Choke (PeerId id)

--- a/src/MonoTorrent/MonoTorrent/MutableBitField.cs
+++ b/src/MonoTorrent/MonoTorrent/MutableBitField.cs
@@ -1,0 +1,92 @@
+﻿//
+// MutableBitField.cs
+//
+// Authors:
+//   Alan McGovern alan.mcgovern@gmail.com
+//
+// Copyright (C) 2021 Alan McGovern
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+namespace MonoTorrent
+{
+    public sealed class MutableBitField : BitField
+    {
+        public new bool this[int index] {
+            get => base[index];
+            set => base[index] = value;
+        }
+
+        public MutableBitField (BitField other)
+            : base (other)
+        {
+        }
+
+        public MutableBitField (byte[] array, int length)
+            : base (array, length)
+        {
+        }
+
+        public MutableBitField (int length)
+            : base (length)
+        {
+        }
+
+        public MutableBitField (bool[] array)
+            : base (array)
+        {
+            
+        }
+
+        public new MutableBitField And (BitField value)
+            => (MutableBitField) base.And (value);
+
+        public new MutableBitField From (BitField value)
+            => (MutableBitField) base.From (value);
+
+        public new MutableBitField From (byte[] array, int offset)
+            => (MutableBitField) base.From (array, offset);
+
+        public new MutableBitField NAnd (BitField value)
+            => (MutableBitField) base.NAnd (value);
+
+        public new MutableBitField Not ()
+            => (MutableBitField) base.Not ();
+
+        public new MutableBitField Or (BitField value)
+            => (MutableBitField) base.Or (value);
+
+        public new MutableBitField Set (int index, bool value)
+            => (MutableBitField) base.Set (index, value);
+
+        public new MutableBitField SetAll (bool value)
+            => (MutableBitField) base.SetAll (value);
+
+        internal MutableBitField SetTrue (int index)
+            => (MutableBitField) base.Set (index, true);
+
+        internal new MutableBitField SetTrue ((int startPiece, int endPiece) range)
+            => (MutableBitField) base.SetTrue (range);
+
+        public new MutableBitField Xor (BitField value)
+            => (MutableBitField) base.Xor (value);
+    }
+}


### PR DESCRIPTION
This now gives us a 'guaranteed' immutable BitField,
and also a Mutable version. Most things internally
instantiate a MutableBitfield but expose it to the
user as a plain old 'BitField'. This reduces the risk
of users accidentally doing the wrong thing and mutating
one of the bitfields the engine is managing.