### PR TITLE
Fast resume improvements

### DIFF
--- a/src/MonoTorrent.Tests/Client/FastResumeTests.cs
+++ b/src/MonoTorrent.Tests/Client/FastResumeTests.cs
@@ -115,6 +115,7 @@ namespace MonoTorrent.Client
             using var tmpDir = TempDir.Create ();
             using var engine = new ClientEngine (new EngineSettingsBuilder (EngineSettingsBuilder.CreateForTests ()) {
                 AutoSaveLoadFastResume = true,
+                FastResumeMode = FastResumeMode.Accurate,
                 CacheDirectory = tmpDir.Path,
             }.ToSettings ());
 
@@ -135,6 +136,7 @@ namespace MonoTorrent.Client
             using var tmpDir = TempDir.Create ();
             using var engine = new ClientEngine (new EngineSettingsBuilder (EngineSettingsBuilder.CreateForTests ()) {
                 AutoSaveLoadFastResume = true,
+                FastResumeMode = FastResumeMode.Accurate,
                 CacheDirectory = tmpDir.Path,
             }.ToSettings ());
 
@@ -155,6 +157,7 @@ namespace MonoTorrent.Client
             using var tmpDir = TempDir.Create ();
             using var engine = new ClientEngine (new EngineSettingsBuilder (EngineSettingsBuilder.CreateForTests ()) {
                 AutoSaveLoadFastResume = true,
+                FastResumeMode = FastResumeMode.Accurate,
                 CacheDirectory = tmpDir.Path,
             }.ToSettings ());
 

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -1006,11 +1006,14 @@ namespace MonoTorrent.Client
             if (!Engine.Settings.AutoSaveLoadFastResume ||!HashChecked)
                 return;
 
+            ClientEngine.MainLoop.CheckThread ();
+            var fastResumeData = SaveFastResume ().Encode ();
+
             await MainLoop.SwitchToThreadpool ();
             var fastResumePath = Engine.Settings.GetFastResumePath (InfoHash);
             var parentDirectory = Path.GetDirectoryName (fastResumePath);
             Directory.CreateDirectory (parentDirectory);
-            File.WriteAllBytes (fastResumePath, SaveFastResume ().Encode ());
+            File.WriteAllBytes (fastResumePath, fastResumeData);
         }
 
         internal void SetTrackerManager (ITrackerManager manager)

--- a/src/MonoTorrent/MonoTorrent.Client/Modes/DownloadMode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Modes/DownloadMode.cs
@@ -84,6 +84,11 @@ namespace MonoTorrent.Client.Modes
                     i--;
                 }
             }
+
+            if (counter % 100 == 0) {
+                if (Settings.AutoSaveLoadFastResume && Settings.FastResumeMode == FastResumeMode.BestEffort)
+                    _ = Manager.MaybeWriteFastResumeAsync ();
+            }
         }
 
         internal async Task UpdateSeedingDownloadingState ()

--- a/src/MonoTorrent/MonoTorrent.Client/Settings/EngineSettings.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Settings/EngineSettings.cs
@@ -123,12 +123,6 @@ namespace MonoTorrent.Client
         public int DhtPort { get; } = 0;
 
         /// <summary>
-        /// The TCP port the engine should listen on for incoming connections. Use 0 to choose a random
-        /// available port. Choose -1 to disable listening for incoming connections. Defaults to 0.
-        /// </summary>
-        public int ListenPort { get; } = 0;
-
-        /// <summary>
         /// This is the full path to a sub-directory of <see cref="CacheDirectory"/>. If <see cref="AutoSaveLoadFastResume"/>
         /// is enabled then fast resume data will be written to this when <see cref="TorrentManager.StopAsync"/> or
         /// <see cref="ClientEngine.StopAllAsync"/> is invoked. If fast resume data is available, the data will be loaded
@@ -137,6 +131,23 @@ namespace MonoTorrent.Client
         /// the possibility of loading stale data later.
         /// </summary>
         public string FastResumeCacheDirectory => Path.Combine (CacheDirectory, "fastresume");
+
+        /// <summary>
+        /// When <see cref="EngineSettings.AutoSaveLoadFastResume"/> is true, this setting is used to control how fast
+        /// resume data is maintained, otherwise it has no effect. You can prioritise accuracy (at the risk of requiring full hash checks if an actively downloading
+        /// torrent does not cleanly enter the <see cref="TorrentState.Stopped"/> state) by choosing <see cref="FastResumeMode.Accurate"/>.
+        /// You can prioritise torrent start speed (at the risk of re-downloading a small amount of data) by choosing <see cref="FastResumeMode.BestEffort"/>,
+        /// in which case a recent, not not 100% accurate, copy of the fast resume data will be loaded whenever it is available. if an actively downloading Torrent does not
+        /// cleanly enter the <see cref="TorrentState.Stopped"/> state.
+        /// Defaults to <see cref="FastResumeMode.BestEffort"/>.
+        /// </summary>
+        public FastResumeMode FastResumeMode { get; } = FastResumeMode.BestEffort;
+
+        /// <summary>
+        /// The TCP port the engine should listen on for incoming connections. Use 0 to choose a random
+        /// available port. Choose -1 to disable listening for incoming connections. Defaults to 0.
+        /// </summary>
+        public int ListenPort { get; } = 0;
 
         /// <summary>
         /// The maximum number of concurrent open connections overall. Defaults to 150.
@@ -198,7 +209,7 @@ namespace MonoTorrent.Client
 
         }
 
-        internal EngineSettings (IList<EncryptionType> allowedEncryption, bool allowHaveSuppression, bool allowLocalPeerDiscovery, bool allowPortForwarding, bool autoSaveLoadDhtCache, bool autoSaveLoadFastResume, bool autoSaveLoadMagnetLinkMetadata, string cacheDirectory, TimeSpan connectionTimeout, int dhtPort, int diskCacheBytes, int listenPort, int maximumConnections, int maximumDiskReadRate, int maximumDiskWriteRate, int maximumDownloadSpeed, int maximumHalfOpenConnections, int maximumOpenFiles, int maximumUploadSpeed, IPEndPoint reportedAddress)
+        internal EngineSettings (IList<EncryptionType> allowedEncryption, bool allowHaveSuppression, bool allowLocalPeerDiscovery, bool allowPortForwarding, bool autoSaveLoadDhtCache, bool autoSaveLoadFastResume, bool autoSaveLoadMagnetLinkMetadata, string cacheDirectory, TimeSpan connectionTimeout, int dhtPort, int diskCacheBytes, FastResumeMode fastResumeMode, int listenPort, int maximumConnections, int maximumDiskReadRate, int maximumDiskWriteRate, int maximumDownloadSpeed, int maximumHalfOpenConnections, int maximumOpenFiles, int maximumUploadSpeed, IPEndPoint reportedAddress)
         {
             // Make sure this is immutable now
             AllowedEncryption = EncryptionTypes.MakeReadOnly (allowedEncryption);
@@ -212,6 +223,7 @@ namespace MonoTorrent.Client
             DiskCacheBytes = diskCacheBytes;
             CacheDirectory = cacheDirectory;
             ConnectionTimeout = connectionTimeout;
+            FastResumeMode = fastResumeMode;
             ListenPort = listenPort;
             MaximumConnections = maximumConnections;
             MaximumDiskReadRate = maximumDiskReadRate;
@@ -254,6 +266,7 @@ namespace MonoTorrent.Client
                    && CacheDirectory == other.CacheDirectory
                    && DhtPort == other.DhtPort
                    && DiskCacheBytes == other.DiskCacheBytes
+                   && FastResumeMode == other.FastResumeMode
                    && ListenPort == other.ListenPort
                    && MaximumConnections == other.MaximumConnections
                    && MaximumDiskReadRate == other.MaximumDiskReadRate

--- a/src/MonoTorrent/MonoTorrent.Client/Settings/EngineSettingsBuilder.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Settings/EngineSettingsBuilder.cs
@@ -167,6 +167,17 @@ namespace MonoTorrent.Client
         }
 
         /// <summary>
+        /// When <see cref="EngineSettings.AutoSaveLoadFastResume"/> is true, this setting is used to control how fast
+        /// resume data is maintained, otherwise it has no effect. You can prioritise accuracy (at the risk of requiring full hash checks if an actively downloading
+        /// torrent does not cleanly enter the <see cref="TorrentState.Stopped"/> state) by choosing <see cref="FastResumeMode.Accurate"/>.
+        /// You can prioritise torrent start speed (at the risk of re-downloading a small amount of data) by choosing <see cref="FastResumeMode.BestEffort"/>,
+        /// in which case a recent, not not 100% accurate, copy of the fast resume data will be loaded whenever it is available. if an actively downloading Torrent does not
+        /// cleanly enter the <see cref="TorrentState.Stopped"/> state.
+        /// Defaults to <see cref="FastResumeMode.BestEffort"/>.
+        /// </summary>
+        public FastResumeMode FastResumeMode { get; set; }
+
+        /// <summary>
         /// The TCP port the engine should listen on for incoming connections. Use 0 to choose a random
         /// available port. Choose -1 to disable listening for incoming connections. Defaults to 0.
         /// </summary>
@@ -265,6 +276,7 @@ namespace MonoTorrent.Client
             ConnectionTimeout = settings.ConnectionTimeout;
             DhtPort = settings.DhtPort;
             DiskCacheBytes = settings.DiskCacheBytes;
+            FastResumeMode = settings.FastResumeMode;
             ListenPort = settings.ListenPort;
             MaximumConnections = settings.MaximumConnections;
             MaximumDiskReadRate = settings.MaximumDiskReadRate;
@@ -296,7 +308,8 @@ namespace MonoTorrent.Client
                 cacheDirectory: string.IsNullOrEmpty (CacheDirectory) ? Environment.CurrentDirectory : Path.GetFullPath (CacheDirectory),
                 connectionTimeout: ConnectionTimeout,
                 dhtPort: DhtPort,
-                diskCacheBytes: diskCacheBytes,
+                diskCacheBytes: DiskCacheBytes,
+                fastResumeMode: FastResumeMode,
                 listenPort: ListenPort,
                 maximumConnections: MaximumConnections,
                 maximumDiskReadRate: MaximumDiskReadRate,

--- a/src/MonoTorrent/MonoTorrent.Client/Settings/FastResumeMode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Settings/FastResumeMode.cs
@@ -1,0 +1,50 @@
+﻿//
+// FastResumeMode.cs
+//
+// Authors:
+//   Alan McGovern alan.mcgovern@gmail.com
+//
+// Copyright (C) 2021 Alan McGovern
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+
+namespace MonoTorrent.Client
+{
+    public enum FastResumeMode
+    {
+        /// <summary>
+        /// When <see cref="EngineSettings.AutoSaveLoadFastResume"/> is enabled the engine will delete fast resume data from disk when
+        /// the <see cref="TorrentManager"/> enters the <see cref="TorrentState.Downloading"/> state, or if the hash check is cancelled.
+        /// FastResume data will be written to disk when the <see cref="TorrentManager"/> enters <see cref="TorrentState.Seeding"/> mode,
+        /// or when the torrent enters the <see cref="TorrentState.Stopped"/> state and no errors occurred. If a crash occurs, a full
+        /// hash check will be performed the next time the torrent is started, meaning there is no chance duplicate data will be downloaded.
+        /// </summary>
+        Accurate,
+        /// <summary>
+        /// When <see cref="EngineSettings.AutoSaveLoadFastResume"/> is enabled the engine will not delete fast resume data from disk when
+        /// the <see cref="TorrentManager"/> enters the <see cref="TorrentState.Downloading"/> state. In this mode the engine will write
+        /// an updated copy of the fast resume data on a regular cadence. In the event of a crash, the most recent fast resume data will
+        /// be loaded from disk and a full hash check will not be performed. This may result in a small amount of data being redownloaded.
+        /// </summary>
+        BestEffort,
+    }
+}


### PR DESCRIPTION
Add the ability to store fast resume on a 'best effort' basis. When `FastResumeMode.BestEffort` is enabled, the engine will automatically save fast data on a regular cadence. This eliminates the need to completely rehash data, but it also means that if there is a crash any pieces which were downloaded in the meantime will be 'lost'. In practice this should be under 30 seconds worth of data.

If accuracy is needed, to reduce the need to re-download *any* data, `FastResumeMode.Accurate` can be used. This mode will cause fast-resume data to be deleted from the cache directory while the torrent is actively downloading, and fast resume data will only be written to disk when the manager enters a mode which *does not* modify data. i..e when the engine enters the `Stopped` mode or `Seeding` mode.

`FastResumeMode.BestEffort` is the default as the failure mode is that a few successfully downloaded pieces will need to be redownloaded. There is no way for *incomplete* pieces to be marked as successfully downloaded.
