### PR TITLE
[core] Force developers to set a usable cache directory

### DIFF
--- a/src/MonoTorrent/MonoTorrent.Client/ClientEngine.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/ClientEngine.cs
@@ -181,6 +181,7 @@ namespace MonoTorrent.Client
 
             PeerId = GeneratePeerId ();
             Settings = settings ?? throw new ArgumentNullException (nameof (settings));
+            CheckSettingsAreValid (Settings);
 
             allTorrents = new List<TorrentManager> ();
             publicTorrents = new List<TorrentManager> ();
@@ -679,11 +680,31 @@ namespace MonoTorrent.Client
 
         public async Task UpdateSettingsAsync (EngineSettings settings)
         {
+            await MainLoop.SwitchThread ();
+            CheckSettingsAreValid (settings);
+
             await MainLoop;
 
             var oldSettings = Settings;
             Settings = settings;
             await UpdateSettingsAsync (oldSettings, settings);
+        }
+
+        static void CheckSettingsAreValid (EngineSettings settings)
+        {
+            if (string.IsNullOrEmpty (settings.CacheDirectory))
+                throw new ArgumentException ("EngineSettings.CacheDirectory cannot be null or empty.", nameof (settings));
+
+            if (File.Exists (settings.CacheDirectory))
+                throw new ArgumentException ("EngineSettings.CacheDirectory should be a directory, but a file exists at that path instead. Please delete the file or choose another path", nameof (settings));
+
+            foreach (var directory in new[] { settings.CacheDirectory, settings.MetadataCacheDirectory, settings.FastResumeCacheDirectory }) {
+                try {
+                    Directory.CreateDirectory (directory);
+                } catch (Exception e) {
+                    throw new ArgumentException ($"Could not create a directory at the path {directory}. Please check this path has read/write permissions for this user.", nameof (settings), e);
+                }
+            }
         }
 
         async Task UpdateSettingsAsync (EngineSettings oldSettings, EngineSettings newSettings)

--- a/src/MonoTorrent/MonoTorrent.Client/Settings/EngineSettings.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Settings/EngineSettings.cs
@@ -97,10 +97,11 @@ namespace MonoTorrent.Client
         /// <summary>
         /// The full path to the directory used to cache any data needed by the engine. Typically used to store a
         /// cache of the DHT table to improve bootstrapping speed, any metadata downloaded
-        /// using a magnet link, or fast resume data for individual torrents.
-        /// Defaults to a sub-directory of <see cref="Environment.CurrentDirectory"/> called 'cache'
+        /// using a magnet link, or fast resume data for individual torrents. Must be set to a path
+        /// with read/write permissions. The directory will be created if it doesn't exist.
+        /// Defaults to <see langword="null"/>.
         /// </summary>
-        public string CacheDirectory { get; } = Path.Combine (Environment.CurrentDirectory, "cache");
+        public string CacheDirectory { get; } = null;
 
         /// <summary>
         /// If a connection attempt does not complete within the given timeout, it will be cancelled so
@@ -130,7 +131,7 @@ namespace MonoTorrent.Client
         /// <see cref="TorrentManager.StartAsync"/> is invoked, any on-disk fast resume data will be deleted to eliminate
         /// the possibility of loading stale data later.
         /// </summary>
-        public string FastResumeCacheDirectory => Path.Combine (CacheDirectory, "fastresume");
+        public string FastResumeCacheDirectory => CacheDirectory == null ? null : Path.Combine (CacheDirectory, "fastresume");
 
         /// <summary>
         /// When <see cref="EngineSettings.AutoSaveLoadFastResume"/> is true, this setting is used to control how fast
@@ -202,7 +203,7 @@ namespace MonoTorrent.Client
         /// This is the full path to a sub-directory of <see cref="CacheDirectory"/>. If a magnet link is used
         /// to download a torrent, the downloaded metata will be cached here.
         /// </summary>
-        public string MetadataCacheDirectory => Path.Combine (CacheDirectory, "metadata");
+        public string MetadataCacheDirectory => CacheDirectory == null ? null : Path.Combine (CacheDirectory, "metadata");
 
         public EngineSettings ()
         {
@@ -236,7 +237,7 @@ namespace MonoTorrent.Client
         }
 
         internal string GetDhtNodeCacheFilePath ()
-            => Path.Combine (CacheDirectory, "dht_nodes.cache");
+            => CacheDirectory == null ? null : Path.Combine (CacheDirectory, "dht_nodes.cache");
 
         /// <summary>
         /// Returns the full path to the <see cref="FastResume"/> file for the specified torrent. This is
@@ -245,10 +246,10 @@ namespace MonoTorrent.Client
         /// <param name="infoHash">The infohash of the torrent</param>
         /// <returns></returns>
         public string GetFastResumePath (InfoHash infoHash)
-            => Path.Combine (FastResumeCacheDirectory, $"{infoHash.ToHex ()}.fresume");
+            => FastResumeCacheDirectory == null ? null : Path.Combine (FastResumeCacheDirectory, infoHash.ToHex () + ".fresume");
 
         internal string GetMetadataPath (InfoHash infoHash)
-            => Path.Combine (MetadataCacheDirectory, infoHash.ToHex () + ".torrent");
+            => MetadataCacheDirectory == null ? null : Path.Combine (MetadataCacheDirectory, infoHash.ToHex () + ".torrent");
 
         public override bool Equals (object obj)
             => Equals (obj as EngineSettings);
@@ -287,7 +288,7 @@ namespace MonoTorrent.Client
                    MaximumHalfOpenConnections +
                    ListenPort.GetHashCode () +
                    AllowedEncryption.GetHashCode () +
-                   CacheDirectory.GetHashCode ();
+                   CacheDirectory?.GetHashCode () ?? 0;
         }
     }
 }

--- a/src/MonoTorrent/MonoTorrent.Client/Settings/EngineSettingsBuilder.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Settings/EngineSettingsBuilder.cs
@@ -54,7 +54,7 @@ namespace MonoTorrent.Client
                 AllowLocalPeerDiscovery = allowLocalPeerDiscovery,
                 AllowPortForwarding = allowPortForwarding,
                 AutoSaveLoadFastResume = automaticFastResume,
-                CacheDirectory = cacheDirectory,
+                CacheDirectory = cacheDirectory ?? Path.Combine (Path.GetDirectoryName (typeof (EngineSettingsBuilder).Assembly.Location), "test_cache_dir"),
                 DhtPort = dhtPort,
                 ListenPort = listenPort,
             }.ToSettings ();
@@ -124,12 +124,11 @@ namespace MonoTorrent.Client
         public bool AutoSaveLoadMagnetLinkMetadata { get; set; }
 
         /// <summary>
-        /// The directory used to cache any data needed by the engine. Typically used to store a
+        /// The full path to the directory used to cache any data needed by the engine. Typically used to store a
         /// cache of the DHT table to improve bootstrapping speed, any metadata downloaded
-        /// using a magnet link, or fast resume data for individual torrents.
-        /// When <see cref="ToSettings"/> is invoked the value will be converted to a full path
-        /// if it is not already a full path, or will be replaced with
-        /// <see cref="Environment.CurrentDirectory"/> if the value is null or empty.
+        /// using a magnet link, or fast resume data for individual torrents. Must be set to a path
+        /// with read/write permissions. The directory will be created if it doesn't exist.
+        /// Defaults to <see langword="null"/>.
         /// </summary>
         public string CacheDirectory { get; set; }
 
@@ -305,7 +304,7 @@ namespace MonoTorrent.Client
                 autoSaveLoadDhtCache: AutoSaveLoadDhtCache,
                 autoSaveLoadFastResume: AutoSaveLoadFastResume,
                 autoSaveLoadMagnetLinkMetadata: AutoSaveLoadMagnetLinkMetadata,
-                cacheDirectory: string.IsNullOrEmpty (CacheDirectory) ? Environment.CurrentDirectory : Path.GetFullPath (CacheDirectory),
+                cacheDirectory: string.IsNullOrEmpty (CacheDirectory) ? null : Path.GetFullPath (CacheDirectory),
                 connectionTimeout: ConnectionTimeout,
                 dhtPort: DhtPort,
                 diskCacheBytes: DiskCacheBytes,


### PR DESCRIPTION
Don't default to using the current directory as the
cache directory. Instead throw an error if a value isn't
set by the user of the library.