### PR TITLE
Improve cache handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+/src/MonoTorrent.sln.DotSettings.user
 /build/
 /out/
 /src/.vs

--- a/src/MonoTorrent/MonoTorrent.Client/ClientEngine.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/ClientEngine.cs
@@ -232,6 +232,12 @@ namespace MonoTorrent.Client
         public Task<TorrentManager> AddAsync (MagnetLink magnetLink, string saveDirectory, TorrentSettings settings)
             => AddAsync (magnetLink, null, saveDirectory, settings);
 
+        public Task<TorrentManager> AddAsync (string metadataPath, string saveDirectory)
+            => AddAsync (metadataPath, saveDirectory, new TorrentSettings ());
+
+        public async Task<TorrentManager> AddAsync (string metadataPath, string saveDirectory, TorrentSettings settings)
+            => await AddAsync (null, await Torrent.LoadAsync (metadataPath), saveDirectory, settings);
+
         public Task<TorrentManager> AddAsync (Torrent torrent, string saveDirectory)
             => AddAsync (torrent, saveDirectory, new TorrentSettings ());
 
@@ -264,6 +270,12 @@ namespace MonoTorrent.Client
 
         public Task<TorrentManager> AddStreamingAsync (MagnetLink magnetLink, string saveDirectory, TorrentSettings settings)
             => AddStreamingAsync (magnetLink, null, saveDirectory, settings);
+
+        public Task<TorrentManager> AddStreamingAsync (string metadataPath, string saveDirectory)
+            => AddStreamingAsync (metadataPath, saveDirectory, new TorrentSettings ());
+
+        public async Task<TorrentManager> AddStreamingAsync (string metadataPath, string saveDirectory, TorrentSettings settings)
+            => await AddStreamingAsync (null, await Torrent.LoadAsync (metadataPath), saveDirectory, settings);
 
         public Task<TorrentManager> AddStreamingAsync (Torrent torrent, string saveDirectory)
             => AddStreamingAsync (torrent, saveDirectory, new TorrentSettings ());

--- a/src/MonoTorrent/MonoTorrent.Client/ClientEngine.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/ClientEngine.cs
@@ -236,13 +236,32 @@ namespace MonoTorrent.Client
             => AddAsync (metadataPath, saveDirectory, new TorrentSettings ());
 
         public async Task<TorrentManager> AddAsync (string metadataPath, string saveDirectory, TorrentSettings settings)
-            => await AddAsync (null, await Torrent.LoadAsync (metadataPath), saveDirectory, settings);
+        {
+            var torrent = await Torrent.LoadAsync (metadataPath).ConfigureAwait (false);
+
+            var metadataCachePath = Settings.GetMetadataPath (torrent.InfoHash);
+            Directory.CreateDirectory (Path.GetDirectoryName (metadataCachePath));
+            File.Copy (metadataPath, metadataCachePath, true);
+
+            return await AddAsync (null, torrent, saveDirectory, settings);
+        }
 
         public Task<TorrentManager> AddAsync (Torrent torrent, string saveDirectory)
             => AddAsync (torrent, saveDirectory, new TorrentSettings ());
 
-        public Task<TorrentManager> AddAsync (Torrent torrent, string saveDirectory, TorrentSettings settings)
-            => AddAsync (null, torrent, saveDirectory, settings);
+        public async Task<TorrentManager> AddAsync (Torrent torrent, string saveDirectory, TorrentSettings settings)
+        {
+            await MainLoop.SwitchThread ();
+            var metadata = new BEncodedDictionary {
+                { "info", BEncodedValue.Decode (torrent.InfoMetadata) }
+            };
+
+            var metadataCachePath = Settings.GetMetadataPath (torrent.InfoHash);
+            Directory.CreateDirectory (Path.GetDirectoryName (metadataCachePath));
+            File.WriteAllBytes (metadataCachePath, metadata.Encode ());
+
+            return await AddAsync (null, torrent, saveDirectory, settings);
+        }
 
         async Task<TorrentManager> AddAsync (MagnetLink magnetLink, Torrent torrent, string saveDirectory, TorrentSettings settings)
         {
@@ -293,18 +312,27 @@ namespace MonoTorrent.Client
         }
 
         public Task<bool> RemoveAsync (MagnetLink magnetLink)
+            => RemoveAsync (magnetLink, RemoveMode.CacheDataOnly);
+
+        public Task<bool> RemoveAsync (MagnetLink magnetLink, RemoveMode mode)
         {
             magnetLink = magnetLink ?? throw new ArgumentNullException (nameof (magnetLink));
-            return RemoveAsync (magnetLink.InfoHash);
+            return RemoveAsync (magnetLink.InfoHash, mode);
         }
 
         public Task<bool> RemoveAsync (Torrent torrent)
+            => RemoveAsync (torrent, RemoveMode.CacheDataOnly);
+
+        public Task<bool> RemoveAsync (Torrent torrent, RemoveMode mode)
         {
             torrent = torrent ?? throw new ArgumentNullException (nameof (torrent));
-            return RemoveAsync (torrent.InfoHash);
+            return RemoveAsync (torrent.InfoHash, mode);
         }
 
-        public async Task<bool> RemoveAsync (TorrentManager manager)
+        public Task<bool> RemoveAsync (TorrentManager manager)
+            => RemoveAsync (manager, RemoveMode.CacheDataOnly);
+
+        public async Task<bool> RemoveAsync (TorrentManager manager, RemoveMode mode)
         {
             CheckDisposed ();
             Check.Manager (manager);
@@ -324,14 +352,26 @@ namespace MonoTorrent.Client
             manager.Engine = null;
             manager.DownloadLimiters.Remove (downloadLimiters);
             manager.UploadLimiters.Remove (uploadLimiters);
+
+            if (mode.HasFlag (RemoveMode.CacheDataOnly)) {
+                foreach (var path in new [] { Settings.GetFastResumePath (manager.InfoHash), Settings.GetMetadataPath (manager.InfoHash) })
+                    if (File.Exists (path))
+                        File.Delete (path);
+            }
+            if (mode.HasFlag (RemoveMode.DownloadedDataOnly)) {
+                foreach (var path in manager.Files.Select (f => f.FullPath))
+                    if (File.Exists (path))
+                        File.Delete (path);
+                // FIXME: Clear the empty directories.
+            }
             return true;
         }
 
-        async Task<bool> RemoveAsync (InfoHash infohash)
+        async Task<bool> RemoveAsync (InfoHash infohash, RemoveMode mode)
         {
             await MainLoop;
             var manager = allTorrents.FirstOrDefault (t => t.InfoHash == infohash);
-            return manager == null ? false : await RemoveAsync (manager);
+            return manager != null && await RemoveAsync (manager, mode);
         }
 
         public async Task ChangePieceWriterAsync (IPieceWriter writer)
@@ -476,6 +516,7 @@ namespace MonoTorrent.Client
             listenManager.Add (manager.InfoHash);
 
             manager.Engine = this;
+            manager.MetadataPath = Settings.GetMetadataPath (manager.InfoHash);
             manager.DownloadLimiters.Add (downloadLimiters);
             manager.UploadLimiters.Add (uploadLimiters);
             if (DhtEngine != null && manager.Torrent?.Nodes != null && DhtEngine.State != DhtState.Ready) {

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -222,6 +222,11 @@ namespace MonoTorrent.Client
         public bool HasMetadata => Torrent != null;
 
         /// <summary>
+        /// The path to the .torrent metadata used to create the TorrentManager. Typically stored within the <see cref="EngineSettings.MetadataCacheDirectory"/> directory.
+        /// </summary>
+        public string MetadataPath { get; internal set; }
+
+        /// <summary>
         /// True if this torrent has activated special processing for the final few pieces
         /// </summary>
         public bool IsInEndGame => State == TorrentState.Downloading && PieceManager.InEndgameMode;

--- a/src/MonoTorrent/MonoTorrent.Client/RemoveMode.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/RemoveMode.cs
@@ -1,0 +1,61 @@
+﻿//
+// RemoveMode.cs
+//
+// Authors:
+//   Alan McGovern alan.mcgovern@gmail.com
+//
+// Copyright (C) 2021 Alan McGovern
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+
+namespace MonoTorrent.Client
+{
+    public enum RemoveMode
+    {
+        /// <summary>
+        /// Does not remove any cache data, such as fast resume data and the copy of the .torrent metadata,
+        /// from the <see cref="EngineSettings.CacheDirectory"/> when removing the <see cref="TorrentManager"/>
+        /// from the <see cref="ClientEngine"/>. Any data downloaded by the <see cref="TorrentManager"/> will not be deleted.
+        /// </summary>
+        KeepAllData = 0,
+
+        /// <summary>
+        /// Removes all cache data, such as fast resume data and the copy of the .torrent metadata,
+        /// from the <see cref="EngineSettings.CacheDirectory"/> when removing the <see cref="TorrentManager"/>
+        /// from the <see cref="ClientEngine"/>. Any data downloaded by the <see cref="TorrentManager"/> will not be deleted.
+        /// </summary>
+        CacheDataOnly = 1 << 0,
+
+        /// <summary>
+        /// Any data downloaded by the <see cref="TorrentManager"/> will be deleted. Does not remove any cache data,
+        /// such as fast resume data and the copy of the .torrent metadata, from the <see cref="EngineSettings.CacheDirectory"/>
+        /// when removing the <see cref="TorrentManager"/> from the <see cref="ClientEngine"/>.
+        /// </summary>
+        DownloadedDataOnly = 1 << 1,
+
+        /// <summary>
+        /// Removes all cache data from the <see cref="EngineSettings.CacheDirectory"/> when removing the <see cref="TorrentManager"/>
+        /// from the <see cref="ClientEngine"/>. Any data downloaded by the <see cref="TorrentManager"/> will be deleted.
+        /// </summary>
+        CacheDataAndDownloadedData = CacheDataOnly | DownloadedDataOnly,
+    }
+}


### PR DESCRIPTION
A few small tweaks here:
- Torrent metadata is always copied to the cache directory when a TorrentManager is loaded.
- The path to the torrent metadata is exposed via `TorrentManager.MetadataPath`.
- `ClientEngine.RemoveAsync` has an additional set of overloads which control how data is deleted when a torrent is removed from the engine. The default is to retain all downloaded data and clear anything in the cache directory.