### PR TITLE
[core] Add serialization methods to [Torrent|Engine]Settings

### DIFF
--- a/src/MonoTorrent.Tests/Client/EngineSettingsTests.cs
+++ b/src/MonoTorrent.Tests/Client/EngineSettingsTests.cs
@@ -1,0 +1,46 @@
+﻿//
+// EngineSettingsTests.cs
+//
+// Authors:
+//   Alan McGovern alan.mcgovern@gmail.com
+//
+// Copyright (C) 2021 Alan McGovern
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+
+using System;
+
+using NUnit.Framework;
+
+namespace MonoTorrent.Client
+{
+    [TestFixture]
+    public class EngineSettingsTests
+    {
+        [Test]
+        public void EncodeDecode()
+        {
+            var value = Serializer.DeserializeEngineSettings (Serializer.Serialize (new EngineSettings ()));
+            Assert.AreEqual (value, new EngineSettings ());
+        }
+    }
+}

--- a/src/MonoTorrent.Tests/Client/TorrentSettingsTests.cs
+++ b/src/MonoTorrent.Tests/Client/TorrentSettingsTests.cs
@@ -1,0 +1,46 @@
+﻿//
+// TorrentSettingsTests.cs
+//
+// Authors:
+//   Alan McGovern alan.mcgovern@gmail.com
+//
+// Copyright (C) 2021 Alan McGovern
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+
+using System;
+
+using NUnit.Framework;
+
+namespace MonoTorrent.Client
+{
+    [TestFixture]
+    public class TorrentSettingsTests
+    {
+        [Test]
+        public void EncodeDecode()
+        {
+            var value = Serializer.DeserializeTorrentSettings (Serializer.Serialize (new TorrentSettings ()));
+            Assert.AreEqual (value, new TorrentSettings ());
+        }
+    }
+}

--- a/src/MonoTorrent/MonoTorrent.Client/Settings/EngineSettings.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Settings/EngineSettings.cs
@@ -40,8 +40,7 @@ namespace MonoTorrent.Client
     /// <summary>
     /// Represents the Settings which need to be passed to the engine
     /// </summary>
-    [Serializable]
-    public class EngineSettings : IEquatable<EngineSettings>
+    public sealed class EngineSettings : IEquatable<EngineSettings>
     {
         /// <summary>
         /// A prioritised list of encryption methods, including plain text, which can be used to connect to another peer.

--- a/src/MonoTorrent/MonoTorrent.Client/Settings/EngineSettingsBuilder.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Settings/EngineSettingsBuilder.cs
@@ -225,7 +225,7 @@ namespace MonoTorrent.Client
         /// </summary>
         public int MaximumOpenFiles {
             get => maximumOpenFiles;
-            set => maximumOpenFiles = CheckZeroOrPositive (20);
+            set => maximumOpenFiles = CheckZeroOrPositive (value);
         }
 
         /// <summary>

--- a/src/MonoTorrent/MonoTorrent.Client/Settings/Serializer.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Settings/Serializer.cs
@@ -1,0 +1,109 @@
+﻿//
+// Serializer.cs
+//
+// Authors:
+//   Alan McGovern alan.mcgovern@gmail.com
+//
+// Copyright (C) 2021 Alan McGovern
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+
+using MonoTorrent.BEncoding;
+
+namespace MonoTorrent.Client
+{
+    static class Serializer
+    {
+        internal static EngineSettings DeserializeEngineSettings (byte[] array)
+            => Deserialize<EngineSettingsBuilder> (array).ToSettings ();
+
+        internal static byte[] Serialize (EngineSettings settings)
+            => Serialize (new EngineSettingsBuilder (settings));
+
+        internal static TorrentSettings DeserializeTorrentSettings (byte[] array)
+            => Deserialize<TorrentSettingsBuilder> (array).ToSettings ();
+
+        internal static byte[] Serialize (TorrentSettings settings)
+            => Serialize (new TorrentSettingsBuilder (settings));
+
+        static T Deserialize<T> (byte[] array)
+            where T : new()
+        {
+            T builder = new T ();
+            var dict = (BEncodedDictionary) BEncodedValue.Decode (array);
+            var props = builder.GetType ().GetProperties ();
+            foreach (var property in props) {
+                if (!dict.TryGetValue (property.Name, out BEncodedValue value))
+                    continue;
+
+                if (property.PropertyType == typeof (bool)) {
+                    property.SetValue (builder, bool.Parse (value.ToString ()));
+                } else if (property.PropertyType == typeof (string)) {
+                    property.SetValue (builder, ((BEncodedString) value).Text);
+                } else if (property.PropertyType == typeof (FastResumeMode)) {
+                    property.SetValue (builder, Enum.Parse (typeof (FastResumeMode), ((BEncodedString) value).Text));
+                } else if (property.PropertyType == typeof (TimeSpan)) {
+                    property.SetValue (builder, TimeSpan.FromTicks (((BEncodedNumber) value).Number));
+                } else if (property.PropertyType == typeof (int)) {
+                    property.SetValue (builder, (int) ((BEncodedNumber) value).Number);
+                } else if (property.PropertyType == typeof (IPAddress)) {
+                    property.SetValue (builder, IPAddress.Parse (((BEncodedString) value).Text));
+                } else if (property.PropertyType == typeof (IList<EncryptionType>)) {
+                    var list = (IList<EncryptionType>) property.GetValue (builder);
+                    list.Clear ();
+                    foreach (BEncodedString encryptionType in (BEncodedList) value)
+                        list.Add ((EncryptionType) Enum.Parse (typeof (EncryptionType), encryptionType.Text));
+                } else
+                    throw new NotSupportedException ($"{property.Name} => type: ${property.PropertyType}");
+            }
+            return builder;
+        }
+
+        static byte[] Serialize (object builder)
+        {
+            var dict = new BEncodedDictionary ();
+            var props = builder.GetType ().GetProperties ();
+            foreach (var property in props) {
+                BEncodedValue convertedValue = property.GetValue (builder) switch {
+                    bool value => convertedValue = new BEncodedString (value.ToString ()),
+                    IList<EncryptionType> value => convertedValue = new BEncodedList (value.Select (v => (BEncodedString) v.ToString ())),
+                    string value => new BEncodedString (value),
+                    TimeSpan value => new BEncodedNumber (value.Ticks),
+                    IPAddress value => new BEncodedString (value.ToString ()),
+                    int value => new BEncodedNumber (value),
+                    FastResumeMode value => new BEncodedString (value.ToString ()),
+                    null => null,
+                    { } => throw new NotSupportedException ($"{property.Name} => type: ${property.PropertyType}"),
+                };
+                if (convertedValue != null)
+                    dict[property.Name] = convertedValue;
+            }
+
+            return dict.Encode ();
+        }
+    }
+}

--- a/src/MonoTorrent/MonoTorrent.Client/Settings/TorrentSettings.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Settings/TorrentSettings.cs
@@ -33,8 +33,7 @@ using MonoTorrent.Dht;
 
 namespace MonoTorrent.Client
 {
-    [Serializable]
-    public class TorrentSettings : IEquatable<TorrentSettings>
+    public sealed class TorrentSettings : IEquatable<TorrentSettings>
     {
         /// <summary>
         /// If set to false then the <see cref="DhtEngine"/> registered with the <see cref="ClientEngine" /> will
@@ -94,7 +93,7 @@ namespace MonoTorrent.Client
         /// When considering peers that have given us data, the inactivity manager will wait TimeToWaiTUntilIdle plus (Number of bytes we've been sent / ConnectionRetentionFactor) seconds
         /// before they are eligible for disconnection.  Default value is 2000.  A value of 0 prevents the inactivity manager from disconnecting peers that have sent data.
         /// </summary>
-        internal long ConnectionRetentionFactor => 1024;
+        internal int ConnectionRetentionFactor => 1024;
 
         /// <summary>
         /// The number of peers we should maintain in our internal lists. If we are allowed maintain 100 connections,


### PR DESCRIPTION
This can be refactored into a separate class. However the logic
should be nicely forwards/backwards compatible between versions.
Any missing settings will have their default value, and any
unknown settings will be ignored.