### PR TITLE
[core] Add a way to save/restore an entire ClientEngine

### DIFF
--- a/src/MonoTorrent.Tests/Client/ClientEngineTests.cs
+++ b/src/MonoTorrent.Tests/Client/ClientEngineTests.cs
@@ -186,6 +186,21 @@ namespace MonoTorrent.Client
         }
 
         [Test]
+        public async Task SaveRestoreState_OneMagnetLink ()
+        {
+            var engine = new ClientEngine (EngineSettingsBuilder.CreateForTests ());
+            await engine.AddAsync (new MagnetLink (new InfoHash (new byte[20]), "test"), "mySaveDirectory", new TorrentSettingsBuilder { CreateContainingDirectory = false }.ToSettings ());
+
+            var restoredEngine = await ClientEngine.RestoreStateAsync (await engine.SaveStateAsync ());
+            Assert.AreEqual (engine.Settings, restoredEngine.Settings);
+            Assert.AreEqual (engine.Torrents[0].SavePath, restoredEngine.Torrents[0].SavePath);
+            Assert.AreEqual (engine.Torrents[0].Settings, restoredEngine.Torrents[0].Settings);
+            Assert.AreEqual (engine.Torrents[0].InfoHash, restoredEngine.Torrents[0].InfoHash);
+            Assert.AreEqual (engine.Torrents[0].MagnetLink.ToV1Uri (), restoredEngine.Torrents[0].MagnetLink.ToV1Uri ());
+            Assert.AreEqual (engine.Torrents[0].Files, restoredEngine.Torrents[0].Files);
+        }
+
+        [Test]
         public async Task StopTest ()
         {
             using var rig = TestRig.CreateMultiFile (new TestWriter ());

--- a/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -220,6 +220,8 @@ namespace MonoTorrent.Client
 
         public bool HasMetadata => Torrent != null;
 
+        public InfoHash InfoHash => Torrent?.InfoHash ?? MagnetLink.InfoHash;
+
         /// <summary>
         /// The path to the .torrent metadata used to create the TorrentManager. Typically stored within the <see cref="EngineSettings.MetadataCacheDirectory"/> directory.
         /// </summary>
@@ -256,6 +258,8 @@ namespace MonoTorrent.Client
         /// Internal timer used to trigger Local PeerDiscovery announces every <see cref="LocalPeerDiscovery.AnnounceInternal"/> seconds.
         /// </summary>
         internal ValueStopwatch LastLocalPeerAnnounceTimer;
+
+        public MagnetLink MagnetLink { get; }
 
         internal MutableBitField PartialProgressSelector { get; private set; }
 
@@ -358,8 +362,6 @@ namespace MonoTorrent.Client
 
         public bool IsInitialSeeding => Mode is InitialSeedingMode;
 
-        public InfoHash InfoHash { get; }
-
         #endregion
 
         #region Constructors
@@ -378,8 +380,8 @@ namespace MonoTorrent.Client
         TorrentManager (ClientEngine engine, Torrent torrent, MagnetLink magnetLink, string savePath, TorrentSettings settings)
         {
             Engine = engine;
+            MagnetLink = magnetLink ?? new MagnetLink (torrent.InfoHash, torrent.Name, torrent.AnnounceUrls.SelectMany (t => t).ToArray (), null, torrent.Size);
             Torrent = torrent;
-            InfoHash = magnetLink?.InfoHash ?? torrent.InfoHash;
             Settings = settings;
 
             MetadataTask = new TaskCompletionSource<Torrent> ();

--- a/src/MonoTorrent/MonoTorrent.Client/Settings/Serializer.cs
+++ b/src/MonoTorrent/MonoTorrent.Client/Settings/Serializer.cs
@@ -38,23 +38,22 @@ namespace MonoTorrent.Client
 {
     static class Serializer
     {
-        internal static EngineSettings DeserializeEngineSettings (byte[] array)
-            => Deserialize<EngineSettingsBuilder> (array).ToSettings ();
+        internal static EngineSettings DeserializeEngineSettings (BEncodedDictionary dictionary)
+            => Deserialize<EngineSettingsBuilder> (dictionary).ToSettings ();
 
-        internal static byte[] Serialize (EngineSettings settings)
+        internal static BEncodedDictionary Serialize (EngineSettings settings)
             => Serialize (new EngineSettingsBuilder (settings));
 
-        internal static TorrentSettings DeserializeTorrentSettings (byte[] array)
-            => Deserialize<TorrentSettingsBuilder> (array).ToSettings ();
+        internal static TorrentSettings DeserializeTorrentSettings (BEncodedDictionary dictionary)
+            => Deserialize<TorrentSettingsBuilder> (dictionary).ToSettings ();
 
-        internal static byte[] Serialize (TorrentSettings settings)
+        internal static BEncodedDictionary Serialize (TorrentSettings settings)
             => Serialize (new TorrentSettingsBuilder (settings));
 
-        static T Deserialize<T> (byte[] array)
+        static T Deserialize<T> (BEncodedDictionary dict)
             where T : new()
         {
             T builder = new T ();
-            var dict = (BEncodedDictionary) BEncodedValue.Decode (array);
             var props = builder.GetType ().GetProperties ();
             foreach (var property in props) {
                 if (!dict.TryGetValue (property.Name, out BEncodedValue value))
@@ -83,7 +82,7 @@ namespace MonoTorrent.Client
             return builder;
         }
 
-        static byte[] Serialize (object builder)
+        static BEncodedDictionary Serialize (object builder)
         {
             var dict = new BEncodedDictionary ();
             var props = builder.GetType ().GetProperties ();
@@ -103,7 +102,7 @@ namespace MonoTorrent.Client
                     dict[property.Name] = convertedValue;
             }
 
-            return dict.Encode ();
+            return dict;
         }
     }
 }

--- a/src/MonoTorrent/MonoTorrent/Torrent.cs
+++ b/src/MonoTorrent/MonoTorrent/Torrent.cs
@@ -31,7 +31,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
-using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
 


### PR DESCRIPTION
Save all user settable state, and allow reloading it later.
This will save the engine settings, the list of loaded
torrents, the settings for those, etc.