### PR TITLE
[core] Properly store metadata for streaming torrents

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Client/ClientEngine.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/ClientEngine.cs
@@ -380,29 +380,26 @@ namespace MonoTorrent.Client
             return manager;
         }
 
-        public Task<TorrentManager> AddStreamingAsync (MagnetLink magnetLink, string saveDirectory)
-            => AddStreamingAsync (magnetLink, saveDirectory, new TorrentSettings ());
+        public async Task<TorrentManager> AddStreamingAsync (MagnetLink magnetLink, string saveDirectory)
+            => await MakeStreamingAsync (await AddAsync (magnetLink, saveDirectory));
 
-        public Task<TorrentManager> AddStreamingAsync (MagnetLink magnetLink, string saveDirectory, TorrentSettings settings)
-            => AddStreamingAsync (magnetLink, null, saveDirectory, settings);
+        public async Task<TorrentManager> AddStreamingAsync (MagnetLink magnetLink, string saveDirectory, TorrentSettings settings)
+            => await MakeStreamingAsync (await AddAsync (magnetLink, saveDirectory, settings));
 
-        public Task<TorrentManager> AddStreamingAsync (string metadataPath, string saveDirectory)
-            => AddStreamingAsync (metadataPath, saveDirectory, new TorrentSettings ());
+        public async Task<TorrentManager> AddStreamingAsync (string metadataPath, string saveDirectory)
+            => await MakeStreamingAsync (await AddAsync (metadataPath, saveDirectory));
 
         public async Task<TorrentManager> AddStreamingAsync (string metadataPath, string saveDirectory, TorrentSettings settings)
-            => await AddStreamingAsync (null, await Torrent.LoadAsync (metadataPath), saveDirectory, settings);
+            => await MakeStreamingAsync (await AddAsync (metadataPath, saveDirectory, settings));
 
-        public Task<TorrentManager> AddStreamingAsync (Torrent torrent, string saveDirectory)
-            => AddStreamingAsync (torrent, saveDirectory, new TorrentSettings ());
+        public async Task<TorrentManager> AddStreamingAsync (Torrent torrent, string saveDirectory)
+            => await MakeStreamingAsync (await AddAsync (torrent, saveDirectory));
 
-        public Task<TorrentManager> AddStreamingAsync (Torrent torrent, string saveDirectory, TorrentSettings settings)
-            => AddStreamingAsync (null, torrent, saveDirectory, settings);
+        public async Task<TorrentManager> AddStreamingAsync (Torrent torrent, string saveDirectory, TorrentSettings settings)
+            => await MakeStreamingAsync (await AddAsync (torrent, saveDirectory, settings));
 
-        async Task<TorrentManager> AddStreamingAsync (MagnetLink magnetLink, Torrent torrent, string saveDirectory, TorrentSettings settings)
+        async Task<TorrentManager> MakeStreamingAsync (TorrentManager manager)
         {
-            await MainLoop;
-
-            var manager = await AddAsync (magnetLink, torrent, saveDirectory, settings);
             await manager.ChangePickerAsync (PieceRequesterFactory.CreateStreamingPieceRequester (manager));
             return manager;
         }

--- a/src/Tests/Tests.MonoTorrent.Client/Client/ClientEngineTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/Client/ClientEngineTests.cs
@@ -225,7 +225,9 @@ namespace MonoTorrent.Client
         }
 
         [Test]
-        public async Task SaveRestoreState_OneInMemoryTorrent ()
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task SaveRestoreState_OneInMemoryTorrent (bool addStreaming)
         {
             var pieceLength = Constants.BlockSize * 4;
             using var tmpDir = TempDir.Create ();
@@ -233,7 +235,12 @@ namespace MonoTorrent.Client
             var torrent = TestRig.CreateMultiFileTorrent (TorrentFile.Create (pieceLength, Constants.BlockSize, Constants.BlockSize * 2, Constants.BlockSize * 3), pieceLength, out BEncoding.BEncodedDictionary metadata);
 
             var engine = new ClientEngine (EngineSettingsBuilder.CreateForTests (cacheDirectory: tmpDir.Path));
-            var torrentManager = await engine.AddAsync (torrent, "mySaveDirectory", new TorrentSettingsBuilder { CreateContainingDirectory = true }.ToSettings ());
+            TorrentManager torrentManager;
+            if (addStreaming)
+                torrentManager = await engine.AddStreamingAsync (torrent, "mySaveDirectory", new TorrentSettingsBuilder { CreateContainingDirectory = true }.ToSettings ());
+            else
+                torrentManager = await engine.AddAsync (torrent, "mySaveDirectory", new TorrentSettingsBuilder { CreateContainingDirectory = true }.ToSettings ());
+
             await torrentManager.SetFilePriorityAsync (torrentManager.Files[0], Priority.High);
             await torrentManager.MoveFileAsync (torrentManager.Files[1], Path.GetFullPath ("some_fake_path.txt"));
 
@@ -253,10 +260,15 @@ namespace MonoTorrent.Client
         }
 
         [Test]
-        public async Task SaveRestoreState_OneMagnetLink ()
+        [TestCase(true)]
+        [TestCase(false)]
+        public async Task SaveRestoreState_OneMagnetLink (bool addStreaming)
         {
             var engine = new ClientEngine (EngineSettingsBuilder.CreateForTests ());
-            await engine.AddAsync (new MagnetLink (new InfoHash (new byte[20]), "test"), "mySaveDirectory", new TorrentSettingsBuilder { CreateContainingDirectory = false }.ToSettings ());
+            if (addStreaming)
+                await engine.AddStreamingAsync (new MagnetLink (new InfoHash (new byte[20]), "test"), "mySaveDirectory", new TorrentSettingsBuilder { CreateContainingDirectory = false }.ToSettings ());
+            else
+                await engine.AddAsync(new MagnetLink (new InfoHash (new byte[20]), "test"), "mySaveDirectory", new TorrentSettingsBuilder { CreateContainingDirectory = false }.ToSettings ());
 
             var restoredEngine = await ClientEngine.RestoreStateAsync (await engine.SaveStateAsync ());
             Assert.AreEqual (engine.Settings, restoredEngine.Settings);
@@ -278,7 +290,7 @@ namespace MonoTorrent.Client
             File.WriteAllBytes (metadataFile, metadata.Encode ());
 
             var engine = new ClientEngine (EngineSettingsBuilder.CreateForTests (cacheDirectory: tmpDir.Path));
-            var torrentManager = await engine.AddAsync (metadataFile, "mySaveDirectory", new TorrentSettingsBuilder { CreateContainingDirectory = true }.ToSettings ());
+            var torrentManager = await engine.AddStreamingAsync (metadataFile, "mySaveDirectory", new TorrentSettingsBuilder { CreateContainingDirectory = true }.ToSettings ());
             await torrentManager.SetFilePriorityAsync (torrentManager.Files[0], Priority.High);
             await torrentManager.MoveFileAsync (torrentManager.Files[1], Path.GetFullPath ("some_fake_path.txt"));
 
@@ -308,7 +320,7 @@ namespace MonoTorrent.Client
             File.WriteAllBytes (metadataFile, metadata.Encode ());
 
             var engine = new ClientEngine (EngineSettingsBuilder.CreateForTests (cacheDirectory: tmpDir.Path));
-            await engine.AddAsync (metadataFile, "mySaveDirectory", new TorrentSettingsBuilder { CreateContainingDirectory = false }.ToSettings ());
+            await engine.AddStreamingAsync (metadataFile, "mySaveDirectory", new TorrentSettingsBuilder { CreateContainingDirectory = false }.ToSettings ());
 
             var restoredEngine = await ClientEngine.RestoreStateAsync (await engine.SaveStateAsync ());
             Assert.AreEqual (engine.Settings, restoredEngine.Settings);


### PR DESCRIPTION
Use the same codepath to load torrents normally and when
loading them for 'streaming'. This ensure core functionality,
such as storing the metadata in the correct location, works
for all overloads.

Probably fixes https://github.com/alanmcgovern/monotorrent/issues/464