### PR TITLE
Piece picking perf improvements

### DIFF
--- a/src/Benchmark/Benchmark.csproj
+++ b/src/Benchmark/Benchmark.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <ProjectReference Include="..\MonoTorrent.BEncoding\MonoTorrent.BEncoding.csproj" />
     <ProjectReference Include="..\MonoTorrent.Messages\MonoTorrent.Messages.csproj" />
+    <ProjectReference Include="..\MonoTorrent.PiecePicking\MonoTorrent.PiecePicking.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/Tests.MonoTorrent.PiecePicking/RandomisedPickerTests.cs
+++ b/src/Tests/Tests.MonoTorrent.PiecePicking/RandomisedPickerTests.cs
@@ -39,6 +39,15 @@ namespace MonoTorrent.PiecePicking
     [TestFixture]
     public class RandomisedPickerTests
     {
+        class OnePieceTorrentData : ITorrentData
+        {
+            public IList<ITorrentFileInfo> Files { get; } = TorrentFileInfo.Create (64 * 1024, 64 * 1024);
+            public InfoHash InfoHash => new InfoHash (new byte[20]);
+            public string Name => "Test Torrent";
+            public int PieceLength { get; } = 64 * 1024;
+            public long Size { get; } = 64 * 1024;
+        }
+
         class TestTorrentData : ITorrentData
         {
             public IList<ITorrentFileInfo> Files { get; } = TorrentFileInfo.Create (64 * 1024, 64 * 1024 * 40);
@@ -83,6 +92,7 @@ namespace MonoTorrent.PiecePicking
         [Test]
         public void SinglePieceBitfield ()
         {
+            picker.Initialise (new OnePieceTorrentData ());
             picker.PickPiece (seeder, new MutableBitField (1).SetAll (true), new List<PeerId> ());
 
             Assert.AreEqual (1, checker.Picks.Count, "#1");


### PR DESCRIPTION
The delta between the first commit where the benchmark was added and the final performance improving commit is (currently):

Unoptimised code:
|                                     Method |     Mean |     Error |    StdDev | Allocated |
|------------------------------------------- |---------:|----------:|----------:|----------:|
|                            PickAndValidate | 8.229 ms | 0.0331 ms | 0.0310 ms |     16 KB |
|              PickAndValidate_600Concurrent | 7.451 ms | 0.0507 ms | 0.0475 ms |     16 KB |
| PickAndValidate_600Concurrent_60Requesters | 7.361 ms | 0.0313 ms | 0.0293 ms |     16 KB |


Optimised code:
|                                     Method |     Mean |   Error |  StdDev |  Gen 0 | Allocated |
|------------------------------------------- |---------:|--------:|--------:|-------:|----------:|
|                            PickAndValidate | 689.1 us | 2.91 us | 2.72 us | 2.9297 |     31 KB |
|              PickAndValidate_600Concurrent | 633.3 us | 2.50 us | 2.34 us | 2.9297 |     32 KB |
| PickAndValidate_600Concurrent_60Requesters | 672.2 us | 3.49 us | 2.91 us | 2.9297 |     32 KB |
