### PR TITLE
[core] Allow to load FastResume objects from a stream

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Client/FastResume/FastResume.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/FastResume/FastResume.cs
@@ -119,19 +119,34 @@ namespace MonoTorrent.Client
             s.Write (data, 0, data.Length);
         }
 
+        public static bool TryLoad (Stream s, out FastResume fastResume)
+        {
+            fastResume = Load (s);
+            return fastResume != null;
+        }
+
         public static bool TryLoad (string fastResumeFilePath, out FastResume fastResume)
         {
+            fastResume = null;
             try {
                 if (File.Exists (fastResumeFilePath)) {
-                    var data = (BEncodedDictionary) BEncodedDictionary.Decode (File.ReadAllBytes (fastResumeFilePath));
-                    fastResume = new FastResume (data);
-                } else {
-                    fastResume = null;
+                    using (FileStream s = File.Open (fastResumeFilePath, FileMode.Open)) {
+                        fastResume = Load (s);
+                    }
                 }
             } catch {
-                fastResume = null;
             }
             return fastResume != null;
+        }
+
+        static FastResume Load (Stream s)
+        {
+            try {
+                var data = (BEncodedDictionary) BEncodedDictionary.Decode (s);
+                return new FastResume (data);
+            } catch {
+            }
+            return null;
         }
     }
 }

--- a/src/Tests/Tests.MonoTorrent.Client/Client/FastResumeTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/Client/FastResumeTests.cs
@@ -110,6 +110,24 @@ namespace MonoTorrent.Client
         }
 
         [Test]
+        public void LoadEncoded ()
+        {
+            var unhashedPieces = new MutableBitField (10).SetAll (false);
+            var downloaded = new MutableBitField (10).SetAll (true);
+            var fastResume = new FastResume (InfoHash, downloaded, unhashedPieces);
+            var stream = new MemoryStream ();
+
+            fastResume.Encode (stream);
+            Assert.IsTrue (stream.Length > 0, "#1");
+
+            stream.Seek(0, SeekOrigin.Begin);
+            Assert.IsTrue (FastResume.TryLoad (stream, out var newFastResume), "#2");
+            Assert.IsNotNull (newFastResume, "#3");
+            Assert.IsTrue (newFastResume.UnhashedPieces.AllFalse, "#4");
+            Assert.IsTrue (newFastResume.Bitfield.AllTrue, "#5");
+        }
+
+        [Test]
         public async Task IgnoreInvalidFastResume ()
         {
             using var tmpDir = TempDir.Create ();


### PR DESCRIPTION
Since `FastResume.Encode()` can write to a stream, it makes sense to allow `FastResume.TryLoad()` to read from a stream. This allows a client application to manage collections of `FastResume` objects.

Right now there is no other way because all constructors are internal.