### PR TITLE
[bep52] Validate 'piece layers' when loading BEP52 torrents

### DIFF
--- a/src/MonoTorrent/MonoTorrent/Constants.cs
+++ b/src/MonoTorrent/MonoTorrent/Constants.cs
@@ -8,6 +8,11 @@
         public const int BlockSize = 16 * 1024;
 
         /// <summary>
+        /// Maximum supported piece length. Value is in bytes.
+        /// </summary>
+        public static readonly int MaximumPieceLength = 128 * 1024 * 1024;
+
+        /// <summary>
         /// The default maximum concurrent requests which can be made to a single peer.
         /// </summary>
         public const int DefaultMaxPendingRequests = 256;
@@ -21,6 +26,5 @@
         /// Protocol string for version 1.0 of Bittorrent Protocol
         /// </summary>
         public const string ProtocolStringV100 = "BitTorrent protocol";
-
     }
 }

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/TorrentV2Test.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/TorrentV2Test.cs
@@ -31,6 +31,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 
 using MonoTorrent.BEncoding;
 
@@ -41,6 +42,8 @@ namespace MonoTorrent.Common
     [TestFixture]
     public class TorrentV2Test
     {
+        string V2OnlyTorrent => Path.Combine (Path.GetDirectoryName (typeof (TorrentV2Test).Assembly.Location), "MonoTorrent", "bittorrent-v2-test.torrent");
+
         [SetUp]
         public void Setup ()
         {
@@ -83,6 +86,15 @@ namespace MonoTorrent.Common
 
             var dict = (BEncodedDictionary) BEncodedValue.Decode (Encoding.UTF8.GetBytes ("d4:infod9:file treed4:dir1d4:dir2d9:fileA.txtd0:d6:lengthi1024e11:pieces root32:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeeeee12:piece lengthi16382eee"));
             Assert.Throws<TorrentException> (() => Torrent.Load (dict));
+        }
+
+        [Test]
+        public void LoadV2OnlyTorrent ()
+        {
+            var torrent = Torrent.Load (V2OnlyTorrent);
+            // A v2 only torrent does not have a regular infohash
+            Assert.IsNull (torrent.InfoHash);
+            Assert.IsNotNull (torrent.InfoHashV2);
         }
     }
 }

--- a/src/Tests/Tests.MonoTorrent.Client/Tests.MonoTorrent.Client.csproj
+++ b/src/Tests/Tests.MonoTorrent.Client/Tests.MonoTorrent.Client.csproj
@@ -23,4 +23,10 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="MonoTorrent\bittorrent-v2-test.torrent">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
This validates the piece data isn't corrupt/faked in the torrent.