### PR TITLE
Hashesv2

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/HashingMode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/HashingMode.cs
@@ -84,7 +84,7 @@ namespace MonoTorrent.Client.Modes
                 int piecesHashed = 0;
                 Cancellation.Token.ThrowIfCancellationRequested ();
                 using var hashBuffer = MemoryPool.Default.Rent (20, out System.Memory<byte> memory);
-                for (int index = 0; index < Manager.Torrent.Pieces.Count; index++) {
+                for (int index = 0; index < Manager.Torrent.PieceCount; index++) {
                     if (!Manager.Files.Any (f => index >= f.StartPieceIndex && index <= f.EndPieceIndex && f.Priority != Priority.DoNotDownload)) {
                         // If a file is marked 'do not download' ensure we update the TorrentFiles
                         // so they also report that the piece is not available/downloaded.
@@ -104,13 +104,13 @@ namespace MonoTorrent.Client.Modes
                         Cancellation.Token.ThrowIfCancellationRequested ();
                     }
 
-                    bool hashPassed = successful && Manager.Torrent.Pieces.IsValid (memory.Span, index);
+                    bool hashPassed = successful && Manager.Torrent.PieceHashes.IsValid (memory.Span, index);
                     Manager.OnPieceHashed (index, hashPassed, ++piecesHashed, Manager.PartialProgressSelector.TrueCount);
                 }
             } else {
                 await PausedCompletionSource.Task;
-                for (int i = 0; i < Manager.Torrent.Pieces.Count; i++)
-                    Manager.OnPieceHashed (i, false, i + 1, Manager.Torrent.Pieces.Count);
+                for (int i = 0; i < Manager.Torrent.PieceCount; i++)
+                    Manager.OnPieceHashed (i, false, i + 1, Manager.Torrent.PieceCount);
             }
         }
 

--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/Mode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/Mode.cs
@@ -215,7 +215,7 @@ namespace MonoTorrent.Client.Modes
             // If they support fast peers, create their list of allowed pieces that they can request off me
             if (id.SupportsFastPeer && Manager != null && Manager.HasMetadata) {
                 AllowedFastHasher ??= SHA1.Create ();
-                id.AmAllowedFastPieces = AllowedFastAlgorithm.Calculate (AllowedFastHasher, id.AddressBytes, Manager.InfoHash, (uint) Manager.Torrent.Pieces.Count);
+                id.AmAllowedFastPieces = AllowedFastAlgorithm.Calculate (AllowedFastHasher, id.AddressBytes, Manager.InfoHash, (uint) Manager.Torrent.PieceCount);
             }
         }
 
@@ -403,7 +403,7 @@ namespace MonoTorrent.Client.Modes
                 return;
             }
 
-            bool result = successful && Manager.Torrent.Pieces.IsValid (memory.Span, block.PieceIndex);
+            bool result = successful && Manager.Torrent.PieceHashes.IsValid (memory.Span, block.PieceIndex);
             Manager.OnPieceHashed (block.PieceIndex, result, 1, 1);
             Manager.PieceManager.PieceHashed (block.PieceIndex);
             if (!result)
@@ -430,7 +430,7 @@ namespace MonoTorrent.Client.Modes
         {
             // If we are not on the last piece and the user requested a stupidly big/small amount of data
             // we will close the connection
-            if (Manager.Torrent.Pieces.Count != (message.PieceIndex + 1))
+            if (Manager.Torrent.PieceCount != (message.PieceIndex + 1))
                 if (message.RequestLength > RequestMessage.MaxSize || message.RequestLength < RequestMessage.MinSize)
                     throw new MessageException (
                         $"Illegal piece request received. Peer requested {message.RequestLength} byte");
@@ -712,7 +712,7 @@ namespace MonoTorrent.Client.Modes
                                 var successful = await DiskManager.GetHashAsync (Manager, index, memory);
                                 Cancellation.Token.ThrowIfCancellationRequested ();
 
-                                bool hashPassed = successful && Manager.Torrent.Pieces.IsValid (memory.Span, index);
+                                bool hashPassed = successful && Manager.Torrent.PieceHashes.IsValid (memory.Span, index);
                                 Manager.OnPieceHashed (index, hashPassed, 1, 1);
 
                                 if (hashPassed)

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -415,9 +415,9 @@ namespace MonoTorrent.Client
             }
             SetTrackerManager (new TrackerManager (engine.Factories, new TrackerRequestFactory (this), announces, torrent?.IsPrivate ?? false));
 
-            MutableBitField = new MutableBitField (HasMetadata ? Torrent.Pieces.Count : 1);
-            PartialProgressSelector = new MutableBitField (HasMetadata ? Torrent.Pieces.Count : 1);
-            UnhashedPieces = new MutableBitField (HasMetadata ? Torrent.Pieces.Count : 1).SetAll (true);
+            MutableBitField = new MutableBitField (HasMetadata ? Torrent.PieceCount: 1);
+            PartialProgressSelector = new MutableBitField (HasMetadata ? Torrent.PieceCount : 1);
+            UnhashedPieces = new MutableBitField (HasMetadata ? Torrent.PieceCount : 1).SetAll (true);
             SavePath = string.IsNullOrEmpty (savePath) ? Environment.CurrentDirectory : Path.GetFullPath (savePath);
             finishedPieces = new Queue<int> ();
             Monitor = new ConnectionMonitor ();
@@ -625,9 +625,9 @@ namespace MonoTorrent.Client
             Torrent = torrent;
             foreach (PeerId id in new List<PeerId> (Peers.ConnectedPeers))
                 Engine.ConnectionManager.CleanupSocket (this, id);
-            MutableBitField = new MutableBitField (Torrent.Pieces.Count);
-            PartialProgressSelector = new MutableBitField (Torrent.Pieces.Count).SetAll (true);
-            UnhashedPieces = new MutableBitField (Torrent.Pieces.Count).SetAll (true);
+            MutableBitField = new MutableBitField (Torrent.PieceCount);
+            PartialProgressSelector = new MutableBitField (Torrent.PieceCount).SetAll (true);
+            UnhashedPieces = new MutableBitField (Torrent.PieceCount).SetAll (true);
 
             // Now we know the torrent name, use it as the base directory name when it's a multi-file torrent
             if (Torrent.Files.Count == 1 || !Settings.CreateContainingDirectory)
@@ -990,11 +990,11 @@ namespace MonoTorrent.Client
             CheckMetadata ();
             if (State != TorrentState.Stopped)
                 throw new InvalidOperationException ("Can only load FastResume when the torrent is stopped");
-            if (InfoHash != data.Infohash || Torrent.Pieces.Count != data.Bitfield.Length)
+            if (InfoHash != data.Infohash || Torrent.PieceCount != data.Bitfield.Length)
                 throw new ArgumentException ("The fast resume data does not match this torrent", "fastResumeData");
 
-            for (int i = 0; i < Torrent.Pieces.Count; i++)
-                OnPieceHashed (i, data.Bitfield[i], i + 1, Torrent.Pieces.Count);
+            for (int i = 0; i < Torrent.PieceCount; i++)
+                OnPieceHashed (i, data.Bitfield[i], i + 1, Torrent.PieceCount);
             UnhashedPieces.From (data.UnhashedPieces);
 
             HashChecked = true;

--- a/src/MonoTorrent.Client/MonoTorrent/IPieceHashes.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/IPieceHashes.cs
@@ -1,0 +1,40 @@
+﻿//
+// IPieceHashes.cs
+//
+// Authors:
+//   Alan McGovern alan.mcgovern@gmail.com
+//
+// Copyright (C) 2022 Alan McGovern
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+
+using System;
+
+namespace MonoTorrent
+{
+    public interface IPieceHashes
+    {
+        int Count { get; }
+        ReadOnlyMemory<byte> GetHash (int hashIndex);
+        bool IsValid (ReadOnlySpan<byte> hash, int hashIndex);
+    }
+}

--- a/src/MonoTorrent.Client/MonoTorrent/PieceHashesV1.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/PieceHashesV1.cs
@@ -1,5 +1,5 @@
 //
-// Hashes.cs
+// PieceHashesV1.cs
 //
 // Authors:
 //   Alan McGovern alan.mcgovern@gmail.com
@@ -31,7 +31,7 @@ using System;
 
 namespace MonoTorrent
 {
-    public class Hashes
+    class PieceHashesV1 : IPieceHashes
     {
         readonly int HashCodeLength;
         readonly ReadOnlyMemory<byte> HashData;
@@ -41,7 +41,7 @@ namespace MonoTorrent
         /// </summary>
         public int Count => HashData.Length / HashCodeLength;
 
-        internal Hashes (ReadOnlyMemory<byte> hashData, int hashCodeLength)
+        internal PieceHashesV1 (ReadOnlyMemory<byte> hashData, int hashCodeLength)
             => (HashData, HashCodeLength) = (hashData, hashCodeLength);
 
         /// <summary>
@@ -57,10 +57,7 @@ namespace MonoTorrent
             if (hash.Length != HashCodeLength)
                 throw new ArgumentException ($"Hash must be {HashCodeLength} bytes in length", nameof (hash));
 
-            if (hashIndex < 0 || hashIndex >= Count)
-                throw new ArgumentOutOfRangeException (nameof (hashIndex), $"hashIndex must be between 0 and {Count}");
-
-            return hash.SequenceEqual (HashData.Span.Slice (hashIndex * hash.Length, hash.Length));
+            return GetHash (hashIndex).Span.SequenceEqual (hash);
         }
     }
 }

--- a/src/MonoTorrent.Client/MonoTorrent/PieceHashesV2.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/PieceHashesV2.cs
@@ -1,0 +1,79 @@
+//
+// PieceHashesV2.cs
+//
+// Authors:
+//   Alan McGovern alan.mcgovern@gmail.com
+//
+// Copyright (C) 2022 Alan McGovern
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using MonoTorrent.BEncoding;
+
+namespace MonoTorrent
+{
+    class PieceHashesV2 : IPieceHashes
+    {
+        readonly int HashCodeLength;
+        readonly IList<TorrentFile> Files;
+        readonly BEncodedDictionary Layers;
+
+        /// <summary>
+        /// Number of Hashes (equivalent to number of Pieces)
+        /// </summary>
+        public int Count { get; }
+
+        internal PieceHashesV2 (IList<TorrentFile> files, BEncodedDictionary layers)
+            => (Files, Layers, HashCodeLength, Count) = (files, layers, 32, files.Last ().EndPieceIndex + 1);
+
+        /// <summary>
+        /// Returns the hash for a specific piece
+        /// </summary>
+        /// <param name="hashIndex">Piece/hash index to return</param>
+        /// <returns>byte[] (length HashCodeLength) containing hashdata</returns>
+        public ReadOnlyMemory<byte> GetHash (int hashIndex)
+        {
+            if (hashIndex < 0 || hashIndex > Count)
+                throw new ArgumentOutOfRangeException (nameof (hashIndex), $"Value must be grater than or equal to '0' and less than '{Count}'");
+
+            for (int i = 0; i < Files.Count; i++) {
+                if (hashIndex < Files[i].StartPieceIndex || hashIndex > Files[i].EndPieceIndex)
+                    continue;
+                var layer = (BEncodedString) Layers[BEncodedString.FromMemory (Files[i].PiecesRoot)];
+                return layer.AsMemory ().Slice ((hashIndex - Files[i].StartPieceIndex) * HashCodeLength, HashCodeLength);
+            }
+            throw new InvalidOperationException ("Requested a piece which does not exist");
+        }
+
+        public bool IsValid (ReadOnlySpan<byte> hash, int hashIndex)
+        {
+            if (hash.Length != HashCodeLength)
+                throw new ArgumentException ($"Hash must be {HashCodeLength} bytes in length", nameof (hash));
+
+            return GetHash (hashIndex).Span.SequenceEqual (hash);
+        }
+    }
+}

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/DownloadModeTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/DownloadModeTests.cs
@@ -313,7 +313,7 @@ namespace MonoTorrent.Client.Modes
         [Test]
         public async Task PartialProgress_AllDownloaded_AllDownloadable ()
         {
-            for (int i = 0; i < Manager.Torrent.Pieces.Count; i++)
+            for (int i = 0; i < Manager.Torrent.PieceCount; i++)
                 Manager.OnPieceHashed (i, true);
 
             var mode = new DownloadMode (Manager, DiskManager, ConnectionManager, Settings);
@@ -328,7 +328,7 @@ namespace MonoTorrent.Client.Modes
         [Test]
         public async Task PartialProgress_AllDownloaded_SomeDownloadable ()
         {
-            for (int i = 0; i < Manager.Torrent.Pieces.Count; i++)
+            for (int i = 0; i < Manager.Torrent.PieceCount; i++)
                 Manager.OnPieceHashed (i, true);
 
             foreach (var file in Manager.Files)
@@ -395,7 +395,7 @@ namespace MonoTorrent.Client.Modes
         public async Task PartialProgress_RelatedDownloaded2 ()
         {
             var lastFile = Manager.Files.Last ();
-            Manager.OnPieceHashed (Manager.Torrent.Pieces.Count - 1, true);
+            Manager.OnPieceHashed (Manager.Torrent.PieceCount - 1, true);
 
             foreach (var file in Manager.Files)
                 await Manager.SetFilePriorityAsync (file, Priority.DoNotDownload);

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/HashingModeTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/HashingModeTests.cs
@@ -239,7 +239,7 @@ namespace MonoTorrent.Client.Modes
         {
             DiskManager.GetHashAsyncOverride = (manager, index, dest) => {
                 if (index >= 0 && index <= 4) {
-                    Manager.Torrent.Pieces.ReadHash (index, dest.Span);
+                    Manager.Torrent.Pieces.GetHash (index).CopyTo (dest);
                 } else {
                     Enumerable.Repeat ((byte) 255, 20).ToArray ().CopyTo (dest);
                 }

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/HashingModeTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/HashingModeTests.cs
@@ -179,7 +179,7 @@ namespace MonoTorrent.Client.Modes
             Manager.PieceHashed += (o, e) => {
                 lock (args) {
                     args.Add (e);
-                    if (args.Count == Manager.Torrent.Pieces.Count)
+                    if (args.Count == Manager.Torrent.PieceCount)
                         tcs.SetResult (true);
                 }
             };
@@ -239,7 +239,7 @@ namespace MonoTorrent.Client.Modes
         {
             DiskManager.GetHashAsyncOverride = (manager, index, dest) => {
                 if (index >= 0 && index <= 4) {
-                    Manager.Torrent.Pieces.GetHash (index).CopyTo (dest);
+                    Manager.Torrent.PieceHashes.GetHash (index).CopyTo (dest);
                 } else {
                     Enumerable.Repeat ((byte) 255, 20).ToArray ().CopyTo (dest);
                 }

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/MetadataModeTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/MetadataModeTests.cs
@@ -131,7 +131,7 @@ namespace MonoTorrent.Client.Modes
         public async Task AfterHandshake_SendBitfieldMessage ()
         {
             await Setup (true);
-            await SendMetadataCore (rig.MetadataPath, new BitfieldMessage (rig.Torrent.Pieces.Count));
+            await SendMetadataCore (rig.MetadataPath, new BitfieldMessage (rig.Torrent.PieceCount));
         }
 
         [Test]
@@ -150,7 +150,7 @@ namespace MonoTorrent.Client.Modes
                 else
                     tcs.SetResult (rig.Manager.Files);
             };
-            await SendMetadataCore (rig.MetadataPath, new BitfieldMessage (rig.Torrent.Pieces.Count), metadataOnly: true);
+            await SendMetadataCore (rig.MetadataPath, new BitfieldMessage (rig.Torrent.PieceCount), metadataOnly: true);
             Assert.IsNotNull (await tcs.Task);
         }
 
@@ -175,7 +175,7 @@ namespace MonoTorrent.Client.Modes
 
             WaitAsync ();
 
-            await SendMetadataCore (rig.MetadataPath, new BitfieldMessage (rig.Torrent.Pieces.Count), metadataOnly: true);
+            await SendMetadataCore (rig.MetadataPath, new BitfieldMessage (rig.Torrent.PieceCount), metadataOnly: true);
             Assert.IsNotNull (await tcs.Task);
         }
 
@@ -190,7 +190,7 @@ namespace MonoTorrent.Client.Modes
             await Setup (true, metadataOnly: true);
 
             rig.Manager.MetadataReceived += (o, e) => tcs.TrySetResult (e);
-            await SendMetadataCore (rig.MetadataPath, new BitfieldMessage (rig.Torrent.Pieces.Count), metadataOnly: true);
+            await SendMetadataCore (rig.MetadataPath, new BitfieldMessage (rig.Torrent.PieceCount), metadataOnly: true);
             Assert.IsTrue ((await tcs.Task).Length > 0);
         }
 

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/FastResumeTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/FastResumeTests.cs
@@ -140,7 +140,7 @@ namespace MonoTorrent.Client
             var torrent = TestRig.CreatePrivate ();
             var path = engine.Settings.GetFastResumePath (torrent.InfoHash);
             Directory.CreateDirectory (Path.GetDirectoryName (path));
-            File.WriteAllBytes (path, new FastResume (InfoHash, new MutableBitField (torrent.Pieces.Count).SetAll (false), new MutableBitField (torrent.Pieces.Count)).Encode ());
+            File.WriteAllBytes (path, new FastResume (InfoHash, new MutableBitField (torrent.PieceCount).SetAll (false), new MutableBitField (torrent.PieceCount)).Encode ());
             var manager = await engine.AddAsync (torrent, "savedir");
             Assert.IsFalse (manager.HashChecked);
             await manager.StartAsync ();
@@ -161,7 +161,7 @@ namespace MonoTorrent.Client
             var torrent = TestRig.CreatePrivate ();
             var path = engine.Settings.GetFastResumePath (torrent.InfoHash);
             Directory.CreateDirectory (Path.GetDirectoryName (path));
-            File.WriteAllBytes (path, new FastResume (torrent.InfoHash, new MutableBitField (torrent.Pieces.Count).SetAll (false), new MutableBitField (torrent.Pieces.Count)).Encode ());
+            File.WriteAllBytes (path, new FastResume (torrent.InfoHash, new MutableBitField (torrent.PieceCount).SetAll (false), new MutableBitField (torrent.PieceCount)).Encode ());
             var manager = await engine.AddAsync (torrent, "savedir");
             Assert.IsTrue (manager.HashChecked);
             await manager.StartAsync ();
@@ -182,7 +182,7 @@ namespace MonoTorrent.Client
             var torrent = TestRig.CreatePrivate ();
             var path = engine.Settings.GetFastResumePath (torrent.InfoHash);
             Directory.CreateDirectory (Path.GetDirectoryName (path));
-            File.WriteAllBytes (path, new FastResume (torrent.InfoHash, new MutableBitField (torrent.Pieces.Count).SetAll (true), new BitField (torrent.Pieces.Count)).Encode ());
+            File.WriteAllBytes (path, new FastResume (torrent.InfoHash, new MutableBitField (torrent.PieceCount).SetAll (true), new BitField (torrent.PieceCount)).Encode ());
             var manager = await engine.AddAsync (torrent, "savedir");
             Assert.IsTrue (manager.HashChecked);
             await manager.StartAsync ();
@@ -206,7 +206,7 @@ namespace MonoTorrent.Client
             var torrent = TestRig.CreatePrivate ();
             var path = engine.Settings.GetFastResumePath (torrent.InfoHash);
             Directory.CreateDirectory (Path.GetDirectoryName (path));
-            File.WriteAllBytes (path, new FastResume (torrent.InfoHash, new MutableBitField (torrent.Pieces.Count).SetAll (true), new MutableBitField (torrent.Pieces.Count)).Encode ());
+            File.WriteAllBytes (path, new FastResume (torrent.InfoHash, new MutableBitField (torrent.PieceCount).SetAll (true), new MutableBitField (torrent.PieceCount)).Encode ());
             var manager = await engine.AddAsync (torrent, "savedir");
             await engine.ChangePieceWriterAsync (new TestWriter {
                 FilesThatExist = new System.Collections.Generic.List<ITorrentFileInfo> (manager.Files)

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/TestRig.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/TestRig.cs
@@ -302,7 +302,7 @@ namespace MonoTorrent.Client
         }
 
         public int Pieces {
-            get { return Torrent.Pieces.Count; }
+            get { return Torrent.PieceCount; }
         }
 
         public int TotalBlocks {

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/HashesTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/HashesTests.cs
@@ -52,8 +52,8 @@ namespace MonoTorrent.Common
         [Test]
         public void Read_InvalidIndex ()
         {
-            Assert.Throws<ArgumentOutOfRangeException> (() => Hashes.ReadHash (-1));
-            Assert.Throws<ArgumentOutOfRangeException> (() => Hashes.ReadHash (Hashes.Count));
+            Assert.Throws<ArgumentOutOfRangeException> (() => Hashes.GetHash (-1));
+            Assert.Throws<ArgumentOutOfRangeException> (() => Hashes.GetHash (Hashes.Count));
         }
     }
 }

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/HashesTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/HashesTests.cs
@@ -8,12 +8,12 @@ namespace MonoTorrent.Common
     [TestFixture]
     public class HashesTests
     {
-        Hashes Hashes { get; set; }
+        IPieceHashes Hashes { get; set; }
 
         [SetUp]
         public void Setup ()
         {
-            Hashes = new Hashes (new byte[20 * 10], 20);
+            Hashes = new PieceHashesV1 (new byte[20 * 10], 20);
         }
 
         [Test]

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/HashesTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/HashesTests.cs
@@ -13,7 +13,7 @@ namespace MonoTorrent.Common
         [SetUp]
         public void Setup ()
         {
-            Hashes = new Hashes (new byte[20 * 10], 10);
+            Hashes = new Hashes (new byte[20 * 10], 20);
         }
 
         [Test]
@@ -34,12 +34,6 @@ namespace MonoTorrent.Common
         public void IsValid_Matches ()
         {
             Assert.IsTrue (Hashes.IsValid (new byte[20], 0));
-        }
-
-        [Test]
-        public void IsValid_Null ()
-        {
-            Assert.Throws<ArgumentNullException> (() => Hashes.IsValid (null, 0));
         }
 
         [Test]

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/TorrentV2Test.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/TorrentV2Test.cs
@@ -94,7 +94,13 @@ namespace MonoTorrent.Common
             var torrent = Torrent.Load (V2OnlyTorrent);
             // A v2 only torrent does not have a regular infohash
             Assert.IsNull (torrent.InfoHash);
+            Assert.IsNull (torrent.PieceHashes);
+
             Assert.IsNotNull (torrent.InfoHashV2);
+            Assert.IsNotNull (torrent.PieceHashesV2);
+
+            Assert.IsFalse (torrent.PieceHashesV2.GetHash (torrent.PieceCount - 1).IsEmpty);
+            Assert.IsFalse (torrent.PieceHashesV2.GetHash (0).IsEmpty);
         }
     }
 }


### PR DESCRIPTION
Load piece layers into the corresponding `Torrent` object.

Though, now that I think about it, as this is supposed to be *mutable* state then we need to be careful about how we access this. If you download using a magnet link then the data will be dynamically downloaded from other peers. Additionally, even if you have a .torrent then there's no guarantee the layers will be contained within it.