### PR TITLE
[bep52] Support dynamic piece sizes

### DIFF
--- a/src/Benchmark/Program.cs
+++ b/src/Benchmark/Program.cs
@@ -194,12 +194,14 @@ namespace MyBenchmarks
     [MemoryDiagnoser]
     public class StandardPickerBenchmark
     {
-        class TorrentData : ITorrentData
+        class TorrentData : ITorrentManagerInfo
         {
             const int PieceCount = 500;
 
-            public IList<ITorrentFileInfo> Files { get; }
+            IList<ITorrentFile> ITorrentInfo.Files => Files.ToArray<ITorrentFile> ();
+            public IList<ITorrentManagerFile> Files { get; }
             public InfoHash InfoHash { get; } = new InfoHash (new byte[20]);
+            public InfoHash InfoHashV2 { get; } = new InfoHash (new byte[32]);
             public string Name { get; } = "Name";
             public int PieceLength { get; } = 32768;
             public long Size { get; } = 32768 * PieceCount;

--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/StartingMode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/StartingMode.cs
@@ -133,7 +133,7 @@ namespace MonoTorrent.Client.Modes
             // FIXME: I should really just ensure that zero length files always exist on disk. If the first file is
             // a zero length file and someone deletes it after the first piece has been written to disk, it will
             // never be recreated. If the downloaded data requires this file to exist, we have an issue.
-            foreach (ITorrentFileInfo file in Manager.Files) {
+            foreach (ITorrentManagerFile file in Manager.Files) {
                 if (!file.BitField.AllFalse && file.Length > 0) {
                     if (!await DiskManager.CheckFileExistsAsync (file)) {
                         Manager.SetNeedsHashCheck ();

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentFileInfo.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentFileInfo.cs
@@ -32,7 +32,7 @@ using System.Linq;
 
 namespace MonoTorrent.Client
 {
-    class TorrentFileInfo : ITorrentFileInfo
+    class TorrentFileInfo : ITorrentManagerFile
     {
         public static string IncompleteFileSuffix => ".!mt";
 
@@ -57,6 +57,8 @@ namespace MonoTorrent.Client
         public int EndPieceIndex => TorrentFile.EndPieceIndex;
 
         public long Length => TorrentFile.Length;
+
+        public ReadOnlyMemory<byte> PiecesRoot { get; }
 
         public TorrentFileInfo (ITorrentFile torrentFile, string fullPath)
         {

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -46,7 +46,7 @@ using ReusableTasks;
 
 namespace MonoTorrent.Client
 {
-    public class TorrentManager : IEquatable<TorrentManager>, ITorrentData
+    public class TorrentManager : IEquatable<TorrentManager>, ITorrentManagerInfo
     {
         #region Events
 
@@ -82,7 +82,7 @@ namespace MonoTorrent.Client
         /// </summary>
         public event EventHandler<PeersAddedEventArgs> PeersFound;
 
-        public async Task SetFilePriorityAsync (ITorrentFileInfo file, Priority priority)
+        public async Task SetFilePriorityAsync (ITorrentManagerFile file, Priority priority)
         {
             if (!Files.Contains (file))
                 throw new ArgumentNullException (nameof (file), "The file is not part of this torrent");
@@ -162,9 +162,10 @@ namespace MonoTorrent.Client
 
         public Error Error { get; private set; }
 
-        public IList<ITorrentFileInfo> Files { get; private set; }
+        IList<ITorrentFile> ITorrentInfo.Files => Torrent?.Files;
+        public IList<ITorrentManagerFile> Files { get; private set; }
 
-        string ITorrentData.Name => Torrent == null ? null : Torrent.Name;
+        string ITorrentInfo.Name => Torrent == null ? null : Torrent.Name;
 
         public int PieceLength => Torrent == null ? -1 : Torrent.PieceLength;
         public long Size => Torrent == null ? -1 : Torrent.Size;
@@ -213,7 +214,7 @@ namespace MonoTorrent.Client
         }
 
         /// <summary>
-        /// If <see cref="ITorrentFileInfo.Priority"/> is set to <see cref="Priority.DoNotDownload"/> then the pieces
+        /// If <see cref="ITorrentManagerFile.Priority"/> is set to <see cref="Priority.DoNotDownload"/> then the pieces
         /// associated with that <see cref="TorrentFile"/> will not be hash checked. An IgnoringPicker is used
         /// to ensure pieces which have not been hash checked are never downloaded.
         /// </summary>
@@ -226,6 +227,8 @@ namespace MonoTorrent.Client
         public bool HasMetadata => Torrent != null;
 
         public InfoHash InfoHash => Torrent?.InfoHash ?? MagnetLink.InfoHash;
+
+        public InfoHash InfoHashV2 => Torrent?.InfoHashV2 ?? MagnetLink.InfoHashV2;
 
         /// <summary>
         /// The path to the .torrent metadata used to create the TorrentManager. Typically stored within the <see cref="EngineSettings.MetadataCacheDirectory"/> directory.
@@ -571,7 +574,7 @@ namespace MonoTorrent.Client
             }
         }
 
-        public async Task MoveFileAsync (ITorrentFileInfo file, string path)
+        public async Task MoveFileAsync (ITorrentManagerFile file, string path)
         {
             Check.File (file);
             Check.PathNotEmpty (path);
@@ -659,7 +662,7 @@ namespace MonoTorrent.Client
                     DownloadCompleteFullPath = downloadCompleteFullPath,
                     DownloadIncompleteFullPath = downloadIncompleteFullPath
                 };
-            }).Cast<ITorrentFileInfo> ().ToList ().AsReadOnly ();
+            }).Cast<ITorrentManagerFile> ().ToList ().AsReadOnly ();
 
             PieceManager.Initialise ();
             MetadataTask.SetResult (Torrent);

--- a/src/MonoTorrent.Client/MonoTorrent.Client/PeerIO.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/PeerIO.cs
@@ -64,12 +64,12 @@ namespace MonoTorrent.Client
             return ReceiveMessageAsync (connection, decryptor, null, null, null, null);
         }
 
-        public static async ReusableTask<PeerMessage> ReceiveMessageAsync (IPeerConnection connection, IEncryption decryptor, IRateLimiter rateLimiter, ConnectionMonitor peerMonitor, ConnectionMonitor managerMonitor, ITorrentData torrentData)
+        public static async ReusableTask<PeerMessage> ReceiveMessageAsync (IPeerConnection connection, IEncryption decryptor, IRateLimiter rateLimiter, ConnectionMonitor peerMonitor, ConnectionMonitor managerMonitor, ITorrentManagerInfo torrentData)
         {
             return (await ReceiveMessageAsync (connection, decryptor, rateLimiter, peerMonitor, managerMonitor, torrentData, default)).message;
         }
 
-        public static async ReusableTask<(PeerMessage message, PeerMessage.Releaser releaser)> ReceiveMessageAsync (IPeerConnection connection, IEncryption decryptor, IRateLimiter rateLimiter, ConnectionMonitor peerMonitor, ConnectionMonitor managerMonitor, ITorrentData torrentData, SocketMemory buffer)
+        public static async ReusableTask<(PeerMessage message, PeerMessage.Releaser releaser)> ReceiveMessageAsync (IPeerConnection connection, IEncryption decryptor, IRateLimiter rateLimiter, ConnectionMonitor peerMonitor, ConnectionMonitor managerMonitor, ITorrentManagerInfo torrentData, SocketMemory buffer)
         {
             await MainLoop.SwitchToThreadpool ();
 

--- a/src/MonoTorrent.Client/MonoTorrent.Connections/HttpPeerConnection.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Connections/HttpPeerConnection.cs
@@ -91,7 +91,7 @@ namespace MonoTorrent.Connections.Peer
 
         public bool IsIncoming => false;
 
-        ITorrentData TorrentData { get; set; }
+        ITorrentManagerInfo TorrentData { get; set; }
 
         AutoResetEvent ReceiveWaiter { get; } = new AutoResetEvent (false);
 
@@ -108,7 +108,7 @@ namespace MonoTorrent.Connections.Peer
 
         #region Constructors
 
-        public HttpPeerConnection (ITorrentData torrentData, Factories requestCreator, Uri uri)
+        public HttpPeerConnection (ITorrentManagerInfo torrentData, Factories requestCreator, Uri uri)
         {
             ConnectionTimeout = TimeSpan.FromSeconds (10);
             RequestCreator = requestCreator;

--- a/src/MonoTorrent.Client/MonoTorrent.Streaming/LocalStream.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Streaming/LocalStream.cs
@@ -62,13 +62,13 @@ namespace MonoTorrent.Streaming
             set => Seek (value, SeekOrigin.Begin);
         }
 
-        ITorrentFileInfo File { get; }
+        ITorrentManagerFile File { get; }
 
         TorrentManager Manager { get; }
 
         IStreamingPieceRequester Picker { get; }
 
-        public LocalStream (TorrentManager manager, ITorrentFileInfo file, IStreamingPieceRequester picker)
+        public LocalStream (TorrentManager manager, ITorrentManagerFile file, IStreamingPieceRequester picker)
         {
             Manager = manager;
             File = file;

--- a/src/MonoTorrent.Client/MonoTorrent.Streaming/StreamProvider.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Streaming/StreamProvider.cs
@@ -62,7 +62,7 @@ namespace MonoTorrent.Streaming
         /// </summary>
         /// <param name="file">The file to open</param>
         /// <returns></returns>
-        public Task<Stream> CreateStreamAsync (ITorrentFileInfo file)
+        public Task<Stream> CreateStreamAsync (ITorrentManagerFile file)
             => CreateStreamAsync (file, prebuffer: true, CancellationToken.None);
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace MonoTorrent.Streaming
         /// <param name="file">The file to open</param>
         /// <param name="token">The cancellation token</param>
         /// <returns></returns>
-        public Task<Stream> CreateStreamAsync (ITorrentFileInfo file, CancellationToken token)
+        public Task<Stream> CreateStreamAsync (ITorrentManagerFile file, CancellationToken token)
             => CreateStreamAsync (file, prebuffer: true, token);
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace MonoTorrent.Streaming
         /// <param name="file">The file to open</param>
         /// <param name="prebuffer">True if the first and last piece should be downloaded before the Stream is created.</param>
         /// <returns></returns>
-        public Task<Stream> CreateStreamAsync (ITorrentFileInfo file, bool prebuffer)
+        public Task<Stream> CreateStreamAsync (ITorrentManagerFile file, bool prebuffer)
             => CreateStreamAsync (file, prebuffer, CancellationToken.None);
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace MonoTorrent.Streaming
         /// <param name="prebuffer">True if the first and last piece should be downloaded before the Stream is created.</param>
         /// <param name="token">The cancellation token.</param>
         /// <returns></returns>
-        public async Task<Stream> CreateStreamAsync (ITorrentFileInfo file, bool prebuffer, CancellationToken token)
+        public async Task<Stream> CreateStreamAsync (ITorrentManagerFile file, bool prebuffer, CancellationToken token)
         {
             if (file == null)
                 throw new ArgumentNullException (nameof (file));
@@ -134,7 +134,7 @@ namespace MonoTorrent.Streaming
         /// </summary>
         /// <param name="file">The file to open</param>
         /// <returns></returns>
-        public Task<IUriStream> CreateHttpStreamAsync (ITorrentFileInfo file)
+        public Task<IUriStream> CreateHttpStreamAsync (ITorrentManagerFile file)
             => CreateHttpStreamAsync (file, prebuffer: true, CancellationToken.None);
 
         /// <summary>
@@ -145,7 +145,7 @@ namespace MonoTorrent.Streaming
         /// <param name="file">The file to open</param>
         /// <param name="token">The cancellation token</param>
         /// <returns></returns>
-        public Task<IUriStream> CreateHttpStreamAsync (ITorrentFileInfo file, CancellationToken token)
+        public Task<IUriStream> CreateHttpStreamAsync (ITorrentManagerFile file, CancellationToken token)
             => CreateHttpStreamAsync (file, prebuffer: true, token);
 
         /// <summary>
@@ -156,7 +156,7 @@ namespace MonoTorrent.Streaming
         /// <param name="file">The file to open</param>
         /// <param name="prebuffer">True if the first and last piece should be downloaded before the Stream is created.</param>
         /// <returns></returns>
-        public Task<IUriStream> CreateHttpStreamAsync (ITorrentFileInfo file, bool prebuffer)
+        public Task<IUriStream> CreateHttpStreamAsync (ITorrentManagerFile file, bool prebuffer)
             => CreateHttpStreamAsync (file, prebuffer, CancellationToken.None);
 
 
@@ -170,7 +170,7 @@ namespace MonoTorrent.Streaming
         /// <param name="token">The cancellation token</param>
         /// <returns></returns>
 
-        public async Task<IUriStream> CreateHttpStreamAsync (ITorrentFileInfo file, bool prebuffer, CancellationToken token)
+        public async Task<IUriStream> CreateHttpStreamAsync (ITorrentManagerFile file, bool prebuffer, CancellationToken token)
         {
             var stream = await CreateStreamAsync (file, prebuffer, token);
             var httpStreamer = new HttpStream (stream);

--- a/src/MonoTorrent.Client/MonoTorrent/MagnetLink.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/MagnetLink.cs
@@ -43,11 +43,15 @@ namespace MonoTorrent
         }
 
         /// <summary>
-        /// The infohash of the torrent.
+        /// The SHA1 hash for this torrent. Used by torrents which comply with the v1 specification, or hybrid v1/v2 torrents.
         /// </summary>
-        public InfoHash InfoHash {
-            get;
-        }
+        public InfoHash InfoHash { get; }
+
+        /// <summary>
+        /// The SHA256 hash for this torrent. Used by torrents which comply with the v2 specification, or hybrid v1/v2 torrents.
+        /// </summary>
+        public InfoHash InfoHashV2 { get; }
+        // FIXME: bep52: support this.
 
         /// <summary>
         /// The size in bytes of the data, if available.
@@ -73,6 +77,13 @@ namespace MonoTorrent
         public MagnetLink (InfoHash infoHash, string name = null, IList<string> announceUrls = null, IEnumerable<string> webSeeds = null, long? size = null)
         {
             InfoHash = infoHash ?? throw new ArgumentNullException (nameof (infoHash));
+            if (InfoHash.AsMemory ().Length == 20)
+                InfoHash = infoHash;
+            else if (InfoHash.AsMemory ().Length == 32)
+                InfoHashV2 = infoHash;
+            else
+                throw new NotSupportedException ();
+
             Name = name;
             AnnounceUrls = new List<string> (announceUrls ?? Array.Empty<string> ()).AsReadOnly ();
             Webseeds = new List<string> (webSeeds ?? Array.Empty<string> ()).AsReadOnly ();

--- a/src/MonoTorrent.Client/MonoTorrent/PieceHashesV2.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/PieceHashesV2.cs
@@ -38,7 +38,7 @@ namespace MonoTorrent
     class PieceHashesV2 : IPieceHashes
     {
         readonly int HashCodeLength;
-        readonly IList<TorrentFile> Files;
+        readonly IList<ITorrentFile> Files;
         readonly BEncodedDictionary Layers;
 
         /// <summary>
@@ -46,7 +46,7 @@ namespace MonoTorrent
         /// </summary>
         public int Count { get; }
 
-        internal PieceHashesV2 (IList<TorrentFile> files, BEncodedDictionary layers)
+        internal PieceHashesV2 (IList<ITorrentFile> files, BEncodedDictionary layers)
             => (Files, Layers, HashCodeLength, Count) = (files, layers, 32, files.Last ().EndPieceIndex + 1);
 
         /// <summary>

--- a/src/MonoTorrent.Client/MonoTorrent/Torrent.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/Torrent.cs
@@ -743,8 +743,9 @@ namespace MonoTorrent
                     files.Add (new TorrentFile (path, length, 0, 0, 0));
                 } else {
                     totalPieces++;
+                    var offsetInTorrent = (files.LastOrDefault ()?.OffsetInTorrent ?? 0) + (files.LastOrDefault ()?.Length ?? 0);
                     var piecesRoot = data.TryGetValue ("pieces root", out var value) ? ((BEncodedString) value).AsMemory () : ReadOnlyMemory<byte>.Empty;
-                    files.Add (new TorrentFile (path, length, totalPieces, totalPieces + (int) (length / pieceLength), pieceLength * totalPieces, piecesRoot));
+                    files.Add (new TorrentFile (path, length, totalPieces, totalPieces + (int) (length / pieceLength), offsetInTorrent, piecesRoot));
                     totalPieces = files.Last ().EndPieceIndex;
                 }
             } else {

--- a/src/MonoTorrent.Client/MonoTorrent/Torrent.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/Torrent.cs
@@ -40,7 +40,7 @@ using MonoTorrent.BEncoding;
 
 namespace MonoTorrent
 {
-    public sealed class Torrent : IEquatable<Torrent>
+    public sealed class Torrent : ITorrentInfo, IEquatable<Torrent>
     {
         static Dictionary<int, ReadOnlyMemory<byte>> FinalLayerHash { get; } = CreateFinalHashPerLayer ();
 
@@ -263,7 +263,7 @@ namespace MonoTorrent
         /// <summary>
         /// The list of files contained within the .torrent which are available for download
         /// </summary>
-        public IList<TorrentFile> Files { get; private set; }
+        public IList<ITorrentFile> Files { get; private set; }
 
         /// <summary>
         /// This is the http-based seeding (getright protocole)
@@ -491,11 +491,8 @@ namespace MonoTorrent
                 long length = long.Parse (dictionary["length"].ToString ());
                 Size = length;
                 string path = Name;
-                var md5 = dictionary.TryGetValue("md5", out BEncodedValue value) ? ((BEncodedString) value).AsMemory () : ReadOnlyMemory<byte>.Empty;
-                var ed2k = dictionary.TryGetValue ("ed2k", out value) ? ((BEncodedString) value).AsMemory () : ReadOnlyMemory<byte>.Empty;
-                var sha1 = dictionary.TryGetValue ("sha1", out value) ? ((BEncodedString) value).AsMemory () : ReadOnlyMemory<byte>.Empty;
                 int endPiece = Math.Min (PieceCount - 1, (int) ((Size + (PieceLength - 1)) / PieceLength));
-                Files = Array.AsReadOnly (new[] { new TorrentFile (path, length, 0, endPiece, 0, md5, ed2k, sha1) });
+                Files = Array.AsReadOnly<ITorrentFile> (new[] { new TorrentFile (path, length, 0, endPiece, 0) });
             }
         }
 
@@ -633,7 +630,7 @@ namespace MonoTorrent
             }
         }
 
-        static IList<TorrentFile> LoadTorrentFilesV1 (BEncodedList list, int pieceLength)
+        static IList<ITorrentFile> LoadTorrentFilesV1 (BEncodedList list, int pieceLength)
         {
             var sb = new StringBuilder (32);
 
@@ -692,10 +689,10 @@ namespace MonoTorrent
                 files.Add ((path, length, md5sum, ed2k, sha1));
             }
 
-            return Array.AsReadOnly (TorrentFile.Create (pieceLength, files.ToArray ()));
+            return Array.AsReadOnly<ITorrentFile> (TorrentFile.Create (pieceLength, files.ToArray ()));
         }
 
-        static PieceHashesV2 LoadHashesV2 (IList<TorrentFile> files, BEncodedDictionary hashes, int actualPieceLength)
+        static PieceHashesV2 LoadHashesV2 (IList<ITorrentFile> files, BEncodedDictionary hashes, int actualPieceLength)
         {
             using var hasher = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
 
@@ -738,16 +735,16 @@ namespace MonoTorrent
             return new PieceHashesV2 (files, hashes);
         }
 
-        static void LoadTorrentFilesV2 (string key, BEncodedDictionary data, List<TorrentFile> files, int pieceLength, ref int totalPieces, string path)
+        static void LoadTorrentFilesV2 (string key, BEncodedDictionary data, List<ITorrentFile> files, int pieceLength, ref int totalPieces, string path)
         {
             if (key == "") {
                 var length = ((BEncodedNumber) data["length"]).Number;
                 if (length == 0) {
-                    files.Add (new TorrentFile (path, length, 0, 0, 0, default, default, default));
+                    files.Add (new TorrentFile (path, length, 0, 0, 0));
                 } else {
                     totalPieces++;
                     var piecesRoot = data.TryGetValue ("pieces root", out var value) ? ((BEncodedString) value).AsMemory () : ReadOnlyMemory<byte>.Empty;
-                    files.Add (new TorrentFile (path, length, totalPieces, totalPieces + (int) (length / pieceLength), pieceLength * totalPieces, default, default, default, piecesRoot));
+                    files.Add (new TorrentFile (path, length, totalPieces, totalPieces + (int) (length / pieceLength), pieceLength * totalPieces, piecesRoot));
                     totalPieces = files.Last ().EndPieceIndex;
                 }
             } else {
@@ -757,9 +754,9 @@ namespace MonoTorrent
             }
         }
 
-        static IList<TorrentFile> LoadTorrentFilesV2 (BEncodedDictionary fileTree, int pieceLength)
+        static IList<ITorrentFile> LoadTorrentFilesV2 (BEncodedDictionary fileTree, int pieceLength)
         {
-            var files = new List<TorrentFile> ();
+            var files = new List<ITorrentFile> ();
             int totalPieces = -1;
             foreach (var entry in fileTree)
                 LoadTorrentFilesV2 (entry.Key.Text, (BEncodedDictionary) entry.Value, files, pieceLength, ref totalPieces, "");

--- a/src/MonoTorrent.Client/MonoTorrent/TorrentCreator.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/TorrentCreator.cs
@@ -46,7 +46,7 @@ namespace MonoTorrent
 {
     public class TorrentCreator : EditableTorrent
     {
-        internal class InputFile : ITorrentFileInfo
+        internal class InputFile : ITorrentManagerFile
         {
             public string DownloadCompleteFullPath { get; }
             public string DownloadIncompleteFullPath { get; }
@@ -55,6 +55,7 @@ namespace MonoTorrent
             public byte[] MD5 { get; set; }
             public SemaphoreSlim Locker { get; } = new SemaphoreSlim (1, 1);
             public long Length { get; set; }
+            public ReadOnlyMemory<byte> PiecesRoot { get; }
 
             internal InputFile (string path, long length)
                 : this (path, path, length)
@@ -106,7 +107,7 @@ namespace MonoTorrent
             return RecommendedPieceSize (files.Sum (f => new FileInfo (f).Length));
         }
 
-        public static int RecommendedPieceSize (IEnumerable<ITorrentFileInfo> files)
+        public static int RecommendedPieceSize (IEnumerable<ITorrentManagerFile> files)
         {
             return RecommendedPieceSize (files.Sum (f => f.Length));
         }

--- a/src/MonoTorrent.Client/MonoTorrent/TorrentFileExtensions.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/TorrentFileExtensions.cs
@@ -5,7 +5,7 @@ namespace MonoTorrent
 {
     static class TorrentFileExtensions
     {
-        static readonly Func<ITorrentFileInfo, long, int> OffsetComparator = (file, offset) => {
+        static readonly Func<ITorrentManagerFile, long, int> OffsetComparator = (file, offset) => {
             var fileStart = file.OffsetInTorrent;
             var fileEnd = fileStart + file.Length;
             if (offset >= fileStart && offset < fileEnd)
@@ -16,7 +16,7 @@ namespace MonoTorrent
                 return 1;
         };
 
-        static readonly Func<ITorrentFileInfo, int, int> PieceIndexComparator = (file, pieceIndex) => {
+        static readonly Func<ITorrentManagerFile, int, int> PieceIndexComparator = (file, pieceIndex) => {
             if (pieceIndex >= file.StartPieceIndex && pieceIndex <= file.EndPieceIndex)
                 return 0;
             if (pieceIndex > file.EndPieceIndex)
@@ -31,7 +31,7 @@ namespace MonoTorrent
         /// <param name="files"></param>
         /// <param name="offset"></param>
         /// <returns></returns>
-        internal static int FindFileByOffset (this IList<ITorrentFileInfo> files, long offset)
+        internal static int FindFileByOffset (this IList<ITorrentManagerFile> files, long offset)
         {
             var firstMatch = files.BinarySearch (OffsetComparator, offset);
             while (firstMatch > 0) {
@@ -51,7 +51,7 @@ namespace MonoTorrent
         /// <param name="files"></param>
         /// <param name="pieceIndex"></param>
         /// <returns></returns>
-        internal static int FindFileByPieceIndex (this IList<ITorrentFileInfo> files, int pieceIndex)
+        internal static int FindFileByPieceIndex (this IList<ITorrentManagerFile> files, int pieceIndex)
         {
             var firstMatch = files.BinarySearch (PieceIndexComparator, (pieceIndex));
             while (firstMatch > 0) {

--- a/src/MonoTorrent.Messages/MonoTorrent.Messages.Peer.Libtorrent/ExtensionMessage.cs
+++ b/src/MonoTorrent.Messages/MonoTorrent.Messages.Peer.Libtorrent/ExtensionMessage.cs
@@ -35,7 +35,7 @@ namespace MonoTorrent.Messages.Peer.Libtorrent
     public abstract class ExtensionMessage : PeerMessage
     {
         internal static readonly byte MessageId = 20;
-        static readonly Dictionary<byte, Func<ITorrentData, (PeerMessage, Releaser)>> messageDict;
+        static readonly Dictionary<byte, Func<ITorrentManagerInfo, (PeerMessage, Releaser)>> messageDict;
 
         internal static readonly List<ExtensionSupport> SupportedMessages = new List<ExtensionSupport> ();
 
@@ -47,7 +47,7 @@ namespace MonoTorrent.Messages.Peer.Libtorrent
             // Actual decoding is handled with manual detection.
             Register<ExtensionMessage> (MessageId, data => throw new MessageException ("Shouldn't decode extension message this way"), false);
 
-            messageDict = new Dictionary<byte, Func<ITorrentData, (PeerMessage, Releaser)>> ();
+            messageDict = new Dictionary<byte, Func<ITorrentManagerInfo, (PeerMessage, Releaser)>> ();
 
             byte id = Register (data => new ExtendedHandshakeMessage (), false);
             if (id != 0)
@@ -68,7 +68,7 @@ namespace MonoTorrent.Messages.Peer.Libtorrent
             ExtensionId = messageId;
         }
 
-        public static byte Register<T> (Func<ITorrentData, T> creator, bool reusable)
+        public static byte Register<T> (Func<ITorrentManagerInfo, T> creator, bool reusable)
             where T : PeerMessage
         {
             if (creator == null)
@@ -76,7 +76,7 @@ namespace MonoTorrent.Messages.Peer.Libtorrent
 
             lock (messageDict) {
                 byte id = (byte) messageDict.Count;
-                Func<ITorrentData, (PeerMessage, Releaser)> wrapper;
+                Func<ITorrentManagerInfo, (PeerMessage, Releaser)> wrapper;
                 if (reusable) {
                     lock (InstanceCache)
                         InstanceCache[typeof (T)] = new Queue<PeerMessage> ();
@@ -93,9 +93,9 @@ namespace MonoTorrent.Messages.Peer.Libtorrent
             return SupportedMessages.Find (s => s.Name == name);
         }
 
-        public static (PeerMessage message, Releaser releaser) DecodeExtensionMessage (ReadOnlySpan<byte> buffer, ITorrentData manager)
+        public static (PeerMessage message, Releaser releaser) DecodeExtensionMessage (ReadOnlySpan<byte> buffer, ITorrentManagerInfo manager)
         {
-            if (!messageDict.TryGetValue (buffer[0], out Func<ITorrentData, (PeerMessage, Releaser)> creator))
+            if (!messageDict.TryGetValue (buffer[0], out Func<ITorrentManagerInfo, (PeerMessage, Releaser)> creator))
                 throw new MessageException ("Unknown extension message received");
 
             (PeerMessage message, Releaser releaser) = creator (manager);

--- a/src/MonoTorrent.Messages/MonoTorrent.Messages.Peer/PeerMessage.cs
+++ b/src/MonoTorrent.Messages/MonoTorrent.Messages.Peer/PeerMessage.cs
@@ -67,7 +67,7 @@ namespace MonoTorrent.Messages.Peer
         int ReuseId;
 
         private protected static readonly Dictionary<Type, Queue<PeerMessage>> InstanceCache;
-        static readonly Dictionary<byte, Func<ITorrentData, (PeerMessage, Releaser)>> messageDict;
+        static readonly Dictionary<byte, Func<ITorrentManagerInfo, (PeerMessage, Releaser)>> messageDict;
 
         static PeerMessage ()
         {
@@ -77,7 +77,7 @@ namespace MonoTorrent.Messages.Peer
                 { typeof (MessageBundle), new Queue<PeerMessage> () },
                 { typeof (RequestBundle), new Queue<PeerMessage> () }
             };
-            messageDict = new Dictionary<byte, Func<ITorrentData, (PeerMessage, Releaser)>> ();
+            messageDict = new Dictionary<byte, Func<ITorrentManagerInfo, (PeerMessage, Releaser)>> ();
 
             // Note - KeepAlive messages aren't registered as they have no payload or ID and are never 'decoded'
             //      - Handshake messages aren't registered as they are always the first message sent/received
@@ -133,17 +133,17 @@ namespace MonoTorrent.Messages.Peer
             return releaser;
         }
 
-        static void Register<T> (byte identifier, Func<ITorrentData, T> creator)
+        static void Register<T> (byte identifier, Func<ITorrentManagerInfo, T> creator)
             where T: PeerMessage
             => Register (identifier, creator, false);
 
-        private protected static void Register<T> (byte identifier, Func<ITorrentData, T> creator, bool reusable)
+        private protected static void Register<T> (byte identifier, Func<ITorrentManagerInfo, T> creator, bool reusable)
             where T : PeerMessage
         {
             if (creator == null)
                 throw new ArgumentNullException (nameof (creator));
 
-            Func<ITorrentData, (PeerMessage, Releaser)> wrapper;
+            Func<ITorrentManagerInfo, (PeerMessage, Releaser)> wrapper;
             if (reusable) {
                 lock (InstanceCache)
                     InstanceCache[typeof (T)] = new Queue<PeerMessage> ();
@@ -156,7 +156,7 @@ namespace MonoTorrent.Messages.Peer
                 messageDict.Add (identifier, wrapper);
         }
 
-        public static (PeerMessage message, Releaser releaser) DecodeMessage (ReadOnlySpan<byte> buffer, ITorrentData manager)
+        public static (PeerMessage message, Releaser releaser) DecodeMessage (ReadOnlySpan<byte> buffer, ITorrentManagerInfo manager)
         {
             if (buffer.Length < 4)
                 throw new ArgumentException ("A message must contain a 4 byte length prefix");
@@ -168,7 +168,7 @@ namespace MonoTorrent.Messages.Peer
             if (buffer[0] == ExtensionMessage.MessageId)
                 return ExtensionMessage.DecodeExtensionMessage (buffer.Slice (1), manager);
 
-            if (!messageDict.TryGetValue (buffer[0], out Func<ITorrentData, (PeerMessage, Releaser)> creator))
+            if (!messageDict.TryGetValue (buffer[0], out Func<ITorrentManagerInfo, (PeerMessage, Releaser)> creator))
                 throw new MessageException ("Unknown message received");
 
             // The message length is given in the second byte and the message body follows directly after that

--- a/src/MonoTorrent.PiecePicking/MonoTorrent.PiecePicking/IPiecePicker.cs
+++ b/src/MonoTorrent.PiecePicking/MonoTorrent.PiecePicking/IPiecePicker.cs
@@ -91,7 +91,7 @@ namespace MonoTorrent.PiecePicking
         /// Reset all internal state.
         /// </summary>
         /// <param name="torrentData"></param>
-        void Initialise (ITorrentData torrentData);
+        void Initialise (ITorrentManagerInfo torrentData);
 
         /// <summary>
         /// 

--- a/src/MonoTorrent.PiecePicking/MonoTorrent.PiecePicking/PiecePickerFilter.cs
+++ b/src/MonoTorrent.PiecePicking/MonoTorrent.PiecePicking/PiecePickerFilter.cs
@@ -60,7 +60,7 @@ namespace MonoTorrent.PiecePicking
         public IList<ActivePieceRequest> ExportActiveRequests ()
             => Next.ExportActiveRequests ();
 
-        public virtual void Initialise (ITorrentData torrentData)
+        public virtual void Initialise (ITorrentManagerInfo torrentData)
             => Next.Initialise (torrentData);
 
         public virtual bool IsInteresting (IPeer peer, BitField bitfield)

--- a/src/MonoTorrent.PiecePicking/MonoTorrent.PiecePicking/PriorityPicker.cs
+++ b/src/MonoTorrent.PiecePicking/MonoTorrent.PiecePicking/PriorityPicker.cs
@@ -37,9 +37,9 @@ namespace MonoTorrent.PiecePicking
         class Files : IComparable<Files>
         {
             public Priority Priority { get; private set; }
-            public ITorrentFileInfo File;
+            public ITorrentManagerFile File;
 
-            public Files (ITorrentFileInfo file)
+            public Files (ITorrentManagerFile file)
             {
                 Priority = file.Priority;
                 File = file;
@@ -71,7 +71,7 @@ namespace MonoTorrent.PiecePicking
             AllSamePriority = file => file.Priority == files[0].Priority;
         }
 
-        public override void Initialise (ITorrentData torrentData)
+        public override void Initialise (ITorrentManagerInfo torrentData)
         {
             base.Initialise (torrentData);
 

--- a/src/MonoTorrent.PiecePicking/MonoTorrent.PiecePicking/RarestFirstPicker.cs
+++ b/src/MonoTorrent.PiecePicking/MonoTorrent.PiecePicking/RarestFirstPicker.cs
@@ -44,7 +44,7 @@ namespace MonoTorrent.PiecePicking
             spares = new Stack<MutableBitField> ();
         }
 
-        public override void Initialise (ITorrentData torrentData)
+        public override void Initialise (ITorrentManagerInfo torrentData)
         {
             base.Initialise (torrentData);
             rarest.Clear ();

--- a/src/MonoTorrent.PiecePicking/MonoTorrent.PiecePicking/StandardPicker.cs
+++ b/src/MonoTorrent.PiecePicking/MonoTorrent.PiecePicking/StandardPicker.cs
@@ -111,7 +111,7 @@ namespace MonoTorrent.PiecePicking
 
         MutableBitField CanRequestBitField;
         PickedPieces Requests { get; set; }
-        ITorrentData TorrentData { get; set; }
+        ITorrentManagerInfo TorrentData { get; set; }
 
         public StandardPicker ()
         {
@@ -205,7 +205,7 @@ namespace MonoTorrent.PiecePicking
             return list;
         }
 
-        public void Initialise (ITorrentData torrentData)
+        public void Initialise (ITorrentManagerInfo torrentData)
         {
             TorrentData = torrentData;
             CanRequestBitField = new MutableBitField (torrentData.PieceCount ());

--- a/src/MonoTorrent.PiecePicking/MonoTorrent.PiecePicking/StandardPieceRequester.cs
+++ b/src/MonoTorrent.PiecePicking/MonoTorrent.PiecePicking/StandardPieceRequester.cs
@@ -37,12 +37,12 @@ namespace MonoTorrent.PiecePicking
         IReadOnlyList<BitField> IgnorableBitfields { get; set; }
         Memory<BlockInfo> RequestBufferCache { get; set; }
         MutableBitField Temp { get; set; }
-        ITorrentData TorrentData { get; set; }
+        ITorrentManagerInfo TorrentData { get; set; }
 
         public bool InEndgameMode { get; private set; }
         public IPiecePicker Picker { get; private set; }
 
-        public void Initialise (ITorrentData torrentData, IReadOnlyList<BitField> ignoringBitfields)
+        public void Initialise (ITorrentManagerInfo torrentData, IReadOnlyList<BitField> ignoringBitfields)
         {
             IgnorableBitfields = ignoringBitfields;
             TorrentData = torrentData;

--- a/src/MonoTorrent.PiecePicking/MonoTorrent.PiecePicking/StreamingPieceRequester.cs
+++ b/src/MonoTorrent.PiecePicking/MonoTorrent.PiecePicking/StreamingPieceRequester.cs
@@ -37,7 +37,7 @@ namespace MonoTorrent.PiecePicking
     {
         bool RefreshAfterSeeking = false;
 
-        ITorrentData TorrentData { get; set; }
+        ITorrentManagerInfo TorrentData { get; set; }
 
         IReadOnlyList<BitField> IgnoringBitfields { get; set; }
 
@@ -64,7 +64,7 @@ namespace MonoTorrent.PiecePicking
 
         MutableBitField Temp { get; set; }
 
-        public void Initialise (ITorrentData torrentData, IReadOnlyList<BitField> ignoringBitfields)
+        public void Initialise (ITorrentManagerInfo torrentData, IReadOnlyList<BitField> ignoringBitfields)
         {
             TorrentData = torrentData;
             IgnoringBitfields = ignoringBitfields;
@@ -246,7 +246,7 @@ namespace MonoTorrent.PiecePicking
         /// </summary>
         /// <param name="file"></param>
         /// <param name="position"></param>
-        public void SeekToPosition (ITorrentFileInfo file, long position)
+        public void SeekToPosition (ITorrentManagerFile file, long position)
         {
             // Update the high priority set, then cancel pending requests.
             var oldIndex = HighPriorityPieceIndex;
@@ -260,7 +260,7 @@ namespace MonoTorrent.PiecePicking
         /// </summary>
         /// <param name="file"></param>
         /// <param name="position"></param>
-        public void ReadToPosition (ITorrentFileInfo file, long position)
+        public void ReadToPosition (ITorrentManagerFile file, long position)
         {
             HighPriorityPieceIndex = Math.Min (file.EndPieceIndex, TorrentData.ByteOffsetToPieceIndex (position + file.OffsetInTorrent));
         }

--- a/src/MonoTorrent.PieceWriter/MonoTorrent.PieceWriter/DiskWriter.cs
+++ b/src/MonoTorrent.PieceWriter/MonoTorrent.PieceWriter/DiskWriter.cs
@@ -40,7 +40,7 @@ namespace MonoTorrent.PieceWriter
     {
         static readonly int DefaultMaxOpenFiles = 196;
 
-        static readonly Func<ITorrentFileInfo, FileAccess, Stream> DefaultStreamCreator =
+        static readonly Func<ITorrentManagerFile, FileAccess, Stream> DefaultStreamCreator =
             (file, access) => new FileStream (file.FullPath, FileMode.OpenOrCreate, access, FileShare.ReadWrite, 1, FileOptions.RandomAccess);
 
         SemaphoreSlim Limiter { get; set; }
@@ -55,7 +55,7 @@ namespace MonoTorrent.PieceWriter
 
         }
 
-        internal DiskWriter (Func<ITorrentFileInfo, FileAccess, Stream> streamCreator)
+        internal DiskWriter (Func<ITorrentManagerFile, FileAccess, Stream> streamCreator)
             : this (streamCreator, DefaultMaxOpenFiles)
         {
 
@@ -67,7 +67,7 @@ namespace MonoTorrent.PieceWriter
 
         }
 
-        internal DiskWriter (Func<ITorrentFileInfo, FileAccess, Stream> streamCreator, int maxOpenFiles)
+        internal DiskWriter (Func<ITorrentManagerFile, FileAccess, Stream> streamCreator, int maxOpenFiles)
         {
             StreamCache = new FileStreamBuffer (streamCreator, maxOpenFiles);
             Limiter = new SemaphoreSlim (maxOpenFiles);
@@ -78,20 +78,20 @@ namespace MonoTorrent.PieceWriter
             StreamCache.Dispose ();
         }
 
-        public async ReusableTask CloseAsync (ITorrentFileInfo file)
+        public async ReusableTask CloseAsync (ITorrentManagerFile file)
         {
             await StreamCache.CloseStreamAsync (file);
         }
 
-        public ReusableTask<bool> ExistsAsync (ITorrentFileInfo file)
+        public ReusableTask<bool> ExistsAsync (ITorrentManagerFile file)
         {
             return ReusableTask.FromResult (File.Exists (file.FullPath));
         }
 
-        public async ReusableTask FlushAsync (ITorrentFileInfo file)
+        public async ReusableTask FlushAsync (ITorrentManagerFile file)
             => await StreamCache.FlushAsync (file);
 
-        public async ReusableTask MoveAsync (ITorrentFileInfo file, string newPath, bool overwrite)
+        public async ReusableTask MoveAsync (ITorrentManagerFile file, string newPath, bool overwrite)
         {
             await StreamCache.CloseStreamAsync (file);
 
@@ -103,7 +103,7 @@ namespace MonoTorrent.PieceWriter
             }
         }
 
-        public async ReusableTask<int> ReadAsync (ITorrentFileInfo file, long offset, Memory<byte> buffer)
+        public async ReusableTask<int> ReadAsync (ITorrentManagerFile file, long offset, Memory<byte> buffer)
         {
             if (file is null)
                 throw new ArgumentNullException (nameof (file));
@@ -124,7 +124,7 @@ namespace MonoTorrent.PieceWriter
             }
         }
 
-        public async ReusableTask WriteAsync (ITorrentFileInfo file, long offset, ReadOnlyMemory<byte> buffer)
+        public async ReusableTask WriteAsync (ITorrentManagerFile file, long offset, ReadOnlyMemory<byte> buffer)
         {
             if (file is null)
                 throw new ArgumentNullException (nameof (file));

--- a/src/MonoTorrent.PieceWriter/MonoTorrent.PieceWriter/IPieceWriterExtensions.cs
+++ b/src/MonoTorrent.PieceWriter/MonoTorrent.PieceWriter/IPieceWriterExtensions.cs
@@ -35,7 +35,7 @@ namespace MonoTorrent.PieceWriter
 {
     static class IPieceWriterExtensions
     {
-        public static async ReusableTask<int> ReadFromFilesAsync (this IPieceWriter writer, ITorrentData manager, BlockInfo request, Memory<byte> buffer)
+        public static async ReusableTask<int> ReadFromFilesAsync (this IPieceWriter writer, ITorrentManagerInfo manager, BlockInfo request, Memory<byte> buffer)
         {
             var count = request.RequestLength;
             var offset = request.ToByteOffset (manager.PieceLength);
@@ -69,7 +69,7 @@ namespace MonoTorrent.PieceWriter
             return totalRead;
         }
 
-        public static async ReusableTask WriteToFilesAsync (this IPieceWriter writer, ITorrentData manager, BlockInfo request, Memory<byte> buffer)
+        public static async ReusableTask WriteToFilesAsync (this IPieceWriter writer, ITorrentManagerInfo manager, BlockInfo request, Memory<byte> buffer)
         {
             var count = request.RequestLength;
             var torrentOffset = request.ToByteOffset (manager.PieceLength);

--- a/src/MonoTorrent.PieceWriter/MonoTorrent.PieceWriter/MemoryCache.cs
+++ b/src/MonoTorrent.PieceWriter/MonoTorrent.PieceWriter/MemoryCache.cs
@@ -107,7 +107,7 @@ namespace MonoTorrent.PieceWriter
         /// <summary>
         /// The blocks which have been cached in memory
         /// </summary>
-        Dictionary<ITorrentData, List<CachedBlock>> CachedBlocks { get; }
+        Dictionary<ITorrentManagerInfo, List<CachedBlock>> CachedBlocks { get; }
 
         /// <summary>
         /// The size of the in memory cache, in bytes.
@@ -125,10 +125,10 @@ namespace MonoTorrent.PieceWriter
             Capacity = capacity;
             Writer = writer ?? throw new ArgumentNullException (nameof (writer));
 
-            CachedBlocks = new Dictionary<ITorrentData, List<CachedBlock>> ();
+            CachedBlocks = new Dictionary<ITorrentManagerInfo, List<CachedBlock>> ();
         }
 
-        public async ReusableTask<bool> ReadAsync (ITorrentData torrent, BlockInfo block, Memory<byte> buffer)
+        public async ReusableTask<bool> ReadAsync (ITorrentManagerInfo torrent, BlockInfo block, Memory<byte> buffer)
         {
             if (await ReadFromCacheAsync (torrent, block, buffer))
                 return true;
@@ -137,7 +137,7 @@ namespace MonoTorrent.PieceWriter
             return await ReadFromFilesAsync (torrent, block, buffer).ConfigureAwait (false) == block.RequestLength;
         }
 
-        public ReusableTask<bool> ReadFromCacheAsync (ITorrentData torrent, BlockInfo block, Memory<byte> buffer)
+        public ReusableTask<bool> ReadFromCacheAsync (ITorrentManagerInfo torrent, BlockInfo block, Memory<byte> buffer)
         {
             if (torrent == null)
                 throw new ArgumentNullException (nameof (torrent));
@@ -162,7 +162,7 @@ namespace MonoTorrent.PieceWriter
             return ReusableTask.FromResult (false);
         }
 
-        async void FlushBlockAsync (ITorrentData torrent, List<CachedBlock> blocks, CachedBlock cached)
+        async void FlushBlockAsync (ITorrentManagerInfo torrent, List<CachedBlock> blocks, CachedBlock cached)
         {
             // FIXME: How do we handle failures from this?
             using (cached.BufferReleaser) {
@@ -184,7 +184,7 @@ namespace MonoTorrent.PieceWriter
             return ReusableTask.CompletedTask;
         }
 
-        public async ReusableTask WriteAsync (ITorrentData torrent, BlockInfo block, Memory<byte> buffer, bool preferSkipCache)
+        public async ReusableTask WriteAsync (ITorrentManagerInfo torrent, BlockInfo block, Memory<byte> buffer, bool preferSkipCache)
         {
             if (preferSkipCache || Capacity < block.RequestLength) {
                 await WriteToFilesAsync (torrent, block, buffer);
@@ -234,13 +234,13 @@ namespace MonoTorrent.PieceWriter
             return -1;
         }
 
-        ReusableTask<int> ReadFromFilesAsync (ITorrentData torrent, BlockInfo block, Memory<byte> buffer)
+        ReusableTask<int> ReadFromFilesAsync (ITorrentManagerInfo torrent, BlockInfo block, Memory<byte> buffer)
         {
             ReadThroughCache?.Invoke (this, block);
             return Writer.ReadFromFilesAsync (torrent, block, buffer);
         }
 
-        ReusableTask WriteToFilesAsync (ITorrentData torrent, BlockInfo block, Memory<byte> buffer)
+        ReusableTask WriteToFilesAsync (ITorrentManagerInfo torrent, BlockInfo block, Memory<byte> buffer)
         {
             WrittenThroughCache?.Invoke (this, block);
             return Writer.WriteToFilesAsync (torrent, block, buffer);

--- a/src/MonoTorrent/MonoTorrent.PiecePicking/IPieceRequester.cs
+++ b/src/MonoTorrent/MonoTorrent.PiecePicking/IPieceRequester.cs
@@ -83,7 +83,7 @@ namespace MonoTorrent.PiecePicking
         /// downloaded and passed a hash check, pieces which have successfully downloaded but have not hash checked yet or
         /// pieces which have not yet been hash checked by the library and so it is not known whether they should be requested or not.
         /// </param>
-        void Initialise (ITorrentData torrentData, IReadOnlyList<BitField> ignorableBitfields);
+        void Initialise (ITorrentManagerInfo torrentData, IReadOnlyList<BitField> ignorableBitfields);
 
         IList<BlockInfo> CancelRequests (IPeer peer, int startIndex, int endIndex);
 

--- a/src/MonoTorrent/MonoTorrent.PiecePicking/IStreamingPieceRequester.cs
+++ b/src/MonoTorrent/MonoTorrent.PiecePicking/IStreamingPieceRequester.cs
@@ -39,7 +39,7 @@ namespace MonoTorrent.PiecePicking
         /// </summary>
         /// <param name="file"></param>
         /// <param name="position"></param>
-        void SeekToPosition (ITorrentFileInfo file, long position);
+        void SeekToPosition (ITorrentManagerFile file, long position);
 
         /// <summary>
         /// Inform the picker that we have sequentially read data and so will need to update the high priority set without
@@ -47,6 +47,6 @@ namespace MonoTorrent.PiecePicking
         /// </summary>
         /// <param name="file"></param>
         /// <param name="position"></param>
-        void ReadToPosition (ITorrentFileInfo file, long position);
+        void ReadToPosition (ITorrentManagerFile file, long position);
     }
 }

--- a/src/MonoTorrent/MonoTorrent.PieceWriter/IBlockCache.cs
+++ b/src/MonoTorrent/MonoTorrent.PieceWriter/IBlockCache.cs
@@ -82,7 +82,7 @@ namespace MonoTorrent.PieceWriter
         /// <param name="block"></param>
         /// <param name="buffer"></param>
         /// <returns></returns>
-        ReusableTask<bool> ReadAsync (ITorrentData torrent, BlockInfo block, Memory<byte> buffer);
+        ReusableTask<bool> ReadAsync (ITorrentManagerInfo torrent, BlockInfo block, Memory<byte> buffer);
 
         /// <summary>
         /// If the block of data is available in the cache, the data is read into the buffer and the method returns true.
@@ -92,7 +92,7 @@ namespace MonoTorrent.PieceWriter
         /// <param name="block"></param>
         /// <param name="buffer"></param>
         /// <returns></returns>
-        ReusableTask<bool> ReadFromCacheAsync (ITorrentData torrent, BlockInfo block, Memory<byte> buffer);
+        ReusableTask<bool> ReadFromCacheAsync (ITorrentManagerInfo torrent, BlockInfo block, Memory<byte> buffer);
 
         /// <summary>
         /// Set the max capacity, in bytes.
@@ -111,6 +111,6 @@ namespace MonoTorrent.PieceWriter
         /// <param name="buffer"></param>
         /// <param name="preferSkipCache"></param>
         /// <returns></returns>
-        ReusableTask WriteAsync (ITorrentData torrent, BlockInfo block, Memory<byte> buffer, bool preferSkipCache);
+        ReusableTask WriteAsync (ITorrentManagerInfo torrent, BlockInfo block, Memory<byte> buffer, bool preferSkipCache);
     }
 }

--- a/src/MonoTorrent/MonoTorrent.PieceWriter/IPieceWriter.cs
+++ b/src/MonoTorrent/MonoTorrent.PieceWriter/IPieceWriter.cs
@@ -37,12 +37,12 @@ namespace MonoTorrent.PieceWriter
     {
         int MaximumOpenFiles { get; }
 
-        ReusableTask CloseAsync (ITorrentFileInfo file);
-        ReusableTask<bool> ExistsAsync (ITorrentFileInfo file);
-        ReusableTask FlushAsync (ITorrentFileInfo file);
-        ReusableTask MoveAsync (ITorrentFileInfo file, string fullPath, bool overwrite);
-        ReusableTask<int> ReadAsync (ITorrentFileInfo file, long offset, Memory<byte> buffer);
-        ReusableTask WriteAsync (ITorrentFileInfo file, long offset, ReadOnlyMemory<byte> buffer);
+        ReusableTask CloseAsync (ITorrentManagerFile file);
+        ReusableTask<bool> ExistsAsync (ITorrentManagerFile file);
+        ReusableTask FlushAsync (ITorrentManagerFile file);
+        ReusableTask MoveAsync (ITorrentManagerFile file, string fullPath, bool overwrite);
+        ReusableTask<int> ReadAsync (ITorrentManagerFile file, long offset, Memory<byte> buffer);
+        ReusableTask WriteAsync (ITorrentManagerFile file, long offset, ReadOnlyMemory<byte> buffer);
         ReusableTask SetMaximumOpenFilesAsync (int maximumOpenFiles);
     }
 }

--- a/src/MonoTorrent/MonoTorrent/ITorrentFileInfo.cs
+++ b/src/MonoTorrent/MonoTorrent/ITorrentFileInfo.cs
@@ -29,7 +29,7 @@
 
 namespace MonoTorrent
 {
-    public interface ITorrentFileInfo : ITorrentFile
+    public interface ITorrentManagerFile : ITorrentFile
     {
         /// <summary>
         /// The <see cref="BitField"/> tracking which pieces of this file have been downloaded.
@@ -59,7 +59,7 @@ namespace MonoTorrent
 
     public static class ITorrentFileInfoExtensions
     {
-        public static long BytesDownloaded (this ITorrentFileInfo info)
+        public static long BytesDownloaded (this ITorrentManagerFile info)
             => (long) (info.BitField.PercentComplete * info.Length / 100.0);
     }
 }

--- a/src/MonoTorrent/MonoTorrent/ITorrentInfo.cs
+++ b/src/MonoTorrent/MonoTorrent/ITorrentInfo.cs
@@ -1,10 +1,10 @@
 ﻿//
-// DiskWriter.cs
+// ITorrentInfo.cs
 //
 // Authors:
 //   Alan McGovern alan.mcgovern@gmail.com
 //
-// Copyright (C) 2006 Alan McGovern
+// Copyright (C) 2022 Alan McGovern
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -31,14 +31,22 @@ using System.Collections.Generic;
 
 namespace MonoTorrent
 {
-    public interface ITorrentData
+    public interface ITorrentInfo
     {
         /// <summary>
         /// The files contained within the Torrent
         /// </summary>
-        IList<ITorrentFileInfo> Files { get; }
+        IList<ITorrentFile> Files { get; }
 
+        /// <summary>
+        /// The SHA1 hash for this torrent. Used by torrents which comply with the v1 specification, or hybrid v1/v2 torrents.
+        /// </summary>
         InfoHash InfoHash { get; }
+
+        /// <summary>
+        /// The SHA256 hash for this torrent. Used by torrents which comply with the v2 specification, or hybrid v1/v2 torrents.
+        /// </summary>
+        InfoHash InfoHashV2 { get; }
 
         /// <summary>
         /// The name of the Torrent.
@@ -56,9 +64,9 @@ namespace MonoTorrent
         long Size { get; }
     }
 
-    public static class ITorrentDataExtensions
+    public static class ITorrentInfoExtensions
     {
-        public static int BlocksPerPiece (this ITorrentData self, int pieceIndex)
+        public static int BlocksPerPiece (this ITorrentInfo self, int pieceIndex)
         {
             if (pieceIndex < self.PieceCount () - 1)
                 return (Constants.BlockSize - 1 + self.PieceLength) / Constants.BlockSize;
@@ -67,14 +75,14 @@ namespace MonoTorrent
             return (int) ((remainder + Constants.BlockSize - 1) / Constants.BlockSize);
         }
 
-        public static int BytesPerPiece (this ITorrentData self, int pieceIndex)
+        public static int BytesPerPiece (this ITorrentInfo self, int pieceIndex)
         {
             if (pieceIndex < self.PieceCount () - 1)
                 return self.PieceLength;
             return (int) (self.Size - self.PieceIndexToByteOffset (pieceIndex));
         }
 
-        public static int ByteOffsetToPieceIndex (this ITorrentData self, long offset)
+        public static int ByteOffsetToPieceIndex (this ITorrentInfo self, long offset)
             => (int) (offset / self.PieceLength);
 
         /// <summary>
@@ -82,10 +90,10 @@ namespace MonoTorrent
         /// </summary>
         /// <param name="self"></param>
         /// <returns></returns>
-        public static int PieceCount (this ITorrentData self)
+        public static int PieceCount (this ITorrentInfo self)
             => (int) ((self.Size + self.PieceLength - 1) / self.PieceLength);
 
-        public static long PieceIndexToByteOffset (this ITorrentData self, int pieceIndex)
+        public static long PieceIndexToByteOffset (this ITorrentInfo self, int pieceIndex)
             => (long) self.PieceLength * pieceIndex;
     }
 }

--- a/src/MonoTorrent/MonoTorrent/ITorrentManagerInfo.cs
+++ b/src/MonoTorrent/MonoTorrent/ITorrentManagerInfo.cs
@@ -1,10 +1,10 @@
 ﻿//
-// ITorrentFile.cs
+// ITorrentManagerInfo.cs
 //
 // Authors:
 //   Alan McGovern alan.mcgovern@gmail.com
 //
-// Copyright (C) 2020 Alan McGovern
+// Copyright (C) 2006 Alan McGovern
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -27,37 +27,15 @@
 //
 
 
-using System;
+using System.Collections.Generic;
 
 namespace MonoTorrent
 {
-    public interface ITorrentFile
+    public interface ITorrentManagerInfo : ITorrentInfo
     {
         /// <summary>
-        /// The relative path to the file within the torrent.
+        /// The files contained within the Torrent
         /// </summary>
-        string Path { get; }
-
-        /// <summary>
-        /// The first piece which contains data for this file
-        /// </summary>
-        int StartPieceIndex { get; }
-
-        /// <summary>
-        /// The last piece which contains data for this file.
-        /// </summary>
-        int EndPieceIndex { get; }
-
-        /// <summary>
-        /// The size of this file in bytes.
-        /// </summary>
-        long Length { get; }
-
-        /// <summary>
-        /// The offset, relative to the first byte in the torrent, where this file begins.
-        /// </summary>
-        long OffsetInTorrent { get; }
-
-        ReadOnlyMemory<byte> PiecesRoot { get; }
+        new IList<ITorrentManagerFile> Files { get; }
     }
 }

--- a/src/Samples/SampleClient/StressTest.cs
+++ b/src/Samples/SampleClient/StressTest.cs
@@ -20,7 +20,7 @@ namespace ClientSample
     {
         public int MaximumOpenFiles => 0;
 
-        public ReusableTask CloseAsync (ITorrentFileInfo file)
+        public ReusableTask CloseAsync (ITorrentManagerFile file)
         {
             return ReusableTask.CompletedTask;
         }
@@ -29,22 +29,22 @@ namespace ClientSample
         {
         }
 
-        public ReusableTask<bool> ExistsAsync (ITorrentFileInfo file)
+        public ReusableTask<bool> ExistsAsync (ITorrentManagerFile file)
         {
             return ReusableTask.FromResult (false);
         }
 
-        public ReusableTask FlushAsync (ITorrentFileInfo file)
+        public ReusableTask FlushAsync (ITorrentManagerFile file)
         {
             return ReusableTask.CompletedTask;
         }
 
-        public ReusableTask MoveAsync (ITorrentFileInfo file, string fullPath, bool overwrite)
+        public ReusableTask MoveAsync (ITorrentManagerFile file, string fullPath, bool overwrite)
         {
             return ReusableTask.CompletedTask;
         }
 
-        public ReusableTask<int> ReadAsync (ITorrentFileInfo file, long offset, Memory<byte> buffer)
+        public ReusableTask<int> ReadAsync (ITorrentManagerFile file, long offset, Memory<byte> buffer)
         {
             return ReusableTask.FromResult (0);
         }
@@ -54,7 +54,7 @@ namespace ClientSample
             return ReusableTask.CompletedTask;
         }
 
-        public ReusableTask WriteAsync (ITorrentFileInfo file, long offset, ReadOnlyMemory<byte> buffer)
+        public ReusableTask WriteAsync (ITorrentManagerFile file, long offset, ReadOnlyMemory<byte> buffer)
         {
             return ReusableTask.CompletedTask;
         }

--- a/src/Samples/TrackerApp/Main.cs
+++ b/src/Samples/TrackerApp/Main.cs
@@ -63,7 +63,7 @@ namespace TrackerSample
         /// <summary>
         /// The files in the torrent
         /// </summary>
-        public IList<TorrentFile> Files { get; }
+        public IList<ITorrentFile> Files { get; }
 
         /// <summary>
         /// The infohash of the torrent

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/MetadataModeTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/MetadataModeTests.cs
@@ -67,7 +67,7 @@ namespace MonoTorrent.Client.Modes
             rig.AddConnection (pair.Outgoing);
 
             var connection = pair.Incoming;
-            PeerId id = new PeerId (new Peer ("", connection.Uri), connection, new MutableBitField (rig.Manager.PieceCount ()));
+            PeerId id = new PeerId (new Peer ("", connection.Uri), connection, new MutableBitField (rig.Torrent.PieceCount));
 
             var result = await EncryptorFactory.CheckIncomingConnectionAsync (id.Connection, id.Peer.AllowedEncryption, new[] { rig.Manager.InfoHash }, Factories.Default);
             decryptor = id.Decryptor = result.Decryptor;

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/MetadataModeTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/MetadataModeTests.cs
@@ -137,7 +137,7 @@ namespace MonoTorrent.Client.Modes
         [Test]
         public async Task MetadataOnly_False_WithEvent ()
         {
-            var tcs = new TaskCompletionSource<IList<ITorrentFileInfo>> ();
+            var tcs = new TaskCompletionSource<IList<ITorrentManagerFile>> ();
             new CancellationTokenSource (Debugger.IsAttached ? 100_000 : 10_000)
                 .Token
                 .Register (() => tcs.TrySetCanceled ());
@@ -157,7 +157,7 @@ namespace MonoTorrent.Client.Modes
         [Test]
         public async Task MetadataOnly_False_WithTask ()
         {
-            var tcs = new TaskCompletionSource<IList<ITorrentFileInfo>> ();
+            var tcs = new TaskCompletionSource<IList<ITorrentManagerFile>> ();
             new CancellationTokenSource (Debugger.IsAttached ? 100_000 : 10_000)
                 .Token
                 .Register (() => tcs.TrySetCanceled ());

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/NullWriter.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/NullWriter.cs
@@ -11,7 +11,7 @@ namespace MonoTorrent.Client
     {
         public int MaximumOpenFiles { get; }
 
-        public ReusableTask CloseAsync (ITorrentFileInfo file)
+        public ReusableTask CloseAsync (ITorrentManagerFile file)
         {
             return ReusableTask.CompletedTask;
         }
@@ -20,22 +20,22 @@ namespace MonoTorrent.Client
         {
         }
 
-        public ReusableTask<bool> ExistsAsync (ITorrentFileInfo file)
+        public ReusableTask<bool> ExistsAsync (ITorrentManagerFile file)
         {
             return ReusableTask.FromResult (false);
         }
 
-        public ReusableTask FlushAsync (ITorrentFileInfo file)
+        public ReusableTask FlushAsync (ITorrentManagerFile file)
         {
             return ReusableTask.CompletedTask;
         }
 
-        public ReusableTask MoveAsync (ITorrentFileInfo file, string fullPath, bool overwrite)
+        public ReusableTask MoveAsync (ITorrentManagerFile file, string fullPath, bool overwrite)
         {
             return ReusableTask.CompletedTask;
         }
 
-        public ReusableTask<int> ReadAsync (ITorrentFileInfo file, long offset, Memory<byte> buffer)
+        public ReusableTask<int> ReadAsync (ITorrentManagerFile file, long offset, Memory<byte> buffer)
         {
             return ReusableTask.FromResult (0);
         }
@@ -45,7 +45,7 @@ namespace MonoTorrent.Client
             return ReusableTask.CompletedTask;
         }
 
-        public ReusableTask WriteAsync (ITorrentFileInfo file, long offset, ReadOnlyMemory<byte> buffer)
+        public ReusableTask WriteAsync (ITorrentManagerFile file, long offset, ReadOnlyMemory<byte> buffer)
         {
             return ReusableTask.CompletedTask;
         }

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/BlockingWriter.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/BlockingWriter.cs
@@ -12,13 +12,13 @@ namespace MonoTorrent.Client
         public BlockingCollection<(ITorrentFile file, ReusableTaskCompletionSource<object> tcs)> Closes = new BlockingCollection<(ITorrentFile file, ReusableTaskCompletionSource<object> tcs)> ();
         public BlockingCollection<(ITorrentFile file, ReusableTaskCompletionSource<bool> tcs)> Exists = new BlockingCollection<(ITorrentFile file, ReusableTaskCompletionSource<bool> tcs)> ();
         public BlockingCollection<(ITorrentFile file, ReusableTaskCompletionSource<object> tcs)> Flushes = new BlockingCollection<(ITorrentFile file, ReusableTaskCompletionSource<object> tcs)> ();
-        public BlockingCollection<(ITorrentFileInfo file, string fullPath, bool overwrite, ReusableTaskCompletionSource<object> tcs)> Moves = new BlockingCollection<(ITorrentFileInfo file, string fullPath, bool overwrite, ReusableTaskCompletionSource<object> tcs)> ();
-        public BlockingCollection<(ITorrentFileInfo file, long offset, Memory<byte> buffer, ReusableTaskCompletionSource<int> tcs)> Reads = new BlockingCollection<(ITorrentFileInfo file, long offset, Memory<byte> buffer, ReusableTaskCompletionSource<int> tcs)> ();
-        public BlockingCollection<(ITorrentFileInfo file, long offset, ReadOnlyMemory<byte> buffer, ReusableTaskCompletionSource<object> tcs)> Writes = new BlockingCollection<(ITorrentFileInfo file, long offset, ReadOnlyMemory<byte> buffer, ReusableTaskCompletionSource<object> tcs)> ();
+        public BlockingCollection<(ITorrentManagerFile file, string fullPath, bool overwrite, ReusableTaskCompletionSource<object> tcs)> Moves = new BlockingCollection<(ITorrentManagerFile file, string fullPath, bool overwrite, ReusableTaskCompletionSource<object> tcs)> ();
+        public BlockingCollection<(ITorrentManagerFile file, long offset, Memory<byte> buffer, ReusableTaskCompletionSource<int> tcs)> Reads = new BlockingCollection<(ITorrentManagerFile file, long offset, Memory<byte> buffer, ReusableTaskCompletionSource<int> tcs)> ();
+        public BlockingCollection<(ITorrentManagerFile file, long offset, ReadOnlyMemory<byte> buffer, ReusableTaskCompletionSource<object> tcs)> Writes = new BlockingCollection<(ITorrentManagerFile file, long offset, ReadOnlyMemory<byte> buffer, ReusableTaskCompletionSource<object> tcs)> ();
 
         public int MaximumOpenFiles => 0;
 
-        public async ReusableTask CloseAsync (ITorrentFileInfo file)
+        public async ReusableTask CloseAsync (ITorrentManagerFile file)
         {
             var tcs = new ReusableTaskCompletionSource<object> ();
             Closes.Add ((file, tcs));
@@ -29,27 +29,27 @@ namespace MonoTorrent.Client
         {
         }
 
-        public async ReusableTask<bool> ExistsAsync (ITorrentFileInfo file)
+        public async ReusableTask<bool> ExistsAsync (ITorrentManagerFile file)
         {
             var tcs = new ReusableTaskCompletionSource<bool> ();
             Exists.Add ((file, tcs));
             return await tcs.Task;
         }
 
-        public async ReusableTask FlushAsync (ITorrentFileInfo file)
+        public async ReusableTask FlushAsync (ITorrentManagerFile file)
         {
             var tcs = new ReusableTaskCompletionSource<object> ();
             Flushes.Add ((file, tcs));
             await tcs.Task;
         }
-        public async ReusableTask MoveAsync (ITorrentFileInfo file, string fullPath, bool overwrite)
+        public async ReusableTask MoveAsync (ITorrentManagerFile file, string fullPath, bool overwrite)
         {
             var tcs = new ReusableTaskCompletionSource<object> ();
             Moves.Add ((file, fullPath, overwrite, tcs));
             await tcs.Task;
         }
 
-        public async ReusableTask<int> ReadAsync (ITorrentFileInfo file, long offset, Memory<byte> buffer)
+        public async ReusableTask<int> ReadAsync (ITorrentManagerFile file, long offset, Memory<byte> buffer)
         {
             var tcs = new ReusableTaskCompletionSource<int> ();
             Reads.Add ((file, offset, buffer, tcs));
@@ -61,7 +61,7 @@ namespace MonoTorrent.Client
             return ReusableTask.CompletedTask;
         }
 
-        public async ReusableTask WriteAsync (ITorrentFileInfo file, long offset, ReadOnlyMemory<byte> buffer)
+        public async ReusableTask WriteAsync (ITorrentManagerFile file, long offset, ReadOnlyMemory<byte> buffer)
         {
             var tcs = new ReusableTaskCompletionSource<object> ();
             Writes.Add ((file, offset, buffer, tcs));

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/ConnectionFactoryTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/ConnectionFactoryTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using NUnit.Framework;
 
@@ -8,10 +9,12 @@ namespace MonoTorrent.Client
     [TestFixture]
     public class PeerConnectionFactoryTests
     {
-        class TorrentData : ITorrentData
+        class TorrentData : ITorrentManagerInfo
         {
-            public IList<ITorrentFileInfo> Files { get; }
+            IList<ITorrentFile> ITorrentInfo.Files => Files.ToArray<ITorrentFile> ();
+            public IList<ITorrentManagerFile> Files { get; }
             public InfoHash InfoHash { get; }
+            public InfoHash InfoHashV2 { get; } = new InfoHash (new byte[32]);
             public string Name { get; }
             public int PieceLength { get; }
             public long Size { get; }

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/DiskManagerExceptionTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/DiskManagerExceptionTests.cs
@@ -46,18 +46,18 @@ namespace MonoTorrent.Client
         {
             public bool exist, close, flush, move, read, write;
 
-            public List<ITorrentFileInfo> FlushedFiles = new List<ITorrentFileInfo> ();
+            public List<ITorrentManagerFile> FlushedFiles = new List<ITorrentManagerFile> ();
 
             public int MaximumOpenFiles { get; }
 
-            public ReusableTask CloseAsync (ITorrentFileInfo file)
+            public ReusableTask CloseAsync (ITorrentManagerFile file)
             {
                 if (close)
                     throw new Exception ("close");
                 return ReusableTask.CompletedTask;
             }
 
-            public ReusableTask<bool> ExistsAsync (ITorrentFileInfo file)
+            public ReusableTask<bool> ExistsAsync (ITorrentManagerFile file)
             {
                 if (exist)
                     throw new Exception ("exists");
@@ -69,7 +69,7 @@ namespace MonoTorrent.Client
 
             }
 
-            public ReusableTask FlushAsync (ITorrentFileInfo file)
+            public ReusableTask FlushAsync (ITorrentManagerFile file)
             {
                 if (flush)
                     throw new Exception ("flush");
@@ -77,21 +77,21 @@ namespace MonoTorrent.Client
                 return ReusableTask.CompletedTask;
             }
 
-            public ReusableTask MoveAsync (ITorrentFileInfo file, string newPath, bool overwrite)
+            public ReusableTask MoveAsync (ITorrentManagerFile file, string newPath, bool overwrite)
             {
                 if (move)
                     throw new Exception ("move");
                 return ReusableTask.CompletedTask;
             }
 
-            public ReusableTask<int> ReadAsync (ITorrentFileInfo file, long offset, Memory<byte> buffer)
+            public ReusableTask<int> ReadAsync (ITorrentManagerFile file, long offset, Memory<byte> buffer)
             {
                 if (read)
                     throw new Exception ("read");
                 return ReusableTask.FromResult (buffer.Length);
             }
 
-            public ReusableTask WriteAsync (ITorrentFileInfo file, long offset, ReadOnlyMemory<byte> buffer)
+            public ReusableTask WriteAsync (ITorrentManagerFile file, long offset, ReadOnlyMemory<byte> buffer)
             {
                 if (write)
                     throw new Exception ("write");
@@ -104,10 +104,12 @@ namespace MonoTorrent.Client
             }
         }
 
-        class TestTorrentData : ITorrentData
+        class TestTorrentData : ITorrentManagerInfo
         {
-            public IList<ITorrentFileInfo> Files { get; set; }
+            IList<ITorrentFile> ITorrentInfo.Files => Files.ToArray<ITorrentFile> ();
+            public IList<ITorrentManagerFile> Files { get; set; }
             public InfoHash InfoHash => new InfoHash (new byte[20]);
+            public InfoHash InfoHashV2 { get; } = new InfoHash (new byte[32]);
             public string Name => "Test Torrent";
             public int PieceLength { get; set; }
             public long Size { get; set; }

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/DiskManagerTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/DiskManagerTests.cs
@@ -96,7 +96,7 @@ namespace MonoTorrent.Client
             public IList<ITorrentManagerFile> Files { get; set; }
             public byte[][] Hashes { get; set; }
             public InfoHash InfoHash => new InfoHash (new byte[20]);
-            public InfoHash InfoHashV2 => new InfoHash (new byte[32]);
+            public InfoHash InfoHashV2 => null;
             public string Name => "Test Torrent";
             public int PieceLength { get; set; }
             public long Size { get; set; }

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/DiskManagerTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/DiskManagerTests.cs
@@ -46,7 +46,7 @@ namespace MonoTorrent.Client
     {
         public int MaximumOpenFiles { get; }
 
-        public ReusableTask CloseAsync (ITorrentFileInfo file)
+        public ReusableTask CloseAsync (ITorrentManagerFile file)
         {
             return ReusableTask.CompletedTask;
         }
@@ -55,22 +55,22 @@ namespace MonoTorrent.Client
         {
         }
 
-        public ReusableTask<bool> ExistsAsync (ITorrentFileInfo file)
+        public ReusableTask<bool> ExistsAsync (ITorrentManagerFile file)
         {
             return ReusableTask.FromResult (false);
         }
 
-        public ReusableTask FlushAsync (ITorrentFileInfo file)
+        public ReusableTask FlushAsync (ITorrentManagerFile file)
         {
             return ReusableTask.CompletedTask;
         }
 
-        public ReusableTask MoveAsync (ITorrentFileInfo file, string fullPath, bool overwrite)
+        public ReusableTask MoveAsync (ITorrentManagerFile file, string fullPath, bool overwrite)
         {
             return ReusableTask.CompletedTask;
         }
 
-        public ReusableTask<int> ReadAsync (ITorrentFileInfo file, long offset, Memory<byte> buffer)
+        public ReusableTask<int> ReadAsync (ITorrentManagerFile file, long offset, Memory<byte> buffer)
         {
             return ReusableTask.FromResult (0);
         }
@@ -80,7 +80,7 @@ namespace MonoTorrent.Client
             return ReusableTask.CompletedTask;
         }
 
-        public ReusableTask WriteAsync (ITorrentFileInfo file, long offset, ReadOnlyMemory<byte> buffer)
+        public ReusableTask WriteAsync (ITorrentManagerFile file, long offset, ReadOnlyMemory<byte> buffer)
         {
             return ReusableTask.CompletedTask;
         }
@@ -89,12 +89,14 @@ namespace MonoTorrent.Client
     [TestFixture]
     public class DiskManagerTests
     {
-        class TestTorrentData : ITorrentData
+        class TestTorrentData : ITorrentManagerInfo
         {
             public byte[][] Data { get; set; }
-            public IList<ITorrentFileInfo> Files { get; set; }
+            IList<ITorrentFile> ITorrentInfo.Files => Files.ToArray<ITorrentFile> ();
+            public IList<ITorrentManagerFile> Files { get; set; }
             public byte[][] Hashes { get; set; }
             public InfoHash InfoHash => new InfoHash (new byte[20]);
+            public InfoHash InfoHashV2 => new InfoHash (new byte[32]);
             public string Name => "Test Torrent";
             public int PieceLength { get; set; }
             public long Size { get; set; }
@@ -102,16 +104,16 @@ namespace MonoTorrent.Client
 
         class PieceWriter : IPieceWriter
         {
-            public Dictionary<ITorrentFileInfo, byte[]> Data = new Dictionary<ITorrentFileInfo, byte[]> ();
-            public readonly List<Tuple<ITorrentFileInfo, long, int>> ReadData = new List<Tuple<ITorrentFileInfo, long, int>> ();
-            public readonly List<Tuple<ITorrentFileInfo, long, byte[]>> WrittenData = new List<Tuple<ITorrentFileInfo, long, byte[]>> ();
+            public Dictionary<ITorrentManagerFile, byte[]> Data = new Dictionary<ITorrentManagerFile, byte[]> ();
+            public readonly List<Tuple<ITorrentManagerFile, long, int>> ReadData = new List<Tuple<ITorrentManagerFile, long, int>> ();
+            public readonly List<Tuple<ITorrentManagerFile, long, byte[]>> WrittenData = new List<Tuple<ITorrentManagerFile, long, byte[]>> ();
 
-            public List<ITorrentFileInfo> ClosedFiles = new List<ITorrentFileInfo> ();
-            public List<ITorrentFileInfo> ExistsFiles = new List<ITorrentFileInfo> ();
+            public List<ITorrentManagerFile> ClosedFiles = new List<ITorrentManagerFile> ();
+            public List<ITorrentManagerFile> ExistsFiles = new List<ITorrentManagerFile> ();
 
             public int MaximumOpenFiles { get; }
 
-            public ReusableTask<int> ReadAsync (ITorrentFileInfo file, long offset, Memory<byte> buffer)
+            public ReusableTask<int> ReadAsync (ITorrentManagerFile file, long offset, Memory<byte> buffer)
             {
                 ReadData.Add (Tuple.Create (file, offset, buffer.Length));
 
@@ -129,7 +131,7 @@ namespace MonoTorrent.Client
                 return ReusableTask.FromResult (buffer.Length);
             }
 
-            public ReusableTask WriteAsync (ITorrentFileInfo file, long offset, ReadOnlyMemory<byte> buffer)
+            public ReusableTask WriteAsync (ITorrentManagerFile file, long offset, ReadOnlyMemory<byte> buffer)
             {
                 var result = new byte[buffer.Length];
                 buffer.CopyTo (result.AsMemory ());
@@ -137,22 +139,22 @@ namespace MonoTorrent.Client
                 return ReusableTask.CompletedTask;
             }
 
-            public ReusableTask CloseAsync (ITorrentFileInfo file)
+            public ReusableTask CloseAsync (ITorrentManagerFile file)
             {
                 return ReusableTask.CompletedTask;
             }
 
-            public ReusableTask<bool> ExistsAsync (ITorrentFileInfo file)
+            public ReusableTask<bool> ExistsAsync (ITorrentManagerFile file)
             {
                 return ReusableTask.FromResult (true);
             }
 
-            public ReusableTask FlushAsync (ITorrentFileInfo file)
+            public ReusableTask FlushAsync (ITorrentManagerFile file)
             {
                 return ReusableTask.CompletedTask;
             }
 
-            public ReusableTask MoveAsync (ITorrentFileInfo file, string fullPath, bool overwrite)
+            public ReusableTask MoveAsync (ITorrentManagerFile file, string fullPath, bool overwrite)
             {
                 return ReusableTask.CompletedTask;
             }

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/FastResumeTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/FastResumeTests.cs
@@ -209,7 +209,7 @@ namespace MonoTorrent.Client
             File.WriteAllBytes (path, new FastResume (torrent.InfoHash, new MutableBitField (torrent.PieceCount).SetAll (true), new MutableBitField (torrent.PieceCount)).Encode ());
             var manager = await engine.AddAsync (torrent, "savedir");
             await engine.ChangePieceWriterAsync (new TestWriter {
-                FilesThatExist = new System.Collections.Generic.List<ITorrentFileInfo> (manager.Files)
+                FilesThatExist = new System.Collections.Generic.List<ITorrentManagerFile> (manager.Files)
             });
 
             Assert.IsTrue (manager.HashChecked);

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/ManualStream.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/ManualStream.cs
@@ -59,7 +59,7 @@ namespace MonoTorrent.Client.PieceWriters
 
         public TaskCompletionSource<int> WriteTcs { get; set; }
 
-        public ManualStream (ITorrentFileInfo file, FileAccess access)
+        public ManualStream (ITorrentManagerFile file, FileAccess access)
         {
             canWrite = access.HasFlag (FileAccess.Write);
         }

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/PieceManagerTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/PieceManagerTests.cs
@@ -29,6 +29,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 using MonoTorrent.Client;
@@ -40,10 +41,12 @@ namespace MonoTorrent.PiecePicking
     [TestFixture]
     public class PieceManagerTests
     {
-        class TestTorrentData : ITorrentData
+        class TestTorrentData : ITorrentManagerInfo
         {
-            public IList<ITorrentFileInfo> Files { get; set; }
+            IList<ITorrentFile> ITorrentInfo.Files => Files.ToArray<ITorrentFile> ();
+            public IList<ITorrentManagerFile> Files { get; set; }
             public InfoHash InfoHash => new InfoHash (new byte[20]);
+            public InfoHash InfoHashV2 => new InfoHash (new byte[32]);
             public string Name => "Test Torrent";
             public int PieceLength { get; set; }
             public long Size { get; set; }

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/TorrentDataExtensionsTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/TorrentDataExtensionsTests.cs
@@ -28,6 +28,7 @@
 
 
 using System.Collections.Generic;
+using System.Linq;
 
 using NUnit.Framework;
 
@@ -36,10 +37,12 @@ namespace MonoTorrent.Client
     [TestFixture]
     public class TorrentDataExtensionsTests
     {
-        class Data : ITorrentData
+        class Data : ITorrentManagerInfo
         {
-            public IList<ITorrentFileInfo> Files { get; set; }
+            IList<ITorrentFile> ITorrentInfo.Files => Files.ToArray<ITorrentFile> ();
+            public IList<ITorrentManagerFile> Files { get; set; }
             public InfoHash InfoHash => new InfoHash (new byte[20]);
+            public InfoHash InfoHashV2 => new InfoHash (new byte[32]);
             public string Name => "Test Torrent";
             public int PieceLength { get; set; }
             public long Size { get; set; }

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/TorrentDataExtensionsTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/TorrentDataExtensionsTests.cs
@@ -42,7 +42,7 @@ namespace MonoTorrent.Client
             IList<ITorrentFile> ITorrentInfo.Files => Files.ToArray<ITorrentFile> ();
             public IList<ITorrentManagerFile> Files { get; set; }
             public InfoHash InfoHash => new InfoHash (new byte[20]);
-            public InfoHash InfoHashV2 => new InfoHash (new byte[32]);
+            public InfoHash InfoHashV2 => null;
             public string Name => "Test Torrent";
             public int PieceLength { get; set; }
             public long Size { get; set; }

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Streaming/StreamProviderTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Streaming/StreamProviderTests.cs
@@ -55,7 +55,7 @@ namespace MonoTorrent.Streaming
 
             PieceWriter = new TestWriter ();
             await Engine.DiskManager.SetWriterAsync (PieceWriter);
-            Torrent = TestRig.CreateMultiFileTorrent (new[] { new TorrentFile ("path", Constants.BlockSize * 1024, 0, 1024 / 8 - 1, 0, null, null, null) }, Constants.BlockSize * 8, out torrentInfo);
+            Torrent = TestRig.CreateMultiFileTorrent (new[] { new TorrentFile ("path", Constants.BlockSize * 1024, 0, 1024 / 8 - 1, 0) }, Constants.BlockSize * 8, out torrentInfo);
             MagnetLink = new MagnetLink (Torrent.InfoHash, "MagnetDownload");
         }
 

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/TorrentTest.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/TorrentTest.cs
@@ -346,7 +346,7 @@ namespace MonoTorrent.Common
         public void StartEndIndices ()
         {
             int pieceLength = 32 * 32;
-            TorrentFile[] files = TorrentFile.Create (pieceLength,
+            ITorrentFile[] files = TorrentFile.Create (pieceLength,
                 ("File0", 0),
                 ("File1", pieceLength),
                 ("File2", 0),
@@ -383,7 +383,7 @@ namespace MonoTorrent.Common
         public void StartEndIndices2 ()
         {
             int pieceLength = 32 * 32;
-            TorrentFile[] files = TorrentFile.Create (pieceLength,
+            ITorrentFile[] files = TorrentFile.Create (pieceLength,
                 ("File0", pieceLength),
                 ("File1", 0)
             );
@@ -400,7 +400,7 @@ namespace MonoTorrent.Common
         public void StartEndIndices3 ()
         {
             int pieceLength = 32 * 32;
-            TorrentFile[] files = TorrentFile.Create (pieceLength,
+            ITorrentFile[] files = TorrentFile.Create (pieceLength,
                 ("File0", pieceLength - 10),
                 ("File1", 10)
             );
@@ -417,7 +417,7 @@ namespace MonoTorrent.Common
         public void StartEndIndices4 ()
         {
             int pieceLength = 32 * 32;
-            TorrentFile[] files = TorrentFile.Create (pieceLength,
+            ITorrentFile[] files = TorrentFile.Create (pieceLength,
                 ("File0", pieceLength - 10),
                 ("File1", 11)
             );
@@ -434,7 +434,7 @@ namespace MonoTorrent.Common
         public void StartEndIndices5 ()
         {
             int pieceLength = 32 * 32;
-            TorrentFile[] files = TorrentFile.Create (pieceLength,
+            ITorrentFile[] files = TorrentFile.Create (pieceLength,
                 ("File0", pieceLength - 10),
                 ("File1", 10),
                 ("File1", 1)

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/TorrentV2Test.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/TorrentV2Test.cs
@@ -42,7 +42,15 @@ namespace MonoTorrent.Common
     [TestFixture]
     public class TorrentV2Test
     {
-        string V2OnlyTorrent => Path.Combine (Path.GetDirectoryName (typeof (TorrentV2Test).Assembly.Location), "MonoTorrent", "bittorrent-v2-test.torrent");
+        string V2OnlyTorrentPath => Path.Combine (Path.GetDirectoryName (typeof (TorrentV2Test).Assembly.Location), "MonoTorrent", "bittorrent-v2-test.torrent");
+
+        Torrent V2OnlyTorrent;
+
+        [OneTimeSetUp]
+        public void FixtureSetup ()
+        {
+            V2OnlyTorrent = Torrent.Load (V2OnlyTorrentPath);
+        }
 
         [SetUp]
         public void Setup ()
@@ -91,16 +99,23 @@ namespace MonoTorrent.Common
         [Test]
         public void LoadV2OnlyTorrent ()
         {
-            var torrent = Torrent.Load (V2OnlyTorrent);
             // A v2 only torrent does not have a regular infohash
-            Assert.IsNull (torrent.InfoHash);
-            Assert.IsNull (torrent.PieceHashes);
+            Assert.IsNull (V2OnlyTorrent.InfoHash);
+            Assert.IsNull (V2OnlyTorrent.PieceHashes);
 
-            Assert.IsNotNull (torrent.InfoHashV2);
-            Assert.IsNotNull (torrent.PieceHashesV2);
+            Assert.IsNotNull (V2OnlyTorrent.InfoHashV2);
+            Assert.IsNotNull (V2OnlyTorrent.PieceHashesV2);
 
-            Assert.IsFalse (torrent.PieceHashesV2.GetHash (torrent.PieceCount - 1).IsEmpty);
-            Assert.IsFalse (torrent.PieceHashesV2.GetHash (0).IsEmpty);
+            Assert.IsFalse (V2OnlyTorrent.PieceHashesV2.GetHash (V2OnlyTorrent.PieceCount - 1).IsEmpty);
+            Assert.IsFalse (V2OnlyTorrent.PieceHashesV2.GetHash (0).IsEmpty);
+        }
+
+        [Test]
+        public void BlocksPerPiece ()
+        {
+            foreach (var file in V2OnlyTorrent.Files) {
+                Enumerable.Range (file.StartPieceIndex, file.EndPieceIndex - file.StartPieceIndex + 1).Select (t => V2OnlyTorrent);
+            }
         }
     }
 }

--- a/src/Tests/Tests.MonoTorrent.Messages/StandardMessageTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Messages/StandardMessageTests.cs
@@ -44,7 +44,7 @@ namespace MonoTorrent.Messages.Peer
             IList<ITorrentFile> ITorrentInfo.Files => Files.ToArray<ITorrentFile> ();
             public IList<ITorrentManagerFile> Files { get; set; }
             public InfoHash InfoHash => new InfoHash (new byte[20]);
-            public InfoHash InfoHashV2 { get; } = new InfoHash (new byte[32]);
+            public InfoHash InfoHashV2 => null;
             public string Name => "Test Torrent";
             public int PieceLength { get; set; }
             public long Size { get; set; }

--- a/src/Tests/Tests.MonoTorrent.Messages/StandardMessageTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Messages/StandardMessageTests.cs
@@ -39,10 +39,12 @@ namespace MonoTorrent.Messages.Peer
     [TestFixture]
     public class StandardMessageTests
     {
-        class TestTorrentData : ITorrentData
+        class TestTorrentData : ITorrentManagerInfo
         {
-            public IList<ITorrentFileInfo> Files { get; set; }
+            IList<ITorrentFile> ITorrentInfo.Files => Files.ToArray<ITorrentFile> ();
+            public IList<ITorrentManagerFile> Files { get; set; }
             public InfoHash InfoHash => new InfoHash (new byte[20]);
+            public InfoHash InfoHashV2 { get; } = new InfoHash (new byte[32]);
             public string Name => "Test Torrent";
             public int PieceLength { get; set; }
             public long Size { get; set; }
@@ -50,7 +52,7 @@ namespace MonoTorrent.Messages.Peer
 
         byte[] buffer;
         int offset;
-        ITorrentData torrentData;
+        ITorrentManagerInfo torrentData;
 
         [SetUp]
         public void Setup ()
@@ -61,7 +63,7 @@ namespace MonoTorrent.Messages.Peer
                 buffer[i] = 0xff;
 
             torrentData = new TestTorrentData {
-                Files = new List<ITorrentFileInfo> (),
+                Files = new List<ITorrentManagerFile> (),
                 PieceLength = 16 * Constants.BlockSize,
                 Size = 40 * 16 * Constants.BlockSize,
             };

--- a/src/Tests/Tests.MonoTorrent.PiecePicking/PiecePickerFilterChecker.cs
+++ b/src/Tests/Tests.MonoTorrent.PiecePicking/PiecePickerFilterChecker.cs
@@ -34,7 +34,7 @@ namespace MonoTorrent.PiecePicking
 {
     class PiecePickerFilterChecker : PiecePickerFilter
     {
-        public List<ITorrentData> Initialised;
+        public List<ITorrentManagerInfo> Initialised;
         public List<(IPeer peer, BitField bitfield)> Interesting;
         public List<(IPeer peer, BitField available, IReadOnlyList<IPeer> otherPeers, int count, int startIndex, int endIndex)> Picks;
 
@@ -46,12 +46,12 @@ namespace MonoTorrent.PiecePicking
         public PiecePickerFilterChecker (IPiecePicker next)
             : base (next)
         {
-            Initialised = new List<ITorrentData> ();
+            Initialised = new List<ITorrentManagerInfo> ();
             Interesting = new List<(IPeer peer, BitField bitfield)> ();
             Picks = new List<(IPeer peer, BitField available, IReadOnlyList<IPeer> otherPeers, int count, int startIndex, int endIndex)> ();
         }
 
-        public override void Initialise (ITorrentData torrentData)
+        public override void Initialise (ITorrentManagerInfo torrentData)
         {
             Initialised.Add (torrentData);
             Next?.Initialise (torrentData);

--- a/src/Tests/Tests.MonoTorrent.PiecePicking/PriorityPickerTests.cs
+++ b/src/Tests/Tests.MonoTorrent.PiecePicking/PriorityPickerTests.cs
@@ -40,12 +40,14 @@ namespace MonoTorrent.PiecePicking
     [TestFixture]
     public class PriorityPickerTests
     {
-        class TestTorrentData : ITorrentData
+        class TestTorrentData : ITorrentManagerInfo
         {
-            IList<ITorrentFileInfo> ITorrentData.Files => new List<ITorrentFileInfo> (Files);
+            IList<ITorrentManagerFile> ITorrentManagerInfo.Files => new List<ITorrentManagerFile> (Files);
 
+            IList<ITorrentFile> ITorrentInfo.Files => Files.ToArray<ITorrentFile> ();
             public IList<TorrentFileInfo> Files { get; set; }
             public InfoHash InfoHash => new InfoHash (new byte[20]);
+            public InfoHash InfoHashV2 => new InfoHash (new byte[32]);
             public string Name => "Test Torrent";
             public int PieceLength { get; set; }
             public int Pieces => (int) Math.Ceiling ((double) Size / PieceLength);

--- a/src/Tests/Tests.MonoTorrent.PiecePicking/PriorityPickerTests.cs
+++ b/src/Tests/Tests.MonoTorrent.PiecePicking/PriorityPickerTests.cs
@@ -47,7 +47,7 @@ namespace MonoTorrent.PiecePicking
             IList<ITorrentFile> ITorrentInfo.Files => Files.ToArray<ITorrentFile> ();
             public IList<TorrentFileInfo> Files { get; set; }
             public InfoHash InfoHash => new InfoHash (new byte[20]);
-            public InfoHash InfoHashV2 => new InfoHash (new byte[32]);
+            public InfoHash InfoHashV2 => null;
             public string Name => "Test Torrent";
             public int PieceLength { get; set; }
             public int Pieces => (int) Math.Ceiling ((double) Size / PieceLength);

--- a/src/Tests/Tests.MonoTorrent.PiecePicking/RandomisedPickerTests.cs
+++ b/src/Tests/Tests.MonoTorrent.PiecePicking/RandomisedPickerTests.cs
@@ -45,7 +45,7 @@ namespace MonoTorrent.PiecePicking
             IList<ITorrentFile> ITorrentInfo.Files => Files.ToArray<ITorrentFile> ();
             public IList<ITorrentManagerFile> Files { get; } = TorrentFileInfo.Create (64 * 1024, 64 * 1024);
             public InfoHash InfoHash => new InfoHash (new byte[20]);
-            public InfoHash InfoHashV2 => new InfoHash (new byte[32]);
+            public InfoHash InfoHashV2 => null;
             public string Name => "Test Torrent";
             public int PieceLength { get; } = 64 * 1024;
             public long Size { get; } = 64 * 1024;
@@ -56,7 +56,7 @@ namespace MonoTorrent.PiecePicking
             IList<ITorrentFile> ITorrentInfo.Files => Files.ToArray<ITorrentFile> ();
             public IList<ITorrentManagerFile> Files { get; } = TorrentFileInfo.Create (64 * 1024, 64 * 1024 * 40);
             public InfoHash InfoHash => new InfoHash (new byte[20]);
-            public InfoHash InfoHashV2 { get; } = new InfoHash (new byte[32]);
+            public InfoHash InfoHashV2 => null;
             public string Name => "Test Torrent";
             public int PieceLength { get; } = 64 * 1024;
             public long Size { get; } = 64 * 1024 * 40;

--- a/src/Tests/Tests.MonoTorrent.PiecePicking/RandomisedPickerTests.cs
+++ b/src/Tests/Tests.MonoTorrent.PiecePicking/RandomisedPickerTests.cs
@@ -29,6 +29,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using MonoTorrent.Client;
 
@@ -39,19 +40,23 @@ namespace MonoTorrent.PiecePicking
     [TestFixture]
     public class RandomisedPickerTests
     {
-        class OnePieceTorrentData : ITorrentData
+        class OnePieceTorrentData : ITorrentManagerInfo
         {
-            public IList<ITorrentFileInfo> Files { get; } = TorrentFileInfo.Create (64 * 1024, 64 * 1024);
+            IList<ITorrentFile> ITorrentInfo.Files => Files.ToArray<ITorrentFile> ();
+            public IList<ITorrentManagerFile> Files { get; } = TorrentFileInfo.Create (64 * 1024, 64 * 1024);
             public InfoHash InfoHash => new InfoHash (new byte[20]);
+            public InfoHash InfoHashV2 => new InfoHash (new byte[32]);
             public string Name => "Test Torrent";
             public int PieceLength { get; } = 64 * 1024;
             public long Size { get; } = 64 * 1024;
         }
 
-        class TestTorrentData : ITorrentData
+        class TestTorrentData : ITorrentManagerInfo
         {
-            public IList<ITorrentFileInfo> Files { get; } = TorrentFileInfo.Create (64 * 1024, 64 * 1024 * 40);
+            IList<ITorrentFile> ITorrentInfo.Files => Files.ToArray<ITorrentFile> ();
+            public IList<ITorrentManagerFile> Files { get; } = TorrentFileInfo.Create (64 * 1024, 64 * 1024 * 40);
             public InfoHash InfoHash => new InfoHash (new byte[20]);
+            public InfoHash InfoHashV2 { get; } = new InfoHash (new byte[32]);
             public string Name => "Test Torrent";
             public int PieceLength { get; } = 64 * 1024;
             public long Size { get; } = 64 * 1024 * 40;

--- a/src/Tests/Tests.MonoTorrent.PiecePicking/RarestFirstPickerTests.cs
+++ b/src/Tests/Tests.MonoTorrent.PiecePicking/RarestFirstPickerTests.cs
@@ -29,6 +29,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using MonoTorrent.Client;
 
@@ -39,11 +40,13 @@ namespace MonoTorrent.PiecePicking
     [TestFixture]
     public class RarestFirstPickerTests
     {
-        class TestTorrentData : ITorrentData
+        class TestTorrentData : ITorrentManagerInfo
         {
             public int BlocksPerPiece => PieceLength / Constants.BlockSize;
-            public IList<ITorrentFileInfo> Files { get; set; }
+            IList<ITorrentFile> ITorrentInfo.Files => Files.ToArray<ITorrentFile> ();
+            public IList<ITorrentManagerFile> Files { get; set; }
             public InfoHash InfoHash => new InfoHash (new byte[20]);
+            public InfoHash InfoHashV2 => new InfoHash (new byte[32]);
             public string Name => "Test Torrent";
             public int PieceLength { get; set; }
             public int Pieces => (int) Math.Ceiling ((double) Size / PieceLength);

--- a/src/Tests/Tests.MonoTorrent.PiecePicking/StandardPickerTests.cs
+++ b/src/Tests/Tests.MonoTorrent.PiecePicking/StandardPickerTests.cs
@@ -40,10 +40,12 @@ namespace MonoTorrent.PiecePicking
     [TestFixture]
     public class StandardPickerTests
     {
-        class TestTorrentData : ITorrentData
+        class TestTorrentData : ITorrentManagerInfo
         {
-            public IList<ITorrentFileInfo> Files { get; set; }
+            IList<ITorrentFile> ITorrentInfo.Files => Files.ToArray<ITorrentFile> ();
+            public IList<ITorrentManagerFile> Files { get; set; }
             public InfoHash InfoHash => new InfoHash (new byte[20]);
+            public InfoHash InfoHashV2 => new InfoHash (new byte[32]);
             public string Name => "Test Torrent";
             public int PieceLength { get; set; }
             public long Size { get; set; }

--- a/src/Tests/Tests.MonoTorrent.PiecePicking/StandardPickerTests.cs
+++ b/src/Tests/Tests.MonoTorrent.PiecePicking/StandardPickerTests.cs
@@ -45,7 +45,7 @@ namespace MonoTorrent.PiecePicking
             IList<ITorrentFile> ITorrentInfo.Files => Files.ToArray<ITorrentFile> ();
             public IList<ITorrentManagerFile> Files { get; set; }
             public InfoHash InfoHash => new InfoHash (new byte[20]);
-            public InfoHash InfoHashV2 => new InfoHash (new byte[32]);
+            public InfoHash InfoHashV2 => null;
             public string Name => "Test Torrent";
             public int PieceLength { get; set; }
             public long Size { get; set; }

--- a/src/Tests/Tests.MonoTorrent.PiecePicking/StreamingPieceRequesterTests.cs
+++ b/src/Tests/Tests.MonoTorrent.PiecePicking/StreamingPieceRequesterTests.cs
@@ -40,10 +40,12 @@ namespace MonoTorrent.PiecePicking
     [TestFixture]
     public class StreamingPieceRequesterTests
     {
-        class TorrentData : ITorrentData
+        class TorrentData : ITorrentManagerInfo
         {
-            public IList<ITorrentFileInfo> Files { get; } = TorrentFileInfo.Create (Constants.BlockSize * 8, 1024 * 1024 * 8);
+            IList<ITorrentFile> ITorrentInfo.Files => Files.ToArray<ITorrentFile> ();
+            public IList<ITorrentManagerFile> Files { get; } = TorrentFileInfo.Create (Constants.BlockSize * 8, 1024 * 1024 * 8);
             public InfoHash InfoHash => new InfoHash (new byte[20]);
+            public InfoHash InfoHashV2 { get; } = new InfoHash (new byte[32]);
             public string Name => "Test Torrent";
             public int PieceLength => Constants.BlockSize * 8;
             public long Size => Files[0].Length;

--- a/src/Tests/Tests.MonoTorrent.PiecePicking/StreamingPieceRequesterTests.cs
+++ b/src/Tests/Tests.MonoTorrent.PiecePicking/StreamingPieceRequesterTests.cs
@@ -45,7 +45,7 @@ namespace MonoTorrent.PiecePicking
             IList<ITorrentFile> ITorrentInfo.Files => Files.ToArray<ITorrentFile> ();
             public IList<ITorrentManagerFile> Files { get; } = TorrentFileInfo.Create (Constants.BlockSize * 8, 1024 * 1024 * 8);
             public InfoHash InfoHash => new InfoHash (new byte[20]);
-            public InfoHash InfoHashV2 { get; } = new InfoHash (new byte[32]);
+            public InfoHash InfoHashV2 => null;
             public string Name => "Test Torrent";
             public int PieceLength => Constants.BlockSize * 8;
             public long Size => Files[0].Length;

--- a/src/Tests/Tests.MonoTorrent.PieceWriter/DiskWriterTests.cs
+++ b/src/Tests/Tests.MonoTorrent.PieceWriter/DiskWriterTests.cs
@@ -41,8 +41,8 @@ namespace MonoTorrent.PieceWriter
     public class DiskWriterTests
     {
         string Temp { get; set; }
-        ITorrentFileInfo[] Others { get; set; }
-        ITorrentFileInfo TorrentFile { get; set; }
+        ITorrentManagerFile[] Others { get; set; }
+        ITorrentManagerFile TorrentFile { get; set; }
 
         [SetUp]
         public void Setup ()

--- a/src/Tests/Tests.MonoTorrent.PieceWriter/NullWriter.cs
+++ b/src/Tests/Tests.MonoTorrent.PieceWriter/NullWriter.cs
@@ -37,7 +37,7 @@ namespace MonoTorrent.PieceWriter
     {
         public int MaximumOpenFiles { get; }
 
-        public ReusableTask CloseAsync (ITorrentFileInfo file)
+        public ReusableTask CloseAsync (ITorrentManagerFile file)
         {
             return ReusableTask.CompletedTask;
         }
@@ -46,22 +46,22 @@ namespace MonoTorrent.PieceWriter
         {
         }
 
-        public ReusableTask<bool> ExistsAsync (ITorrentFileInfo file)
+        public ReusableTask<bool> ExistsAsync (ITorrentManagerFile file)
         {
             return ReusableTask.FromResult (false);
         }
 
-        public ReusableTask FlushAsync (ITorrentFileInfo file)
+        public ReusableTask FlushAsync (ITorrentManagerFile file)
         {
             return ReusableTask.CompletedTask;
         }
 
-        public ReusableTask MoveAsync (ITorrentFileInfo file, string fullPath, bool overwrite)
+        public ReusableTask MoveAsync (ITorrentManagerFile file, string fullPath, bool overwrite)
         {
             return ReusableTask.CompletedTask;
         }
 
-        public ReusableTask<int> ReadAsync (ITorrentFileInfo file, long offset, Memory<byte> buffer)
+        public ReusableTask<int> ReadAsync (ITorrentManagerFile file, long offset, Memory<byte> buffer)
         {
             return ReusableTask.FromResult (0);
         }
@@ -71,7 +71,7 @@ namespace MonoTorrent.PieceWriter
             return ReusableTask.CompletedTask;
         }
 
-        public ReusableTask WriteAsync (ITorrentFileInfo file, long offset, ReadOnlyMemory<byte> buffer)
+        public ReusableTask WriteAsync (ITorrentManagerFile file, long offset, ReadOnlyMemory<byte> buffer)
         {
             return ReusableTask.CompletedTask;
         }


### PR DESCRIPTION
With bittorrent v2, the last piece of every file may be less than 'PieceLength' bytes. This means all calculations covering PieceIndex -> byte offset, or vice versa, need to be adapted.