### PR TITLE
[bep52] Modify the API to support dynamically retrieving Bep52 hashes

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/HashingMode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/HashingMode.cs
@@ -107,7 +107,7 @@ namespace MonoTorrent.Client.Modes
                         Cancellation.Token.ThrowIfCancellationRequested ();
                     }
 
-                    bool hashPassed = successful && Manager.Torrent.PieceHashes.IsValid (hashes, index);
+                    bool hashPassed = successful && Manager.PieceHashes.IsValid (hashes, index);
                     Manager.OnPieceHashed (index, hashPassed, ++piecesHashed, Manager.PartialProgressSelector.TrueCount);
                 }
             } else {

--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/Mode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/Mode.cs
@@ -406,7 +406,7 @@ namespace MonoTorrent.Client.Modes
                 return;
             }
 
-            bool result = successful && Manager.Torrent!.PieceHashes.IsValid (hashes, block.PieceIndex);
+            bool result = successful && Manager.PieceHashes.IsValid (hashes, block.PieceIndex);
             Manager.OnPieceHashed (block.PieceIndex, result, 1, 1);
             Manager.PieceManager.PieceHashed (block.PieceIndex);
             if (!result)
@@ -718,7 +718,7 @@ namespace MonoTorrent.Client.Modes
                                 var successful = await DiskManager.GetHashAsync (Manager, index, hashes);
                                 Cancellation.Token.ThrowIfCancellationRequested ();
 
-                                bool hashPassed = successful && Manager.Torrent!.PieceHashes.IsValid (hashes, index);
+                                bool hashPassed = successful && Manager.PieceHashes.IsValid (hashes, index);
                                 Manager.OnPieceHashed (index, hashPassed, 1, 1);
 
                                 if (hashPassed)

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -411,8 +411,9 @@ namespace MonoTorrent.Client
             Engine = engine;
             Files = Array.Empty<ITorrentManagerFile> ();
             MagnetLink = magnetLink ?? new MagnetLink (torrent!.InfoHashes, torrent.Name, torrent.AnnounceUrls.SelectMany (t => t).ToArray (), null, torrent.Size);
-            Torrent = torrent;
+            PieceHashes = new PieceHashes (null, null);
             Settings = settings;
+            Torrent = torrent;
 
             ContainingDirectory = "";
 

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -389,6 +389,8 @@ namespace MonoTorrent.Client
 
         public bool IsInitialSeeding => Mode is InitialSeedingMode;
 
+        internal IPieceHashes PieceHashes { get; set; }
+
         #endregion
 
         #region Constructors
@@ -670,6 +672,7 @@ namespace MonoTorrent.Client
                 };
             }).Cast<ITorrentManagerFile> ().ToList ().AsReadOnly ();
 
+            PieceHashes = Torrent.CreatePieceHashes ();
             PieceManager.Initialise ();
             MetadataTask.SetResult (Torrent);
         }

--- a/src/MonoTorrent.Client/MonoTorrent/PieceHashes.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/PieceHashes.cs
@@ -36,7 +36,7 @@ namespace MonoTorrent
         PieceHashesV1? V1 { get; }
         PieceHashesV2? V2 { get; }
 
-        public int Count => ((IPieceHashes?) V1 ?? (IPieceHashes?) V2)!.Count;
+        public int Count => V1?.Count ?? V2?.Count ?? 0;
 
         internal PieceHashes (PieceHashesV1? v1Hashes, PieceHashesV2? v2Hashes)
             => (V1, V2) = (v1Hashes, v2Hashes);
@@ -51,7 +51,8 @@ namespace MonoTorrent
         public bool IsValid (ReadOnlyPieceHash hashes, int hashIndex)
         {
             return (V1 is null || V1.IsValid (hashes, hashIndex))
-                && (V2 is null || V2.IsValid (hashes, hashIndex));
+                && (V2 is null || V2.IsValid (hashes, hashIndex))
+                && !(V1 is null && V2 is null);
         }
     }
 }

--- a/src/MonoTorrent.Client/MonoTorrent/PieceHashesV2.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/PieceHashesV2.cs
@@ -39,14 +39,14 @@ namespace MonoTorrent
     {
         readonly int HashCodeLength;
         readonly IList<ITorrentFile> Files;
-        readonly BEncodedDictionary Layers;
+        readonly Dictionary<BEncodedString, BEncodedString> Layers;
 
         /// <summary>
         /// Number of Hashes (equivalent to number of Pieces)
         /// </summary>
         public int Count { get; }
 
-        internal PieceHashesV2 (IList<ITorrentFile> files, BEncodedDictionary layers)
+        internal PieceHashesV2 (IList<ITorrentFile> files, Dictionary<BEncodedString, BEncodedString> layers)
             => (Files, Layers, HashCodeLength, Count) = (files, layers, 32, files.Last ().EndPieceIndex + 1);
 
         /// <summary>
@@ -64,8 +64,8 @@ namespace MonoTorrent
                     continue;
 
                 // If the file has 2 or more pieces then we'll need to grab the appropriate sha from the layer
-                if (Layers.TryGetValue (BEncodedString.FromMemory (Files[i].PiecesRoot), out BEncodedValue? layer))
-                    return new ReadOnlyPieceHash (ReadOnlyMemory<byte>.Empty, ((BEncodedString) layer).AsMemory ().Slice ((hashIndex - Files[i].StartPieceIndex) * HashCodeLength, HashCodeLength));
+                if (Layers.TryGetValue (BEncodedString.FromMemory (Files[i].PiecesRoot), out BEncodedString? layer))
+                    return new ReadOnlyPieceHash (ReadOnlyMemory<byte>.Empty, layer.AsMemory ().Slice ((hashIndex - Files[i].StartPieceIndex) * HashCodeLength, HashCodeLength));
 
                 // Otherwise, if the file is *exactly* one piece long 'PiecesRoot' is the hash!
                 return new ReadOnlyPieceHash (ReadOnlyMemory<byte>.Empty, Files[i].PiecesRoot);

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/HashingModeTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/HashingModeTests.cs
@@ -237,7 +237,7 @@ namespace MonoTorrent.Client.Modes
         {
             DiskManager.GetHashAsyncOverride = (manager, index, dest) => {
                 if (index >= 0 && index <= 4) {
-                    Manager.Torrent.PieceHashes.GetHash (index).V1Hash.Span.CopyTo (dest.V1Hash.Span);
+                    Manager.Torrent.CreatePieceHashes ().GetHash (index).V1Hash.Span.CopyTo (dest.V1Hash.Span);
                 } else {
                     Enumerable.Repeat ((byte) 255, 20).ToArray ().CopyTo (dest.V1Hash.Span);
                 }

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/TorrentV2Test.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/TorrentV2Test.cs
@@ -109,9 +109,9 @@ namespace MonoTorrent.Common
             Assert.IsNull (V2OnlyTorrent.InfoHashes.V1);
             Assert.IsNotNull (V2OnlyTorrent.InfoHashes.V2);
 
-            Assert.IsTrue (V2OnlyTorrent.PieceHashes.GetHash (V2OnlyTorrent.PieceCount - 1).V1Hash.IsEmpty);
-            Assert.IsFalse (V2OnlyTorrent.PieceHashes.GetHash (V2OnlyTorrent.PieceCount - 1).V2Hash.IsEmpty);
-            Assert.IsFalse (V2OnlyTorrent.PieceHashes.GetHash (0).V2Hash.IsEmpty);
+            Assert.IsTrue (V2OnlyTorrent.CreatePieceHashes ().GetHash (V2OnlyTorrent.PieceCount - 1).V1Hash.IsEmpty);
+            Assert.IsFalse (V2OnlyTorrent.CreatePieceHashes ().GetHash (V2OnlyTorrent.PieceCount - 1).V2Hash.IsEmpty);
+            Assert.IsFalse (V2OnlyTorrent.CreatePieceHashes ().GetHash (0).V2Hash.IsEmpty);
 
             Assert.AreEqual (InfoHash.FromHex ("caf1e1c30e81cb361b9ee167c4aa64228a7fa4fa9f6105232b28ad099f3a302e"), V2OnlyTorrent.InfoHashes.V2);
         }
@@ -123,8 +123,8 @@ namespace MonoTorrent.Common
 
             Assert.IsNull (HybridTorrent.InfoHashes.V1);
             Assert.IsNotNull (HybridTorrent.InfoHashes.V2);
-            Assert.IsTrue (HybridTorrent.PieceHashes.GetHash (0).V1Hash.IsEmpty);
-            Assert.IsFalse (HybridTorrent.PieceHashes.GetHash (0).V2Hash.IsEmpty);
+            Assert.IsTrue (HybridTorrent.CreatePieceHashes ().GetHash (0).V1Hash.IsEmpty);
+            Assert.IsFalse (HybridTorrent.CreatePieceHashes ().GetHash (0).V2Hash.IsEmpty);
         }
 
         [Test]


### PR DESCRIPTION
The torrent metadata is no longer the source of truth for piece
hashes. Piece hashes are optionally part of a bittorrent v2 (bep52)
compliant torrent. In the event they're missing, they can be requested
from peers after the metadata has been retrieved.

One invariant I wish to maintain is that the 'Torrent' object should be
completely immutable.

As such, remove the 'IPieceHashes PieceHashes' property and
expose a public method instead. This method has an overload where you
can supply a Dictionary of piece hashes, keyed by
'ITorrentFile.PiecesRoot'. This way an IPieceHashes object can be
created after hashes are fetched from another peer and those hashes
have been validated as being correct.

'TorrentManager' is mutable and stores the latest version of the
PieceHashes object, allowing it to be updated when the data has been
fetched.