### PR TITLE
[bep52] Ensure nothing is downloaded before piece hashes are available

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/PieceManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/PieceManager.cs
@@ -119,6 +119,7 @@ namespace MonoTorrent.Client
 
                 var ignorableBitfieds = new[] {
                     Manager.Bitfield,
+                    Manager.PendingV2PieceHashes,
                     PendingHashCheckPieces,
                     Manager.UnhashedPieces,
                 };

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -389,6 +389,7 @@ namespace MonoTorrent.Client
 
         public bool IsInitialSeeding => Mode is InitialSeedingMode;
 
+        internal MutableBitField PendingV2PieceHashes { get; private set; }
         internal IPieceHashes PieceHashes { get; set; }
 
         #endregion
@@ -429,6 +430,7 @@ namespace MonoTorrent.Client
             TrackerManager = new TrackerManager (engine.Factories, new TrackerRequestFactory (this), announces, torrent?.IsPrivate ?? false);
             SetTrackerManager (TrackerManager);
 
+            PendingV2PieceHashes = new MutableBitField (Torrent != null ? Torrent.PieceCount : 1).SetAll (true);
             MutableBitField = new MutableBitField (Torrent != null ? Torrent.PieceCount: 1);
             PartialProgressSelector = new MutableBitField (Torrent != null ? Torrent.PieceCount : 1);
             UnhashedPieces = new MutableBitField (Torrent != null ? Torrent.PieceCount : 1).SetAll (true);
@@ -639,6 +641,7 @@ namespace MonoTorrent.Client
                 Engine!.ConnectionManager.CleanupSocket (this, id);
             MutableBitField = new MutableBitField (Torrent.PieceCount);
             PartialProgressSelector = new MutableBitField (Torrent.PieceCount).SetAll (true);
+            PendingV2PieceHashes = new MutableBitField (Torrent.PieceCount);
             UnhashedPieces = new MutableBitField (Torrent.PieceCount).SetAll (true);
 
             // Now we know the torrent name, use it as the base directory name when it's a multi-file torrent
@@ -674,6 +677,13 @@ namespace MonoTorrent.Client
             }).Cast<ITorrentManagerFile> ().ToList ().AsReadOnly ();
 
             PieceHashes = Torrent.CreatePieceHashes ();
+            // If this torrent is supposed to have V2 hashes *and* we do not have them, mark them as missing.
+            // This will cause all pieces to be treated as 'not downloadable' and no peers will be treated as interesting.
+            // Otherwise set everything here to 'false' so the engine knows all pieces can be requested/verified.
+            //
+            // This will be set to 'false' when the V2 hashes have been fully requested, allowing all pieces to be
+            // downloaded normally.
+            PendingV2PieceHashes.SetAll (Torrent.InfoHashes.V2 != null && !PieceHashes.HasV2Hashes);
             PieceManager.Initialise ();
             MetadataTask.SetResult (Torrent);
         }

--- a/src/MonoTorrent.Client/MonoTorrent/IPieceHashes.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/IPieceHashes.cs
@@ -34,6 +34,9 @@ namespace MonoTorrent
     public interface IPieceHashes
     {
         int Count { get; }
+        bool HasV1Hashes { get; }
+        bool HasV2Hashes { get; }
+
         ReadOnlyPieceHash GetHash (int hashIndex);
         bool IsValid (ReadOnlyPieceHash hashes, int hashIndex);
     }

--- a/src/MonoTorrent.Client/MonoTorrent/PieceHashesV1.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/PieceHashesV1.cs
@@ -36,6 +36,10 @@ namespace MonoTorrent
         readonly int HashCodeLength;
         readonly ReadOnlyMemory<byte> HashData;
 
+        public bool HasV1Hashes => true;
+
+        public bool HasV2Hashes => false;
+
         /// <summary>
         /// Number of Hashes (equivalent to number of Pieces)
         /// </summary>

--- a/src/MonoTorrent.Client/MonoTorrent/PieceHashesV2.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/PieceHashesV2.cs
@@ -46,6 +46,10 @@ namespace MonoTorrent
         /// </summary>
         public int Count { get; }
 
+        public bool HasV1Hashes => false;
+
+        public bool HasV2Hashes => true;
+
         internal PieceHashesV2 (IList<ITorrentFile> files, Dictionary<BEncodedString, BEncodedString> layers)
             => (Files, Layers, HashCodeLength, Count) = (files, layers, 32, files.Last ().EndPieceIndex + 1);
 

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/PieceHashesTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/PieceHashesTests.cs
@@ -1,5 +1,5 @@
-//
-// PieceHashes.cs
+﻿//
+// PieceHashesTests.cs
 //
 // Authors:
 //   Alan McGovern alan.mcgovern@gmail.com
@@ -13,10 +13,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-//
+// 
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-//
+// 
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -27,36 +27,34 @@
 //
 
 
-using System;
+using System.Linq;
 
-namespace MonoTorrent
+using NUnit.Framework;
+
+namespace MonoTorrent.Common
 {
-    class PieceHashes : IPieceHashes
+    [TestFixture]
+    public class PieceHashesTests
     {
-        PieceHashesV1? V1 { get; }
-        PieceHashesV2? V2 { get; }
-
-        public int Count => V1?.Count ?? V2?.Count ?? 0;
-
-        public bool HasV1Hashes => V1 != null;
-
-        public bool HasV2Hashes => V2 != null;
-
-        internal PieceHashes (PieceHashesV1? v1Hashes, PieceHashesV2? v2Hashes)
-            => (V1, V2) = (v1Hashes, v2Hashes);
-
-        public ReadOnlyPieceHash GetHash (int hashIndex)
+        [Test]
+        public void V2Only_NoHashes_IsValid ()
         {
-            var v1 = V1 is null ? default : V1.GetHash (hashIndex);
-            var v2 = V2 is null ? default : V2.GetHash (hashIndex);
-            return new ReadOnlyPieceHash (v1.V1Hash, v2.V2Hash);
+            var hashes = new PieceHashes (null, null);
+            Assert.IsFalse (hashes.IsValid (new ReadOnlyPieceHash (new byte[20], new byte[32]), 1));
         }
 
-        public bool IsValid (ReadOnlyPieceHash hashes, int hashIndex)
+        [Test]
+        public void V2Only_NoHashes_GetHash ()
         {
-            return (V1 is null || V1.IsValid (hashes, hashIndex))
-                && (V2 is null || V2.IsValid (hashes, hashIndex))
-                && !(V1 is null && V2 is null);
+            var hashes = new PieceHashes (null, null).GetHash (5);
+            Assert.IsTrue (hashes.V1Hash.IsEmpty);
+            Assert.IsTrue (hashes.V2Hash.IsEmpty);
+        }
+
+        [Test]
+        public void V2Only_NoHashes_Count ()
+        {
+            Assert.AreEqual (0, new PieceHashes (null, null).Count);
         }
     }
 }


### PR DESCRIPTION
The addition of this bitfield ensures no pieces are downloaded by the
engine until V2 piece hashes have been fetched. For V1 only torrents
this will have no effect.