### PR TITLE
[webseed] This should be moved to engine level config

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/Mode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/Mode.cs
@@ -616,7 +616,6 @@ namespace MonoTorrent.Client.Modes
         {
             PeerId id;
 
-            var fifteenSeconds = TimeSpan.FromSeconds (15);
             var ninetySeconds = TimeSpan.FromSeconds (90);
             var onhundredAndEightySeconds = TimeSpan.FromSeconds (180);
 
@@ -638,7 +637,7 @@ namespace MonoTorrent.Client.Modes
                     continue;
                 }
 
-                if (id.LastBlockReceived.Elapsed > fifteenSeconds && id.AmRequestingPiecesCount > 0) {
+                if (id.LastBlockReceived.Elapsed > Settings.StaleRequestTimeout && id.AmRequestingPiecesCount > 0) {
                     ConnectionManager.CleanupSocket (Manager, id);
                     i--;
                     continue;
@@ -654,13 +653,13 @@ namespace MonoTorrent.Client.Modes
 
         void DownloadLogic (int counter)
         {
-            if (ClientEngine.SupportsWebSeed && (DateTime.Now - Manager.StartTime) > Manager.Settings.WebSeedDelay && Manager.Monitor.DownloadRate < Manager.Settings.WebSeedSpeedTrigger) {
+            if (ClientEngine.SupportsWebSeed && (DateTime.Now - Manager.StartTime) > Settings.WebSeedDelay && Manager.Monitor.DownloadRate < Settings.WebSeedSpeedTrigger) {
                 foreach (Uri uri in Manager.Torrent!.HttpSeeds) {
                     BEncodedString peerId = CreatePeerId ();
 
                     var peer = new Peer (peerId, uri);
 
-                    var connection = new HttpPeerConnection (Manager, Manager.Engine!.Factories, uri);
+                    var connection = new HttpPeerConnection (Manager, Settings.WebSeedConnectionTimeout, Manager.Engine!.Factories, uri);
                     // Unsupported connection type.
                     if (connection == null)
                         continue;

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Settings/EngineSettings.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Settings/EngineSettings.cs
@@ -199,6 +199,15 @@ namespace MonoTorrent.Client
         public IPEndPoint? ReportedAddress { get; }
 
         /// <summary>
+        /// When blocks have been requested from a peer, the connection to that peer will be closed and the
+        /// requests will be cancelled if it takes longer than this time to receive a 16kB block. This
+        /// value must be higher than <see cref="WebSeedConnectionTimeout"/> or the web seeds will be
+        /// considered unhealthy before their connection timeout is exceeded.
+        /// Defaults to 40 seconds.
+        /// </summary>
+        public TimeSpan StaleRequestTimeout { get; } = TimeSpan.FromSeconds (40);
+
+        /// <summary>
         /// This is the full path to a sub-directory of <see cref="CacheDirectory"/>. If a magnet link is used
         /// to download a torrent, the downloaded metata will be cached here.
         /// </summary>
@@ -210,6 +219,24 @@ namespace MonoTorrent.Client
         /// </summary>
         public bool UsePartialFiles { get; } = false;
 
+        /// <summary>
+        /// The timeout used when connecting to a WebSeed's HTTP endpoint.
+        /// Defaults to 30 seconds.
+        /// </summary>
+        public TimeSpan WebSeedConnectionTimeout { get; } = TimeSpan.FromSeconds (30);
+
+        /// <summary>
+        /// The delay before a torrent will start using web seeds.
+        /// Defaults to 1 minute.
+        /// </summary>
+        public TimeSpan WebSeedDelay { get; } = TimeSpan.FromMinutes (1);
+
+        /// <summary>
+        /// The download speed under which a torrent will start using web seeds.
+        /// Defaults to 15kB/sec.
+        /// </summary>
+        public int WebSeedSpeedTrigger { get; } = 15 * 1024;
+
         public EngineSettings ()
         {
 
@@ -220,7 +247,8 @@ namespace MonoTorrent.Client
             bool autoSaveLoadDhtCache, bool autoSaveLoadFastResume, bool autoSaveLoadMagnetLinkMetadata, string cacheDirectory,
             TimeSpan connectionTimeout, IPEndPoint? dhtEndPoint, int diskCacheBytes, FastResumeMode fastResumeMode, IPEndPoint? listenEndPoint,
             int maximumConnections, int maximumDiskReadRate, int maximumDiskWriteRate, int maximumDownloadRate, int maximumHalfOpenConnections,
-            int maximumOpenFiles, int maximumUploadRate, IPEndPoint? reportedAddress, bool usePartialFiles)
+            int maximumOpenFiles, int maximumUploadRate, IPEndPoint? reportedAddress, bool usePartialFiles,
+            TimeSpan webSeedConnectionTimeout, TimeSpan webSeedDelay, int webSeedSpeedTrigger, TimeSpan staleRequestTimeout)
         {
             // Make sure this is immutable now
             AllowedEncryption = EncryptionTypes.MakeReadOnly (allowedEncryption);
@@ -244,7 +272,11 @@ namespace MonoTorrent.Client
             MaximumOpenFiles = maximumOpenFiles;
             MaximumUploadRate = maximumUploadRate;
             ReportedAddress = reportedAddress;
+            StaleRequestTimeout = staleRequestTimeout;
             UsePartialFiles = usePartialFiles;
+            WebSeedConnectionTimeout = webSeedConnectionTimeout;
+            WebSeedDelay = webSeedDelay;
+            WebSeedSpeedTrigger = webSeedSpeedTrigger;
         }
 
         internal string GetDhtNodeCacheFilePath ()
@@ -288,7 +320,11 @@ namespace MonoTorrent.Client
                    && MaximumOpenFiles == other.MaximumOpenFiles
                    && MaximumUploadRate == other.MaximumUploadRate
                    && ReportedAddress == other.ReportedAddress
+                   && StaleRequestTimeout == other.StaleRequestTimeout
                    && UsePartialFiles == other.UsePartialFiles
+                   && WebSeedConnectionTimeout == other.WebSeedConnectionTimeout
+                   && WebSeedDelay == other.WebSeedDelay
+                   && WebSeedSpeedTrigger == other.WebSeedSpeedTrigger
                    ;
         }
 

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Settings/TorrentSettings.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Settings/TorrentSettings.cs
@@ -80,16 +80,6 @@ namespace MonoTorrent.Client
         public int UploadSlots { get; } = 8;
 
         /// <summary>
-        /// The delay before a torrent will start using web seeds.
-        /// </summary>
-        public TimeSpan WebSeedDelay { get; } = TimeSpan.FromMinutes (1);
-
-        /// <summary>
-        /// The download speed under which a torrent will start using web seeds.
-        /// </summary>
-        public int WebSeedSpeedTrigger { get; } = 15 * 1024;
-
-        /// <summary>
         /// When considering peers that have given us data, the inactivity manager will wait TimeToWaiTUntilIdle plus (Number of bytes we've been sent / ConnectionRetentionFactor) seconds
         /// before they are eligible for disconnection.  Default value is 2000.  A value of 0 prevents the inactivity manager from disconnecting peers that have sent data.
         /// </summary>
@@ -112,7 +102,7 @@ namespace MonoTorrent.Client
 
         }
 
-        internal TorrentSettings (bool allowDht, bool allowInitialSeeding, bool allowPeerExchange, int maximumConnections, int maximumDownloadRate, int maximumUploadRate, int uploadSlots, TimeSpan webSeedDelay, int webSeedSpeedTrigger, bool createContainingDirectory)
+        internal TorrentSettings (bool allowDht, bool allowInitialSeeding, bool allowPeerExchange, int maximumConnections, int maximumDownloadRate, int maximumUploadRate, int uploadSlots, bool createContainingDirectory)
         {
             AllowDht = allowDht;
             AllowInitialSeeding = allowInitialSeeding;
@@ -122,8 +112,6 @@ namespace MonoTorrent.Client
             MaximumDownloadRate = maximumDownloadRate;
             MaximumUploadRate = maximumUploadRate;
             UploadSlots = uploadSlots;
-            WebSeedDelay = webSeedDelay;
-            WebSeedSpeedTrigger = webSeedSpeedTrigger;
         }
 
         public override bool Equals (object? obj)
@@ -139,9 +127,7 @@ namespace MonoTorrent.Client
                 && MaximumConnections == other.MaximumConnections
                 && MaximumDownloadRate == other.MaximumDownloadRate
                 && MaximumUploadRate == other.MaximumUploadRate
-                && UploadSlots == other.UploadSlots
-                && WebSeedDelay == other.WebSeedDelay
-                && WebSeedSpeedTrigger == other.WebSeedSpeedTrigger;
+                && UploadSlots == other.UploadSlots;
         }
 
         public override int GetHashCode ()

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Settings/TorrentSettingsBuilder.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Settings/TorrentSettingsBuilder.cs
@@ -96,16 +96,6 @@ namespace MonoTorrent.Client
             set => uploadSlots = CheckZeroOrPositive (value);
         }
 
-        /// <summary>
-        /// The delay before a torrent will start using web seeds.
-        /// </summary>
-        public TimeSpan WebSeedDelay { get; set; }
-
-        /// <summary>
-        /// The download speed under which a torrent will start using web seeds.
-        /// </summary>
-        public int WebSeedSpeedTrigger { get; set; }
-
         public TorrentSettingsBuilder ()
             : this (new TorrentSettings ())
         {
@@ -122,23 +112,19 @@ namespace MonoTorrent.Client
             MaximumDownloadRate = settings.MaximumDownloadRate;
             MaximumUploadRate = settings.MaximumUploadRate;
             UploadSlots = settings.UploadSlots;
-            WebSeedDelay = settings.WebSeedDelay;
-            WebSeedSpeedTrigger = settings.WebSeedSpeedTrigger;
         }
 
         public TorrentSettings ToSettings ()
         {
             return new TorrentSettings (
-                AllowDht,
-                AllowInitialSeeding,
-                AllowPeerExchange,
-                MaximumConnections,
-                MaximumDownloadRate,
-                MaximumUploadRate,
-                UploadSlots,
-                WebSeedDelay,
-                WebSeedSpeedTrigger,
-                CreateContainingDirectory
+                allowDht: AllowDht,
+                allowInitialSeeding: AllowInitialSeeding,
+                allowPeerExchange: AllowPeerExchange,
+                createContainingDirectory: CreateContainingDirectory,
+                maximumConnections: MaximumConnections,
+                maximumDownloadRate: MaximumDownloadRate,
+                maximumUploadRate: MaximumUploadRate,
+                uploadSlots: UploadSlots
             );
         }
 

--- a/src/MonoTorrent.Client/MonoTorrent.Connections/HttpPeerConnection.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Connections/HttpPeerConnection.cs
@@ -106,9 +106,9 @@ namespace MonoTorrent.Connections.Peer
 
         #region Constructors
 
-        public HttpPeerConnection (ITorrentManagerInfo torrentData, Factories requestCreator, Uri uri)
+        public HttpPeerConnection (ITorrentManagerInfo torrentData, TimeSpan connectionTimeout, Factories requestCreator, Uri uri)
         {
-            ConnectionTimeout = TimeSpan.FromSeconds (10);
+            ConnectionTimeout = connectionTimeout;
             RequestCreator = requestCreator;
             TorrentData = torrentData ?? throw new ArgumentNullException (nameof (torrentData));
             Uri = uri;

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/TestWebSeed.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/TestWebSeed.cs
@@ -84,7 +84,7 @@ namespace MonoTorrent.Client
 
             rig = TestRig.CreateMultiFile ();
 
-            connection = new HttpPeerConnection (rig.Manager, rig.Engine.Factories, new Uri (ListenerURL));
+            connection = new HttpPeerConnection (rig.Manager, rig.Engine.Settings.WebSeedConnectionTimeout, rig.Engine.Factories, new Uri (ListenerURL));
             rig.Manager.UnhashedPieces.SetAll (false);
 
             id = new PeerId (new Peer ("this is my id", connection.Uri), connection, new BitField (rig.Manager.Torrent.PieceCount ()).SetAll (true));
@@ -380,7 +380,7 @@ namespace MonoTorrent.Client
             rig.Torrent.HttpSeeds.Add (new Uri ($"{ListenerURL}File1.exe"));
 
             Uri url = rig.Torrent.HttpSeeds[0];
-            connection = new HttpPeerConnection (rig.Manager, rig.Engine.Factories, url);
+            connection = new HttpPeerConnection (rig.Manager, rig.Engine.Settings.WebSeedConnectionTimeout, rig.Engine.Factories, url);
             rig.Manager.UnhashedPieces.SetAll (false);
 
             id = new PeerId (new Peer ("this is my id", connection.Uri), id.Connection, new BitField (rig.Manager.Torrent.PieceCount ()).SetAll (true));


### PR DESCRIPTION
Increase some timeouts as some web servers, specifically some
from internet archive, take longer than 10 seconds to respond,
which means the time between block requests can be significantly
longer than 15 seconds too.

These new (arbitrary) values are enough to reliably download from
both webseed urls for the public domain torrent listed in

https://github.com/alanmcgovern/monotorrent/issues/538