### PR TITLE
[piecewriter] Add a cache policy so reads can be cached

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/DiskManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/DiskManager.cs
@@ -270,7 +270,7 @@ namespace MonoTorrent.Client
             Settings = settings ?? throw new ArgumentNullException (nameof (settings));
 
             writer ??= factories.CreatePieceWriter (settings.MaximumOpenFiles);
-            Cache = factories.CreateBlockCache (writer, settings.DiskCacheBytes, BufferPool);
+            Cache = factories.CreateBlockCache (writer, settings.DiskCacheBytes, settings.DiskCachePolicy, BufferPool);
             Cache.ReadThroughCache += (o, e) => WriterReadMonitor.AddDelta (e.RequestLength);
             Cache.WrittenThroughCache += (o, e) => WriterWriteMonitor.AddDelta (e.RequestLength);
             IncrementalHashCache = new Cache<IncrementalHashData> (() => new IncrementalHashData ());

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Settings/EngineSettings.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Settings/EngineSettings.cs
@@ -35,6 +35,7 @@ using System.Net;
 
 using MonoTorrent.Connections;
 using MonoTorrent.Dht;
+using MonoTorrent.PieceWriter;
 
 namespace MonoTorrent.Client
 {
@@ -115,6 +116,13 @@ namespace MonoTorrent.Client
         /// Defaults to 5MB.
         /// </summary>
         public int DiskCacheBytes { get; } = 5 * 1024 * 1024;
+
+        /// <summary>
+        /// Creates a cache which buffers data before it's written to the disk, or after it's been read from disk.
+        /// Set to 0 to disable the cache.
+        /// Defaults to 5MB.
+        /// </summary>
+        public CachePolicy DiskCachePolicy { get; } = CachePolicy.WritesOnly;
 
         /// <summary>
         /// The UDP port used for DHT communications. Set the port to 0 to choose a random available port.
@@ -245,7 +253,7 @@ namespace MonoTorrent.Client
         internal EngineSettings (
             IList<EncryptionType> allowedEncryption, bool allowHaveSuppression, bool allowLocalPeerDiscovery, bool allowPortForwarding,
             bool autoSaveLoadDhtCache, bool autoSaveLoadFastResume, bool autoSaveLoadMagnetLinkMetadata, string cacheDirectory,
-            TimeSpan connectionTimeout, IPEndPoint? dhtEndPoint, int diskCacheBytes, FastResumeMode fastResumeMode, IPEndPoint? listenEndPoint,
+            TimeSpan connectionTimeout, IPEndPoint? dhtEndPoint, int diskCacheBytes, CachePolicy diskCachePolicy, FastResumeMode fastResumeMode, IPEndPoint? listenEndPoint,
             int maximumConnections, int maximumDiskReadRate, int maximumDiskWriteRate, int maximumDownloadRate, int maximumHalfOpenConnections,
             int maximumOpenFiles, int maximumUploadRate, IPEndPoint? reportedAddress, bool usePartialFiles,
             TimeSpan webSeedConnectionTimeout, TimeSpan webSeedDelay, int webSeedSpeedTrigger, TimeSpan staleRequestTimeout)
@@ -260,6 +268,7 @@ namespace MonoTorrent.Client
             AutoSaveLoadMagnetLinkMetadata = autoSaveLoadMagnetLinkMetadata;
             DhtEndPoint = dhtEndPoint;
             DiskCacheBytes = diskCacheBytes;
+            DiskCachePolicy = diskCachePolicy;
             CacheDirectory = cacheDirectory;
             ConnectionTimeout = connectionTimeout;
             FastResumeMode = fastResumeMode;
@@ -310,6 +319,7 @@ namespace MonoTorrent.Client
                    && CacheDirectory == other.CacheDirectory
                    && Equals (DhtEndPoint, other.DhtEndPoint)
                    && DiskCacheBytes == other.DiskCacheBytes
+                   && DiskCachePolicy == other.DiskCachePolicy
                    && FastResumeMode == other.FastResumeMode
                    && Equals (ListenEndPoint, other.ListenEndPoint)
                    && MaximumConnections == other.MaximumConnections

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Settings/EngineSettingsBuilder.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Settings/EngineSettingsBuilder.cs
@@ -35,6 +35,7 @@ using System.Net;
 
 using MonoTorrent.Connections;
 using MonoTorrent.Dht;
+using MonoTorrent.PieceWriter;
 
 namespace MonoTorrent.Client
 {
@@ -164,6 +165,12 @@ namespace MonoTorrent.Client
             get => diskCacheBytes;
             set => diskCacheBytes = CheckZeroOrPositive (value);
         }
+
+
+        /// <summary>
+        /// Determines if writes should be cached, or if reads and writes should be cached.
+        /// </summary>
+        public CachePolicy DiskCachePolicy { get; set; }
 
         /// <summary>
         /// The UDP port used for DHT communications. Use 0 to choose a random available port.
@@ -321,6 +328,7 @@ namespace MonoTorrent.Client
             ConnectionTimeout = settings.ConnectionTimeout;
             DhtEndPoint = settings.DhtEndPoint;
             DiskCacheBytes = settings.DiskCacheBytes;
+            DiskCachePolicy = settings.DiskCachePolicy;
             FastResumeMode = settings.FastResumeMode;
             ListenEndPoint = settings.ListenEndPoint;
             MaximumConnections = settings.MaximumConnections;
@@ -359,6 +367,7 @@ namespace MonoTorrent.Client
                 connectionTimeout: ConnectionTimeout,
                 dhtEndPoint: DhtEndPoint,
                 diskCacheBytes: DiskCacheBytes,
+                diskCachePolicy: DiskCachePolicy,
                 fastResumeMode: FastResumeMode,
                 listenEndPoint: ListenEndPoint,
                 maximumConnections: MaximumConnections,

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Settings/Serializer.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Settings/Serializer.cs
@@ -34,6 +34,7 @@ using System.Net;
 
 using MonoTorrent.BEncoding;
 using MonoTorrent.Connections;
+using MonoTorrent.PieceWriter;
 
 namespace MonoTorrent.Client
 {
@@ -70,6 +71,8 @@ namespace MonoTorrent.Client
                     property.SetValue (builder, TimeSpan.FromTicks (((BEncodedNumber) value).Number));
                 } else if (property.PropertyType == typeof (int)) {
                     property.SetValue (builder, (int) ((BEncodedNumber) value).Number);
+                } else if (property.PropertyType == typeof (CachePolicy)) {
+                    property.SetValue (builder, Enum.Parse (typeof (CachePolicy), ((BEncodedString) value).Text));
                 } else if (property.PropertyType == typeof (IPAddress)) {
                     property.SetValue (builder, IPAddress.Parse (((BEncodedString) value).Text));
                 } else if (property.PropertyType == typeof (IPEndPoint)) {
@@ -106,6 +109,7 @@ namespace MonoTorrent.Client
                     IPEndPoint value => new BEncodedList { (BEncodedString) value.Address.ToString (), (BEncodedNumber) value.Port },
                     int value => new BEncodedNumber (value),
                     FastResumeMode value => new BEncodedString (value.ToString ()),
+                    CachePolicy value => new BEncodedString (value.ToString ()),
                     null => null,
                     _ => throw new NotSupportedException ($"{property.Name} => type: ${property.PropertyType}"),
                 };

--- a/src/MonoTorrent.Factories/MonoTorrent/Factories.cs
+++ b/src/MonoTorrent.Factories/MonoTorrent/Factories.cs
@@ -47,7 +47,7 @@ namespace MonoTorrent
 {
     public partial class Factories
     {
-        public delegate IBlockCache BlockCacheCreator (IPieceWriter writer, long capacity, MemoryPool buffer);
+        public delegate IBlockCache BlockCacheCreator (IPieceWriter writer, long capacity, CachePolicy policy, MemoryPool buffer);
         public delegate IDhtEngine DhtCreator ();
         public delegate IDhtListener DhtListenerCreator (IPEndPoint endpoint);
         public delegate HttpClient HttpClientCreator ();
@@ -83,7 +83,7 @@ namespace MonoTorrent
 
         public Factories ()
         {
-            BlockCacheFunc = (writer, capacity, buffer) => new MemoryCache (buffer, capacity, writer);
+            BlockCacheFunc = (writer, capacity, policy, buffer) => new MemoryCache (buffer, capacity, policy, writer);
             DhtFunc = () => new DhtEngine ();
             DhtListenerFunc = endpoint => new DhtListener (endpoint);
             HttpClientFunc = () => {
@@ -114,8 +114,8 @@ namespace MonoTorrent
             );
         }
 
-        public IBlockCache CreateBlockCache (IPieceWriter writer, long capacity, MemoryPool buffer)
-            => BlockCacheFunc (writer, capacity, buffer);
+        public IBlockCache CreateBlockCache (IPieceWriter writer, long capacity, CachePolicy policy, MemoryPool buffer)
+            => BlockCacheFunc (writer, capacity, policy, buffer);
         public Factories WithBlockCacheCreator (BlockCacheCreator creator)
         {
             var dupe = MemberwiseClone ();

--- a/src/MonoTorrent/MonoTorrent.PieceWriter/CachePolicy.cs
+++ b/src/MonoTorrent/MonoTorrent.PieceWriter/CachePolicy.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MonoTorrent.PieceWriter
+{
+    public enum CachePolicy
+    {
+        WritesOnly,
+        ReadsAndWrites,
+    }
+}

--- a/src/MonoTorrent/MonoTorrent.PieceWriter/IBlockCache.cs
+++ b/src/MonoTorrent/MonoTorrent.PieceWriter/IBlockCache.cs
@@ -70,6 +70,8 @@ namespace MonoTorrent.PieceWriter
         /// </summary>
         long Capacity { get; }
 
+        CachePolicy Policy { get; }
+
         /// <summary>
         /// Pieces will be written to this <see cref="IPieceWriter"/> when they are evicted from the cache.
         /// </summary>
@@ -100,6 +102,13 @@ namespace MonoTorrent.PieceWriter
         /// <param name="capacity"></param>
         /// <returns></returns>
         ReusableTask SetCapacityAsync (long capacity);
+
+        /// <summary>
+        /// Sets the cache policy.
+        /// </summary>
+        /// <param name="policy"></param>
+        /// <returns></returns>
+        ReusableTask SetPolicyAsync (CachePolicy policy);
 
         ReusableTask SetWriterAsync (IPieceWriter writer);
 


### PR DESCRIPTION
This will be useful when creating torrents. In this scenario
we want to be able to read a piece into memory, hash it using
both SHA1 and SHA256, and then return the bittorrent v1 and
v2 hashes for that piece.

Afterwards, we need to compute the SHA1 and MD5 hashes for the
individual file. This would normally require re-reading the
exact same data from disk, but now we can fetch it from memory.