### PR TITLE
Add support for creating V1/V2 hybrid  torrents, and V2 torrents

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/StartingMode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/StartingMode.cs
@@ -101,7 +101,7 @@ namespace MonoTorrent.Client.Modes
 
             Manager.PieceManager.Initialise ();
             if (Manager.PendingV2PieceHashes.TrueCount > 0) {
-                Manager.Mode = new PieceHashesMode (Manager, DiskManager, ConnectionManager, Settings);
+                Manager.Mode = new PieceHashesMode (Manager, DiskManager, ConnectionManager, Settings, false);
             } else if (Manager.Complete && Manager.Settings.AllowInitialSeeding && ClientEngine.SupportsInitialSeed) {
                 Manager.Mode = new InitialSeedingMode (Manager, DiskManager, ConnectionManager, Settings);
             } else {

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/DiskManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/DiskManager.cs
@@ -360,7 +360,7 @@ namespace MonoTorrent.Client
 
                     while (startOffset != endOffset) {
                         int count = Math.Min (Constants.BlockSize, endOffset - startOffset);
-                        if (!await ReadAsync (manager, new BlockInfo (pieceIndex, startOffset, count), hashBuffer).ConfigureAwait (false))
+                        if (!await ReadAsync (manager, new BlockInfo (pieceIndex, startOffset, count), hashBuffer.Slice (0, count)).ConfigureAwait (false))
                             return false;
                         startOffset += count;
                         incrementalHash.AppendData (hashBuffer.Span.Slice (0, count));

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentFileInfo.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentFileInfo.cs
@@ -75,12 +75,15 @@ namespace MonoTorrent.Client
 
 
         internal static TorrentFileInfo[] Create (int pieceLength, params long[] sizes)
-            => Create (pieceLength, sizes.Select ((size, index) => ("File_" + index, size, "full/path/to/File_" + index)).ToArray ());
+            => Create (pieceLength, sizes.Select ((size, index) => ("File_" + index, size, 0, "full/path/to/File_" + index)).ToArray ());
 
         internal static TorrentFileInfo[] Create (int pieceLength, params (string torrentPath, long size, string fullPath)[] infos)
+            => Create (pieceLength, infos.Select (t => (t.torrentPath, t.size, 0, t.fullPath)).ToArray ());
+
+        internal static TorrentFileInfo[] Create (int pieceLength, params (string torrentPath, long size, int padding, string fullPath)[] infos)
         {
             // TorrentFile.Create can reorder the files if there are any of length zero.
-            var torrentFiles = MonoTorrent.TorrentFile.Create (pieceLength, infos.Select (t => (t.torrentPath, t.size)).ToArray ());
+            var torrentFiles = MonoTorrent.TorrentFile.Create (pieceLength, infos.Select (t => (t.torrentPath, t.size, t.padding)).ToArray ());
             return torrentFiles.Select (t => {
                 var info = infos.Single (info => info.torrentPath == t.Path);
                 return new TorrentFileInfo (t, info.fullPath);

--- a/src/MonoTorrent.Client/MonoTorrent/EditableTorrent.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/EditableTorrent.cs
@@ -91,8 +91,8 @@ namespace MonoTorrent
             set => SetString (InfoDict, NameKey, value);
         }
 
-        public long PieceLength {
-            get => GetLong (InfoDict, PieceLengthKey);
+        public int PieceLength {
+            get => (int) GetLong (InfoDict, PieceLengthKey);
             set => SetLong (InfoDict, PieceLengthKey, value);
         }
 

--- a/src/MonoTorrent.Client/MonoTorrent/MerkleLayers.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/MerkleLayers.cs
@@ -41,7 +41,7 @@ namespace MonoTorrent
 
         List<Memory<byte>> Layers { get; }
 
-        MerkleRoot ExpectedRoot { get; }
+        MerkleRoot ExpectedRoot { get; set; }
 
         public int PieceLayerIndex { get; }
 
@@ -79,8 +79,10 @@ namespace MonoTorrent
             using var hasher = IncrementalHash.CreateHash (HashAlgorithmName.SHA256);
             if (!MerkleHash.TryHash (hasher, hashes, (int) Math.Pow (2, baseLayer) * 16384, proofs, index, length, computedHash, out int written))
                 return false;
-            if (!computedHash.SequenceEqual (ExpectedRoot.Span))
+            if (!ExpectedRoot.IsEmpty && !computedHash.SequenceEqual (ExpectedRoot.Span))
                 return false;
+            if (ExpectedRoot.IsEmpty)
+                ExpectedRoot = new MerkleRoot (computedHash);
             
             hashes.Slice (0, hashLength).CopyTo (fileHashes.Span.Slice (hashOffset, hashLength));
             return true;

--- a/src/MonoTorrent.Client/MonoTorrent/PieceHashesV2.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/PieceHashesV2.cs
@@ -54,7 +54,7 @@ namespace MonoTorrent
         internal PieceHashesV2 (int pieceLength, IList<ITorrentFile> files, BEncodedDictionary layers)
             : this (pieceLength,
                   files,
-                  layers.ToDictionary (kvp => new MerkleRoot (kvp.Key.AsMemory ()), kvp => ReadOnlyMerkleLayers.FromLayer (pieceLength, new MerkleRoot (kvp.Key.AsMemory ()), ((BEncodedString) kvp.Value).AsMemory ().Span)!))
+                  layers.ToDictionary (kvp => MerkleRoot.FromMemory (kvp.Key.AsMemory ()), kvp => ReadOnlyMerkleLayers.FromLayer (pieceLength, MerkleRoot.FromMemory (kvp.Key.AsMemory ()), ((BEncodedString) kvp.Value).AsMemory ().Span)!))
         {
         }
 

--- a/src/MonoTorrent.Client/MonoTorrent/TorrentFile.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/TorrentFile.cs
@@ -139,7 +139,10 @@ namespace MonoTorrent
             => Create (pieceLength, lengths.Select ((length, index) => ("File_" + index, length)).ToArray ());
 
         internal static ITorrentFile[] Create (int pieceLength, params (string torrentPath, long length)[] files)
-            => Create (pieceLength, files.Select (t => new TorrentFileTuple { path = t.torrentPath, length = t.length }).ToArray ());
+            => Create (pieceLength, files.Select (t => new TorrentFileTuple { path = t.torrentPath, length = t.length, padding = 0 }).ToArray ());
+
+        internal static ITorrentFile[] Create (int pieceLength, params (string torrentPath, long length, int padding)[] files)
+            => Create (pieceLength, files.Select (t => new TorrentFileTuple { path = t.torrentPath, length = t.length, padding = t.padding }).ToArray ());
 
         internal static ITorrentFile[] Create (int pieceLength, TorrentFileTuple[] files)
         {

--- a/src/MonoTorrent.Client/MonoTorrent/TorrentFileSource.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/TorrentFileSource.cs
@@ -64,7 +64,7 @@ namespace MonoTorrent
             string fullPath = System.IO.Path.GetFullPath (Path);
             if (File.Exists (fullPath)) {
                 TorrentName = System.IO.Path.GetFileName (fullPath);
-                Files = new List<FileMapping> { new FileMapping (fullPath, TorrentName) };
+                Files = new List<FileMapping> { new FileMapping (fullPath, TorrentName, new FileInfo (fullPath).Length) };
                 return;
             }
 
@@ -99,7 +99,7 @@ namespace MonoTorrent
 
             // Turn the full path of each file into a full path + relative path. The relative path is the 'path'
             // which the file will have within the .torrent metadata.
-            Files = files.ConvertAll (file => new FileMapping (file, file.Substring (fullPath.Length)));
+            Files = files.ConvertAll (file => new FileMapping (file, file.Substring (fullPath.Length), new FileInfo (file).Length));
 
             // Set the torrent name (user can change it later)
             TorrentName = new DirectoryInfo (fullPath).Name;

--- a/src/MonoTorrent.Client/MonoTorrent/TorrentType.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/TorrentType.cs
@@ -1,10 +1,11 @@
-//
-// FileMapping.cs
+﻿//
+// TorrentCreator.cs
 //
 // Authors:
+//   Gregor Burger burger.gregor@gmail.com
 //   Alan McGovern alan.mcgovern@gmail.com
 //
-// Copyright (C) 2009 Alan McGovern
+// Copyright (C) 2006-2007 Gregor Burger and Alan McGovern
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -13,10 +14,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -26,31 +27,25 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-
 namespace MonoTorrent
 {
-    public struct FileMapping
+    public enum TorrentType
     {
         /// <summary>
-        /// This is the full path to the file on disk
+        /// Generates a V1 compatible torrent.
         /// </summary>
-        public string Source { get; }
-
+        V1Only,
         /// <summary>
-        /// This is the relative path to the file within the Torrent
+        /// A torrent file with BitTorrent V1 metadata. All files are padded so they align to piece boundaries.
         /// </summary>
-        public string Destination { get; }
-
+        V1OnlyWithPaddingFiles,
         /// <summary>
-        /// The length of the file
+        /// A torrent file with BitTorrent V1 and BitTorrent V2 metadata
         /// </summary>
-        public long Length { get; }
-
-        public FileMapping (string source, string destination, long length)
-        {
-            Source = source;
-            Destination = destination;
-            Length = length;
-        }
+        V1V2Hybrid,
+        /// <summary>
+        /// A torrent file with BitTorrent V2 metadata
+        /// </summary>
+        V2Only,
     }
 }

--- a/src/MonoTorrent.Messages/MonoTorrent.Messages.Peer/HashRejectMessage.cs
+++ b/src/MonoTorrent.Messages/MonoTorrent.Messages.Peer/HashRejectMessage.cs
@@ -60,7 +60,7 @@ namespace MonoTorrent.Messages.Peer
 
         public override void Decode (ReadOnlySpan<byte> buffer)
         {
-            PiecesRoot = new MerkleRoot (ReadBytes (ref buffer, 32));
+            PiecesRoot = MerkleRoot.FromMemory (ReadBytes (ref buffer, 32));
             BaseLayer = ReadInt (ref buffer);
             Index = ReadInt (ref buffer);
             Length = ReadInt (ref buffer);

--- a/src/MonoTorrent.Messages/MonoTorrent.Messages.Peer/HashRequestMessage.cs
+++ b/src/MonoTorrent.Messages/MonoTorrent.Messages.Peer/HashRequestMessage.cs
@@ -60,7 +60,7 @@ namespace MonoTorrent.Messages.Peer
 
         public override void Decode (ReadOnlySpan<byte> buffer)
         {
-            PiecesRoot = new MerkleRoot (ReadBytes (ref buffer, 32));
+            PiecesRoot = MerkleRoot.FromMemory (ReadBytes (ref buffer, 32));
             BaseLayer = ReadInt (ref buffer);
             Index = ReadInt (ref buffer);
             Length = ReadInt (ref buffer);

--- a/src/MonoTorrent.Messages/MonoTorrent.Messages.Peer/HashesMessage.cs
+++ b/src/MonoTorrent.Messages/MonoTorrent.Messages.Peer/HashesMessage.cs
@@ -64,7 +64,7 @@ namespace MonoTorrent.Messages.Peer
 
         public override void Decode (ReadOnlySpan<byte> buffer)
         {
-            PiecesRoot = new MerkleRoot (ReadBytes (ref buffer, 32));
+            PiecesRoot = MerkleRoot.FromMemory (ReadBytes (ref buffer, 32));
             BaseLayer = ReadInt (ref buffer);
             Index = ReadInt (ref buffer);
             Length = ReadInt (ref buffer);

--- a/src/MonoTorrent.PieceWriter/MonoTorrent.PieceWriter/IPieceWriterExtensions.cs
+++ b/src/MonoTorrent.PieceWriter/MonoTorrent.PieceWriter/IPieceWriterExtensions.cs
@@ -55,7 +55,7 @@ namespace MonoTorrent.PieceWriter
                 int fileToRead = (int) Math.Min (files[i].Length + files[i].Padding - offset, count - totalRead);
                 fileToRead = Math.Min (fileToRead, Constants.BlockSize);
 
-                if (fileToRead != await writer.PaddingAwareReadAsync (files[i], offset, buffer.Slice (totalRead, fileToRead)))
+                if (fileToRead != await writer.PaddingAwareReadAsync (files[i], offset, buffer.Slice (totalRead, fileToRead)).ConfigureAwait (false))
                     return totalRead;
 
                 offset += fileToRead;

--- a/src/MonoTorrent/MonoTorrent.PieceWriter/IPieceWriter.cs
+++ b/src/MonoTorrent/MonoTorrent.PieceWriter/IPieceWriter.cs
@@ -68,7 +68,7 @@ namespace MonoTorrent.PieceWriter
             int done = 0;
 
             if (todoFile > 0) {
-                done = await writer.ReadAsync (file, offset, buffer.Slice (0, todoFile));
+                done = await writer.ReadAsync (file, offset, buffer.Slice (0, todoFile)).ConfigureAwait (false);
                 if (done < todoFile)
                     return done;
             }
@@ -96,7 +96,7 @@ namespace MonoTorrent.PieceWriter
             if (todoFile > 0) {
                 done = await writer.ReadAsync (file, offset, buffer.Slice (0, todoFile));
                 if (done < todoFile)
-                    return (done,0);
+                    return (done, 0);
             }
 
             if (todoPadding > 0) {
@@ -104,7 +104,7 @@ namespace MonoTorrent.PieceWriter
                 done += todoPadding;
             }
 
-            return (done,todoPadding);
+            return (done, todoPadding);
         }
 
         public static async ReusableTask PaddingAwareWriteAsync (this IPieceWriter writer, ITorrentManagerFile file, long offset, ReadOnlyMemory<byte> buffer)

--- a/src/MonoTorrent/MonoTorrent/MerkleRoot.cs
+++ b/src/MonoTorrent/MonoTorrent/MerkleRoot.cs
@@ -36,13 +36,22 @@ namespace MonoTorrent
     {
         public static MerkleRoot Empty => new MerkleRoot ();
 
+        public static MerkleRoot FromMemory (ReadOnlyMemory<byte> hash)
+            => new MerkleRoot (hash);
+
         readonly ReadOnlyMemory<byte> Hash;
 
         public bool IsEmpty => Hash.IsEmpty;
 
         public ReadOnlySpan<byte> Span => Hash.Span;
 
-        public MerkleRoot (ReadOnlyMemory<byte> hash)
+        public MerkleRoot (Span<byte> hash)
+            : this (new ReadOnlyMemory<byte> (hash.ToArray ()))
+        {
+
+        }
+
+        private MerkleRoot (ReadOnlyMemory<byte> hash)
         {
             if (hash.Length != 32)
                 throw new ArgumentException ("The hash must be exactly 32 bytes long");

--- a/src/Samples/SampleClient/StressTest.cs
+++ b/src/Samples/SampleClient/StressTest.cs
@@ -107,7 +107,7 @@ namespace ClientSample
             trackerListener.Start ();
 
             // Create the torrent file for the fake data
-            var creator = new TorrentCreator ();
+            var creator = new TorrentCreator (TorrentType.V1Only);
             creator.Announces.Add (new List<string> ());
             creator.Announces[0].Add ("http://127.0.0.1:25611/announce");
 

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/PieceHashesModeTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/PieceHashesModeTests.cs
@@ -72,7 +72,7 @@ namespace MonoTorrent.Client.Modes
         {
             (var engine, var manager, var layers) = await CreateTorrent (V2OnlyTorrentPath);
 
-            var pieceHashesMode = new PieceHashesMode (manager, engine.DiskManager, engine.ConnectionManager, engine.Settings);
+            var pieceHashesMode = new PieceHashesMode (manager, engine.DiskManager, engine.ConnectionManager, engine.Settings, true);
             var peer = manager.AddConnectedPeer (supportsLTMetdata: true);
 
             Assert.AreEqual (manager.PieceHashes.Count, 0);
@@ -85,7 +85,7 @@ namespace MonoTorrent.Client.Modes
         public async Task RequestHashes ()
         {
             (var engine, var manager, var layers) = await CreateTorrent (V2OnlyTorrentPath);
-            var pieceHashesMode = new PieceHashesMode (manager, engine.DiskManager, engine.ConnectionManager, engine.Settings);
+            var pieceHashesMode = new PieceHashesMode (manager, engine.DiskManager, engine.ConnectionManager, engine.Settings, true);
             var peer = manager.AddConnectedPeer (supportsLTMetdata: true);
             pieceHashesMode.HandleMessage (peer, new ExtendedHandshakeMessage (false, manager.Torrent.InfoMetadata.Length, 12345), default);
             while (!manager.PendingV2PieceHashes.AllFalse && manager.PieceHashes.Count == 0 && !manager.PieceHashes.HasV2Hashes) {
@@ -107,7 +107,7 @@ namespace MonoTorrent.Client.Modes
         {
             (var engine, var manager, var layers) = await CreateTorrent (V2OnlyTorrentPath);
 
-            var pieceHashesMode = new PieceHashesMode (manager, engine.DiskManager, engine.ConnectionManager, engine.Settings);
+            var pieceHashesMode = new PieceHashesMode (manager, engine.DiskManager, engine.ConnectionManager, engine.Settings, true);
             var peer = manager.AddConnectedPeer (supportsLTMetdata: true);
             pieceHashesMode.Tick (0);
             Assert.AreNotEqual (0, peer.AmRequestingPiecesCount);

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/TestRig.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/TestRig.cs
@@ -53,6 +53,7 @@ namespace MonoTorrent.Client
         public List<ITorrentManagerFile> FilesThatExist = new List<ITorrentManagerFile> ();
         public List<ITorrentManagerFile> DoNotReadFrom = new List<ITorrentManagerFile> ();
         public bool DontWrite;
+        public byte? FillValue;
 
         /// <summary>
         /// this is the list of paths we have read from
@@ -76,6 +77,9 @@ namespace MonoTorrent.Client
                 for (int i = 0; i < buffer.Length; i++)
                     buffer.Span[i] = (byte) (offset + i);
             }
+
+            if (FillValue.HasValue)
+                buffer.Span.Fill (FillValue.Value);
 
             return ReusableTask.FromResult (buffer.Length);
         }

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/MerkleTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/MerkleTests.cs
@@ -24,7 +24,7 @@ namespace MonoTorrent.Client
         [Test]
         public void CreateTree_OneRootHash ([Values (1)] int hashes)
         {
-            var expectedRoot = new MerkleRoot (MerkleHash.PaddingHashes[Constants.BlockSize * 2]);
+            var expectedRoot = MerkleRoot.FromMemory (MerkleHash.PaddingHashes[Constants.BlockSize * 2]);
             var leafHashes = Replicate (MerkleHash.PaddingHashes[Constants.BlockSize], hashes);
 
             Assert.Throws<ArgumentException> (() => CreateMerkleTree (Constants.BlockSize, expectedRoot, leafHashes.Span));
@@ -33,7 +33,7 @@ namespace MonoTorrent.Client
         [Test]
         public void CreateTree_2Hashes ([Values(2)] int hashes)
         {
-            var expectedRoot = new MerkleRoot (MerkleHash.PaddingHashes[Constants.BlockSize * 2]);
+            var expectedRoot = MerkleRoot.FromMemory (MerkleHash.PaddingHashes[Constants.BlockSize * 2]);
             var leafHashes = Replicate (MerkleHash.PaddingHashes[Constants.BlockSize], hashes);
 
             var layers = CreateMerkleTree (Constants.BlockSize, expectedRoot, leafHashes.Span);
@@ -44,7 +44,7 @@ namespace MonoTorrent.Client
         [Test]
         public void CreateTree_4Hashes ([Values (3, 4)] int hashes)
         {
-            var expectedRoot = new MerkleRoot (MerkleHash.PaddingHashes[Constants.BlockSize * 4]);
+            var expectedRoot = MerkleRoot.FromMemory (MerkleHash.PaddingHashes[Constants.BlockSize * 4]);
             var leafHashes = Replicate (MerkleHash.PaddingHashes[Constants.BlockSize], hashes);
 
             var layers = CreateMerkleTree (Constants.BlockSize, expectedRoot, leafHashes.Span);
@@ -56,7 +56,7 @@ namespace MonoTorrent.Client
         [Test]
         public void CreateTree_8Hashes ([Values (5, 6, 7, 8)] int hashes)
         {
-            var expectedRoot = new MerkleRoot (MerkleHash.PaddingHashes[Constants.BlockSize * 8]);
+            var expectedRoot = MerkleRoot.FromMemory (MerkleHash.PaddingHashes[Constants.BlockSize * 8]);
             var leafHashes = Replicate (MerkleHash.PaddingHashes[Constants.BlockSize], hashes);
 
             var layers = CreateMerkleTree (Constants.BlockSize, expectedRoot, leafHashes.Span);

--- a/src/Tests/Tests.MonoTorrent.Messages/StandardMessageTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Messages/StandardMessageTests.cs
@@ -167,7 +167,7 @@ namespace MonoTorrent.Messages.Peer
         [Test]
         public void HashReject ()
         {
-            var array = new MerkleRoot (Enumerable.Range (0, 32).Select (s => (byte) s).ToArray ());
+            var array = MerkleRoot.FromMemory (Enumerable.Range (0, 32).Select (s => (byte) s).ToArray ());
             EncodeDecode (new HashRequestMessage (array, 1, 2, 3, 4));
         }
 


### PR DESCRIPTION
Augment `TorrentCreator` to allow creating different kinds of torrents. By default `TorrentCreator` will now create hybrid torrents, with V1 and V2 metadata.

A `TorrentType` parameter can be passed to the `TorrentCreator` to allow creating a torrent file with:
- BitTorrent V1 metadata
- BitTorrent V1 metadata with [BEP47 ](https://www.bittorrent.org/beps/bep_0047.html) compliant padding/alignment. All files align with the start of a piece.
- A [BEP 52 ](https://www.bittorrent.org/beps/bep_0052.html) compliant hybrid V1/V2 torrent, contains BitTorrent V1 and BitTorrentV2 metadata.
- A [BEP 52](https://www.bittorrent.org/beps/bep_0052.html) compliant V2 torrent, does not contain BitTorrent V1 metadata.