### PR TITLE
[core] Optimise TorrentCreator performance

### DIFF
--- a/src/MonoTorrent.PieceWriter/MonoTorrent.PieceWriter/FileStreamBuffer.cs
+++ b/src/MonoTorrent.PieceWriter/MonoTorrent.PieceWriter/FileStreamBuffer.cs
@@ -39,6 +39,17 @@ namespace MonoTorrent.PieceWriter
 {
     class FileStreamBuffer : IDisposable
     {
+        class Comparer : IEqualityComparer<ITorrentManagerFile>
+        {
+            public static Comparer Instance { get; } = new Comparer ();
+
+            public bool Equals (ITorrentManagerFile? x, ITorrentManagerFile? y)
+                => x == y;
+
+            public int GetHashCode (ITorrentManagerFile obj)
+                => obj.GetHashCode ();
+        }
+
         internal readonly struct RentedStream : IDisposable
         {
             internal readonly Stream? Stream;
@@ -77,7 +88,7 @@ namespace MonoTorrent.PieceWriter
         {
             StreamCreator = streamCreator;
             MaxStreams = maxStreams;
-            Streams = new Dictionary<ITorrentManagerFile, StreamData> (maxStreams);
+            Streams = new Dictionary<ITorrentManagerFile, StreamData> (maxStreams, Comparer.Instance);
         }
 
         internal async ReusableTask<bool> CloseStreamAsync (ITorrentManagerFile file)

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/TorrentCreatorBep47Tests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/TorrentCreatorBep47Tests.cs
@@ -49,7 +49,6 @@ namespace MonoTorrent.Common
             var creator = new TorrentCreator (type, Factories.Default
                             .WithPieceWriterCreator (maxOpenFiles => new TestWriter { DontWrite = false, FillValue = 0 })) {
                 StoreMD5 = true,
-                StoreSHA1 = true,
             };
 
             var announces = new List<List<string>> {
@@ -127,20 +126,32 @@ namespace MonoTorrent.Common
                 var fileA = (BEncodedDictionary) filesA[0];
                 long lengthA = ((BEncodedNumber) fileA[(BEncodedString) "length"]).Number;
                 var md5sumA = ((BEncodedString) fileA[(BEncodedString) "md5sum"]);
-                var sha1sumA = ((BEncodedString) fileA[(BEncodedString) "sha1"]);
 
                 var fileB = (BEncodedDictionary) filesB[0];
                 long lengthB = ((BEncodedNumber) fileB[(BEncodedString) "length"]).Number;
                 var md5sumB = ((BEncodedString) fileB[(BEncodedString) "md5sum"]);
-                var sha1sumB = ((BEncodedString) fileB[(BEncodedString) "sha1"]);
 
                 Assert.AreEqual (lengthA, lengthB);
                 Assert.AreEqual (md5sumA, md5sumB);
-                Assert.AreEqual (sha1sumA, sha1sumB);
+
+                Assert.AreEqual (MD5SumZeros (lengthA), md5sumA);
+            }
+        }
+
+        [Test]
+        public async Task SHA1HashNotAffectedByPadding ()
+        {
+            var paddedBenc = await CreateTestBenc (TorrentType.V1OnlyWithPaddingFiles);
+
+            var infoA = (BEncodedDictionary) paddedBenc[(BEncodedString) "info"];
+            var filesA = (BEncodedList) infoA[(BEncodedString) "files"];
+
+            for (int i = 0; i < filesA.Count; i++) {
+                var fileA = (BEncodedDictionary) filesA[0];
+                long lengthA = ((BEncodedNumber) fileA[(BEncodedString) "length"]).Number;
+                var sha1sumA = ((BEncodedString) fileA[(BEncodedString) "sha1"]);
 
                 Assert.AreEqual (SHA1SumZeros (lengthA), sha1sumA);
-                Assert.AreEqual (MD5SumZeros (lengthA), md5sumA);
-
             }
         }
 


### PR DESCRIPTION
Use some fancier threading here to ensure disk IO happens in
parallel with hashing data. This allows the creator to create a
V1/V2 hybrid torrent with a 2.6GB input file in approximately
6.2 seconds seconds instead of 9-12 seconds.