### PR TITLE
[dht] Fix a DHT initialization issue

### DIFF
--- a/src/Tests/Tests.MonoTorrent.Dht/MonoTorrent.Dht/DhtEngineTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Dht/MonoTorrent.Dht/DhtEngineTests.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+namespace MonoTorrent.Dht
+{
+    [TestFixture]
+    public class DhtEngineTests
+    {
+        [Test]
+        public void AddRawNodesBeforeStarting ()
+        {
+            int count = 0;
+            var engine = new DhtEngine ();
+            engine.MessageLoop.QuerySent += (o, e) => count++;
+            engine.Add (new ReadOnlyMemory<byte>[] { new byte[100] });
+            Assert.AreEqual (0, engine.MessageLoop.PendingQueries);
+            Assert.AreEqual (0, count);
+            Assert.AreEqual (0, engine.RoutingTable.CountNodes ());
+            Assert.AreEqual (0, engine.MessageLoop.DhtMessageFactory.RegisteredMessages);
+        }
+    }
+}

--- a/src/Tests/Tests.MonoTorrent.Dht/MonoTorrent.Dht/MessageHandlingTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Dht/MonoTorrent.Dht/MessageHandlingTests.cs
@@ -83,7 +83,7 @@ namespace MonoTorrent.Dht
         public void SendPing_Asynchronous ()
             => SendPing (true);
 
-        void SendPing (bool asynchronous)
+        async void SendPing (bool asynchronous)
         {
             listener.SendAsynchronously = asynchronous;
 
@@ -103,8 +103,10 @@ namespace MonoTorrent.Dht
 
             Assert.AreEqual (NodeState.Unknown, node.State, "#1");
 
+            await engine.StartAsync ();
+
             // Should cause an implicit Ping to be sent to the node to verify it's alive.
-            engine.Add (node);
+            engine.Add (new[] { node.CompactNode ().AsMemory () });
 
             Assert.IsTrue (tcs.Task.Wait (1000), "#1a");
             Assert.IsTrue (node.LastSeen < TimeSpan.FromSeconds (1), "#2");


### PR DESCRIPTION
Handle adding nodes to the engine before calling StartAsync. These should be cached and then checked whenever `StartAsync` is invoked