### PR TITLE
[core] Cache bittorrent v2 hashes after retrieving them

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/ConnectionManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/ConnectionManager.cs
@@ -303,7 +303,12 @@ namespace MonoTorrent.Client
 
             if (!id.Disposed) {
                 id.LastMessageReceived.Restart ();
-                torrentManager.Mode.HandleMessage (id, message, releaser);
+                try {
+                    torrentManager.Mode.HandleMessage (id, message, releaser);
+                } catch (Exception ex) {
+                    logger.Exception (ex, "Unexpected error handling a message from a peer");
+                    torrentManager.Engine.ConnectionManager.CleanupSocket (torrentManager, id);
+                }
             } else {
                 releaser.Dispose ();
             }

--- a/src/MonoTorrent.Client/MonoTorrent.Client/MessageQueue.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/MessageQueue.cs
@@ -48,11 +48,8 @@ namespace MonoTorrent.Client
 
         internal bool BeginProcessing (bool force = false)
         {
-            if (Disposed)
-                throw new ObjectDisposedException (nameof (MessageQueue));
-
             lock (SendQueue) {
-                if (!Ready || ProcessingQueue || (SendQueue.Count == 0 && !force))
+                if (Disposed|| !Ready || ProcessingQueue || (SendQueue.Count == 0 && !force))
                     return false;
 
                 ProcessingQueue = true;
@@ -175,8 +172,8 @@ namespace MonoTorrent.Client
             if (Disposed)
                 return;
 
-            Disposed = true;
             lock (SendQueue) {
+                Disposed = true;
                 for (int i = 0; i < SendQueue.Count; i++)
                     SendQueue[i].releaser.Dispose ();
                 SendQueue.Clear ();

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Settings/EngineSettings.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Settings/EngineSettings.cs
@@ -303,6 +303,9 @@ namespace MonoTorrent.Client
         internal string GetMetadataPath (InfoHashes infoHashes)
             => Path.Combine (MetadataCacheDirectory, $"{infoHashes.V1OrV2.ToHex ()}.torrent");
 
+        internal string GetV2HashesPath (InfoHashes infoHashes)
+            => Path.Combine (MetadataCacheDirectory, $"{infoHashes.V2.ToHex ()}.v2hashes");
+
         public override bool Equals (object? obj)
             => Equals (obj as EngineSettings);
 

--- a/src/MonoTorrent.Client/MonoTorrent/ReadOnlyMerkleLayers.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/ReadOnlyMerkleLayers.cs
@@ -30,6 +30,8 @@
 using System;
 using System.Collections.Generic;
 
+using MonoTorrent.BEncoding;
+
 namespace MonoTorrent
 {
     public class ReadOnlyMerkleLayers
@@ -79,5 +81,8 @@ namespace MonoTorrent
 
         internal void CopyHashes (int layer, int index, Span<byte> dest)
             => Layers[layer].Slice (index * 32, dest.Length).Span.CopyTo (dest);
+
+        internal ReadOnlyMemory<byte> GetHashes (int layer)
+            => Layers[layer];
     }
 }


### PR DESCRIPTION
If a V2 (or hybrid) magnet link is used and the v2 hashes are missing,
then we will fetch them from other peers on the swarm. Once they are
received, cache them alongside any cached metadata so they can be
implicitly reloaded the next time the torrent is started.