### PR TITLE
[core] Make the Http streaming uri configurable

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Client/Settings/EngineSettings.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Settings/EngineSettings.cs
@@ -152,6 +152,13 @@ namespace MonoTorrent.Client
         public FastResumeMode FastResumeMode { get; } = FastResumeMode.BestEffort;
 
         /// <summary>
+        /// The list of HTTP(s) endpoints which the engine should bind to when a <see cref="TorrentManager"/> is set up
+        /// to stream data from the torrent and <see cref="TorrentManager.StreamProvider"/> is non-null. Should be of
+        /// the form "http://ip-address-or-hostname:port". Defaults to 'http://127.0.0.1:5555'.
+        /// </summary>
+        public Uri HttpStreamingPrefix { get; } = new Uri ("http://127.0.0.1:5555/");
+
+        /// <summary>
         /// The TCP port the engine should listen on for incoming connections. Set the port to 0 to use a random
         /// available port, set to null to disable incoming connections. Defaults to IPAddress.Any with port 0.
         /// </summary>
@@ -256,7 +263,8 @@ namespace MonoTorrent.Client
             TimeSpan connectionTimeout, IPEndPoint? dhtEndPoint, int diskCacheBytes, CachePolicy diskCachePolicy, FastResumeMode fastResumeMode, IPEndPoint? listenEndPoint,
             int maximumConnections, int maximumDiskReadRate, int maximumDiskWriteRate, int maximumDownloadRate, int maximumHalfOpenConnections,
             int maximumOpenFiles, int maximumUploadRate, IPEndPoint? reportedAddress, bool usePartialFiles,
-            TimeSpan webSeedConnectionTimeout, TimeSpan webSeedDelay, int webSeedSpeedTrigger, TimeSpan staleRequestTimeout)
+            TimeSpan webSeedConnectionTimeout, TimeSpan webSeedDelay, int webSeedSpeedTrigger, TimeSpan staleRequestTimeout,
+            Uri httpStreamingEndpoint)
         {
             // Make sure this is immutable now
             AllowedEncryption = EncryptionTypes.MakeReadOnly (allowedEncryption);
@@ -272,6 +280,7 @@ namespace MonoTorrent.Client
             CacheDirectory = cacheDirectory;
             ConnectionTimeout = connectionTimeout;
             FastResumeMode = fastResumeMode;
+            HttpStreamingPrefix = httpStreamingEndpoint;
             ListenEndPoint = listenEndPoint;
             MaximumConnections = maximumConnections;
             MaximumDiskReadRate = maximumDiskReadRate;
@@ -324,6 +333,7 @@ namespace MonoTorrent.Client
                    && DiskCacheBytes == other.DiskCacheBytes
                    && DiskCachePolicy == other.DiskCachePolicy
                    && FastResumeMode == other.FastResumeMode
+                   && HttpStreamingPrefix.Equals (other.HttpStreamingPrefix)
                    && Equals (ListenEndPoint, other.ListenEndPoint)
                    && MaximumConnections == other.MaximumConnections
                    && MaximumDiskReadRate == other.MaximumDiskReadRate

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Settings/EngineSettingsBuilder.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Settings/EngineSettingsBuilder.cs
@@ -68,6 +68,7 @@ namespace MonoTorrent.Client
 
         TimeSpan connectionTimeout;
         int diskCacheBytes;
+        Uri httpStreamingEndpoint;
         int maximumConnections;
         int maximumDiskReadRate;
         int maximumDiskWriteRate;
@@ -188,6 +189,16 @@ namespace MonoTorrent.Client
         /// Defaults to <see cref="FastResumeMode.BestEffort"/>.
         /// </summary>
         public FastResumeMode FastResumeMode { get; set; }
+
+        /// <summary>
+        /// The HTTP(s) prefix which the engine should bind to when a <see cref="TorrentManager"/> is set up
+        /// to stream data from the torrent and <see cref="TorrentManager.StreamProvider"/> is non-null. Should be of
+        /// the form "http://ip-address-or-hostname:port". Defaults to 'http://127.0.0.1:5555'.
+        /// </summary>
+        public Uri HttpStreamingPrefix {
+            get => httpStreamingEndpoint;
+            set => httpStreamingEndpoint = value ?? throw new ArgumentNullException (nameof (HttpStreamingPrefix));
+        }
 
         /// <summary>
         /// The TCP port the engine should listen on for incoming connections. Use 0 to choose a random
@@ -330,6 +341,7 @@ namespace MonoTorrent.Client
             DiskCacheBytes = settings.DiskCacheBytes;
             DiskCachePolicy = settings.DiskCachePolicy;
             FastResumeMode = settings.FastResumeMode;
+            httpStreamingEndpoint = settings.HttpStreamingPrefix;
             ListenEndPoint = settings.ListenEndPoint;
             MaximumConnections = settings.MaximumConnections;
             MaximumDiskReadRate = settings.MaximumDiskReadRate;
@@ -369,6 +381,7 @@ namespace MonoTorrent.Client
                 diskCacheBytes: DiskCacheBytes,
                 diskCachePolicy: DiskCachePolicy,
                 fastResumeMode: FastResumeMode,
+                httpStreamingEndpoint: HttpStreamingPrefix,
                 listenEndPoint: ListenEndPoint,
                 maximumConnections: MaximumConnections,
                 maximumDiskReadRate: MaximumDiskReadRate,

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Settings/Serializer.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Settings/Serializer.cs
@@ -73,6 +73,8 @@ namespace MonoTorrent.Client
                     property.SetValue (builder, (int) ((BEncodedNumber) value).Number);
                 } else if (property.PropertyType == typeof (CachePolicy)) {
                     property.SetValue (builder, Enum.Parse (typeof (CachePolicy), ((BEncodedString) value).Text));
+                } else if (property.PropertyType == typeof (Uri)) {
+                    property.SetValue (builder, new Uri (((BEncodedString) value).Text));
                 } else if (property.PropertyType == typeof (IPAddress)) {
                     property.SetValue (builder, IPAddress.Parse (((BEncodedString) value).Text));
                 } else if (property.PropertyType == typeof (IPEndPoint)) {
@@ -110,6 +112,7 @@ namespace MonoTorrent.Client
                     int value => new BEncodedNumber (value),
                     FastResumeMode value => new BEncodedString (value.ToString ()),
                     CachePolicy value => new BEncodedString (value.ToString ()),
+                    Uri value => new BEncodedString (value.OriginalString),
                     null => null,
                     _ => throw new NotSupportedException ($"{property.Name} => type: ${property.PropertyType}"),
                 };

--- a/src/MonoTorrent.Client/MonoTorrent.Streaming/HttpStream.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Streaming/HttpStream.cs
@@ -28,6 +28,7 @@
 
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Net;
@@ -50,10 +51,13 @@ namespace MonoTorrent.Streaming
 
         public Uri Uri { get; }
 
-        public HttpStream (Stream stream)
+        internal HttpStream (Uri basePrefix, Stream stream)
         {
             // Set up a HTTP listener for VLC/UWP to connect to.
-            Uri = new Uri ($"http://127.0.0.1:5555/{Guid.NewGuid ()}/");
+            var baseUriString = basePrefix.OriginalString;
+            if (!baseUriString.EndsWith ("/"))
+                baseUriString += "/";
+            Uri = new Uri ($"{baseUriString}{Guid.NewGuid ()}/");
 
             Listener = new HttpListener ();
             Listener.Prefixes.Add (Uri.ToString ());

--- a/src/MonoTorrent.Client/MonoTorrent.Streaming/StreamProvider.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Streaming/StreamProvider.cs
@@ -173,7 +173,7 @@ namespace MonoTorrent.Streaming
         public async Task<IUriStream> CreateHttpStreamAsync (ITorrentManagerFile file, bool prebuffer, CancellationToken token)
         {
             var stream = await CreateStreamAsync (file, prebuffer, token);
-            var httpStreamer = new HttpStream (stream);
+            var httpStreamer = new HttpStream (Manager.Engine!.Settings.HttpStreamingPrefix, stream);
             return httpStreamer;
         }
     }

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/EngineSettingsTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/EngineSettingsTests.cs
@@ -40,5 +40,16 @@ namespace MonoTorrent.Client
             var value = Serializer.DeserializeEngineSettings (Serializer.Serialize (new EngineSettings ()));
             Assert.AreEqual (value, new EngineSettings ());
         }
+
+        [Test]
+        public void UriPrefix ()
+        {
+            var modified = new EngineSettingsBuilder { HttpStreamingPrefix = new System.Uri ("http://test.com") };
+            Assert.AreEqual (new EngineSettingsBuilder ().HttpStreamingPrefix, new EngineSettings ().HttpStreamingPrefix);
+            Assert.AreEqual (modified.ToSettings ().HttpStreamingPrefix, modified.HttpStreamingPrefix);
+
+            Assert.AreNotEqual (modified.HttpStreamingPrefix, new EngineSettings ().HttpStreamingPrefix);
+            Assert.AreNotEqual (modified.ToSettings ().HttpStreamingPrefix, new EngineSettings ().HttpStreamingPrefix);
+        }
     }
 }


### PR DESCRIPTION
THe library can now be configured to use any ip or port when
setting up the HttpListener to serve data when a torrent is
set up to support streaming.