### PR TITLE
[bep52] Fix creating v2 torrents with zero length files

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent/Torrent.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/Torrent.cs
@@ -814,6 +814,8 @@ namespace MonoTorrent
             foreach (var entry in fileTree)
                 LoadTorrentFilesV2 (entry.Key.Text, (BEncodedDictionary) entry.Value, files, pieceLength, ref totalPieces, "", isHybrid);
 
+            TorrentFile.Sort (files);
+
             // padding of last torrent must be 0.
             var last = files.Last ();
             files[files.Count - 1] = new TorrentFile (last.Path, last.Length, last.StartPieceIndex, last.EndPieceIndex, last.OffsetInTorrent, last.PiecesRoot, TorrentFileAttributes.None, 0);

--- a/src/MonoTorrent.Client/MonoTorrent/TorrentCreator.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/TorrentCreator.cs
@@ -389,6 +389,9 @@ namespace MonoTorrent
             using var fileSHA1 = StoreSHA1 ? IncrementalHash.CreateHash (HashAlgorithmName.SHA1) : null;
 
             var files = manager.Files.ToArray ().AsMemory ();
+            while (files.Length > 0 && files.Span[0].Length == 0)
+                files = files.Slice (1);
+
             // Store the MD5/SHA1 hash per file if needed.
             Dictionary<ITorrentManagerFile, ReadOnlyMemory<byte>> fileMD5Hashes = new Dictionary<ITorrentManagerFile, ReadOnlyMemory<byte>> ();
             Dictionary<ITorrentManagerFile, ReadOnlyMemory<byte>> fileSHA1Hashes = new Dictionary<ITorrentManagerFile, ReadOnlyMemory<byte>> ();

--- a/src/MonoTorrent.Client/MonoTorrent/TorrentFile.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/TorrentFile.cs
@@ -190,11 +190,16 @@ namespace MonoTorrent
                 results.Add (new TorrentFile (files[i].path!, length, pieceStart, pieceEnd, startOffsetInTorrent, files[i].attributes, padding));
                 totalSize += (length + padding);
             }
+            Sort (results);
+            return results.ToArray ();
+        }
 
+        internal static void Sort (List<ITorrentFile> files)
+        {
             // Ensure files are always sorted so that 'OffsetInTorrent' is always increasing. If files have the same starting 'OffsetInTorrent'
             // then they are of length 0, and so should be sorted based on their length, so empty files are first. If there are multiple
             // empty files then sort them by path so we always have deterministic sorting.
-            results.Sort ((left, right) => {
+            files.Sort ((left, right) => {
                 var comparison = left.OffsetInTorrent.CompareTo (right.OffsetInTorrent);
                 if (comparison == 0)
                     comparison = left.Length.CompareTo (right.Length);
@@ -202,7 +207,6 @@ namespace MonoTorrent
                     comparison = left.Path.CompareTo (right.Path);
                 return comparison;
             });
-            return results.ToArray ();
         }
     }
 }

--- a/src/MonoTorrent/MonoTorrent/ITorrentInfo.cs
+++ b/src/MonoTorrent/MonoTorrent/ITorrentInfo.cs
@@ -109,7 +109,7 @@ namespace MonoTorrent
                 // pieces at the end of each file.
                 for (int i = 0; i < self.Files.Count; i++) {
                     var file = self.Files[i];
-                    if (pieceIndex < file.StartPieceIndex || pieceIndex > file.EndPieceIndex)
+                    if (pieceIndex < file.StartPieceIndex || pieceIndex > file.EndPieceIndex || file.Length == 0)
                         continue;
                     var remainder = file.Length - (pieceIndex - file.StartPieceIndex) * self.PieceLength;
                     return (int) (remainder > self.PieceLength ? self.PieceLength : remainder);


### PR DESCRIPTION
Zero length files should not have a root hash as they have no data. Skip them!

Fixes https://github.com/alanmcgovern/monotorrent/issues/560