### PR TITLE
[core] Sort files before creating hybrid or v2 torrents

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent/TorrentCreator.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/TorrentCreator.cs
@@ -259,6 +259,13 @@ namespace MonoTorrent
                 var info = (file.Destination, length, padding, file.Source);
                 return info;
             }).ToArray ();
+
+            // Hybrid and V2 torrents *must* hash files in the same order as they end up being stored in the bencoded dictionary,
+            // which means they must be alphabetical.
+            if (Type.HasV2 ())
+                rawFiles = rawFiles.OrderBy (t => t.Destination).ToArray ();
+
+            // The last file never has padding bytes
             rawFiles[rawFiles.Length - 1].padding = 0;
 
             var files = TorrentFileInfo.Create (PieceLength, rawFiles);

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/TorrentCreatorTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/TorrentCreatorTests.cs
@@ -261,6 +261,32 @@ namespace MonoTorrent.Common
         }
 
         [Test]
+        public async Task CreateV2Torrent_SortFilesCorrectly ()
+        {
+            using var releaser = TempDir.Create ();
+
+            var dir = new DirectoryInfo (releaser.Path);
+            var eFile = new FileInfo (Path.Combine (dir.FullName, "E.file"));
+            File.WriteAllText (eFile.FullName, "aoeu");
+
+            var bFile = new FileInfo (Path.Combine (dir.FullName, "B.file"));
+            File.WriteAllText (bFile.FullName, "aoeu");
+
+            var aFileInDir = new FileInfo (Path.Combine (dir.FullName, "Dir/A.file"));
+            if (!aFileInDir.Directory.Exists)
+                aFileInDir.Directory.Create ();
+            File.WriteAllText (aFileInDir.FullName, "aoeu");
+
+            ITorrentFileSource fileSource = new TorrentFileSource (dir.FullName);
+            TorrentCreator torrentCreator = new TorrentCreator (TorrentType.V1V2Hybrid);
+            var encodedTorrent = await torrentCreator.CreateAsync (fileSource);
+            var torrent = Torrent.Load (encodedTorrent);
+
+            Assert.IsNotNull (torrent);
+        }
+
+
+        [Test]
         public void CannotCreateTorrentWithAllEmptyFiles ([Values (TorrentType.V1Only, TorrentType.V1V2Hybrid, TorrentType.V2Only)] TorrentType torrentType)
         {
             // Create a torrent from files with all zeros


### PR DESCRIPTION
As the underlying storage is a bencoded dictionary, whose keys must be sorted, you *must* sort the list of files which will be placed in a hybrid or v2 torrent prior to hashing them, otherwise the order of the files will be flipped and piece hashes won't match anymore.

This doesn't appear to be mentioned in the spec, but is called out in a code comment in the sample torrent creator linked as part of the bep52 spec.

            # the directory entries must be processed in lexicographic order so that
            # the files list matches the bencoded ordering of the file tree

I went hunting as soon as i realised i didn't know how to make this test pass as the files were not in a bencoded list.

Fixes https://github.com/alanmcgovern/monotorrent/issues/563

Test case written by @borigas