### PR TITLE
Handle timeouts requesting metadata

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/MetadataMode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/MetadataMode.cs
@@ -94,7 +94,6 @@ namespace MonoTorrent.Client.Modes
             {
                 var peer = UnwrappedPeers[(IgnoringChokeStateRequester) wrappedPeer];
                 var message = new LTMetadata (peer.ExtensionSupports, LTMetadata.MessageType.Request, block.BlockIndex);
-                peer.LastBlockReceived.Restart ();
                 peer.MessageQueue.Enqueue (message);
             }
 
@@ -188,7 +187,11 @@ namespace MonoTorrent.Client.Modes
 
                     // If the piece validated correctly we should indicate that this peer is healthy and is providing the data
                     // we requested
-                    id.LastBlockReceived.Restart ();
+                    if (id.AmRequestingPiecesCount == 0) {
+                        id.LastBlockReceived.Reset ();
+                    } else {
+                        id.LastBlockReceived.Restart ();
+                    }
 
                     message.MetadataPiece.CopyTo (Stream.AsMemory (message.Piece * LTMetadata.BlockSize));
                     if (pieceComplete) {

--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/Mode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/Mode.cs
@@ -670,10 +670,17 @@ namespace MonoTorrent.Client.Modes
             for (int i = 0; i < Manager.Peers.ConnectedPeers.Count; i++) {
                 var id = Manager.Peers.ConnectedPeers[i];
 
-                if (id.LastBlockReceived.Elapsed > Settings.StaleRequestTimeout && id.AmRequestingPiecesCount > 0) {
-                    ConnectionManager.CleanupSocket (Manager, id);
-                    i--;
-                    continue;
+                if (id.AmRequestingPiecesCount > 0) {
+                    if (!id.LastBlockReceived.IsRunning)
+                        id.LastBlockReceived.Restart ();
+
+                    if (id.LastBlockReceived.Elapsed > Settings.StaleRequestTimeout) {
+                        ConnectionManager.CleanupSocket (Manager, id);
+                        i--;
+                        continue;
+                    }
+                } else {
+                    id.LastBlockReceived.Reset ();
                 }
             }
         }

--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/Mode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/Mode.cs
@@ -654,18 +654,27 @@ namespace MonoTorrent.Client.Modes
                     i--;
                     continue;
                 }
+            }
+
+            CloseConnectionsForStalePeers ();
+
+            Manager.PieceManager.AddPieceRequests (Manager.Peers.ConnectedPeers);
+
+            if (Manager.State == TorrentState.Seeding || Manager.State == TorrentState.Downloading) {
+                _ = Manager.TrackerManager.AnnounceAsync (TorrentEvent.None, CancellationToken.None);
+            }
+        }
+
+        protected internal void CloseConnectionsForStalePeers ()
+        {
+            for (int i = 0; i < Manager.Peers.ConnectedPeers.Count; i++) {
+                var id = Manager.Peers.ConnectedPeers[i];
 
                 if (id.LastBlockReceived.Elapsed > Settings.StaleRequestTimeout && id.AmRequestingPiecesCount > 0) {
                     ConnectionManager.CleanupSocket (Manager, id);
                     i--;
                     continue;
                 }
-            }
-
-            Manager.PieceManager.AddPieceRequests (Manager.Peers.ConnectedPeers);
-
-            if (Manager.State == TorrentState.Seeding || Manager.State == TorrentState.Downloading) {
-                _ = Manager.TrackerManager.AnnounceAsync (TorrentEvent.None, CancellationToken.None);
             }
         }
 

--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/PieceHashesMode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/PieceHashesMode.cs
@@ -96,7 +96,6 @@ namespace MonoTorrent.Client.Modes
             {
                 var peer = UnwrappedPeers[(IgnoringChokeStateRequester) wrappedPeer];
                 var message = HashRequestMessage.Create (root, totalHashes, actualPieceLength, block.PieceIndex * PieceLength, MaxHashesPerRequest);
-                peer.LastBlockReceived.Restart ();
                 peer.MessageQueue.Enqueue (message);
             }
 
@@ -224,7 +223,11 @@ namespace MonoTorrent.Client.Modes
 
             // If the piece validated correctly we should indicate that this peer is healthy and is providing the data
             // we requested
-            id.LastBlockReceived.Restart ();
+            if (id.AmRequestingPiecesCount == 0) {
+                id.LastBlockReceived.Reset ();
+            } else {
+                id.LastBlockReceived.Restart ();
+            }
 
             // NOTE: Tweak this so we validate the hash in-place, and ensure the data we've been given, provided with the ancestor
             // hashes, combines to form the `PiecesRoot` value.

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/ConnectionManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/ConnectionManager.cs
@@ -254,7 +254,7 @@ namespace MonoTorrent.Client
                 ReceiveMessagesAsync (id.Connection, id.Decryptor, manager.DownloadLimiters, id.Monitor, manager, id);
 
                 id.WhenConnected.Restart ();
-                id.LastBlockReceived.Restart ();
+                id.LastBlockReceived.Reset ();
             } catch {
                 manager.RaiseConnectionAttemptFailed (new ConnectionAttemptFailedEventArgs (id.Peer.Info, ConnectionFailureReason.Unknown, manager));
                 CleanupSocket (manager, id);
@@ -419,7 +419,7 @@ namespace MonoTorrent.Client
 
                 id.WhenConnected.Restart ();
                 // Baseline the time the last block was received
-                id.LastBlockReceived.Restart ();
+                id.LastBlockReceived.Reset ();
 
                 // Send our handshake now that we've decided to keep the connection
                 var handshake = new HandshakeMessage (id.ExpectedInfoHash.Truncate (), manager.Engine!.PeerId, Constants.ProtocolStringV100);

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/PieceManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/PieceManager.cs
@@ -69,7 +69,13 @@ namespace MonoTorrent.Client
             //FIXME: Ensure piece length is correct?
             var isValidLength = Manager.Torrent!.BytesPerBlock (message.PieceIndex, message.StartOffset / Constants.BlockSize) == message.RequestLength;
             if (Initialised && isValidLength && Requester.ValidatePiece (id, new PieceSegment (message.PieceIndex, message.StartOffset / Constants.BlockSize), out pieceComplete, peersInvolved)) {
-                id.LastBlockReceived.Restart ();
+                // If the piece validated correctly we should indicate that this peer is healthy and is providing the data
+                // we requested
+                if (id.AmRequestingPiecesCount == 0) {
+                    id.LastBlockReceived.Reset ();
+                } else {
+                    id.LastBlockReceived.Restart ();
+                }
                 if (pieceComplete)
                     PendingHashCheckPieces[message.PieceIndex] = true;
                 return true;

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -1191,6 +1191,7 @@ namespace MonoTorrent.Client
         {
             (var bundle, var releaser) = RequestBundle.Rent<RequestBundle> ();
             bundle.Initialize (segments.ToBlockInfo (stackalloc BlockInfo[segments.Length], this));
+            ((PeerId) peer).LastBlockReceived.Restart ();
             ((PeerId) peer).MessageQueue.Enqueue (bundle, releaser);
         }
 

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -1191,7 +1191,6 @@ namespace MonoTorrent.Client
         {
             (var bundle, var releaser) = RequestBundle.Rent<RequestBundle> ();
             bundle.Initialize (segments.ToBlockInfo (stackalloc BlockInfo[segments.Length], this));
-            ((PeerId) peer).LastBlockReceived.Restart ();
             ((PeerId) peer).MessageQueue.Enqueue (bundle, releaser);
         }
 


### PR DESCRIPTION
This change ensures that requests for pieces, metadata or bittorrent v2 hashes use a consistent mechanism for timing out when peers fail to send the requested data. When a timeout occurs, the connection to the peer is closed, all pending requests are cancelled and the data will be re-requested from a new peer.

Fixes https://github.com/alanmcgovern/monotorrent/issues/559