### PR TITLE
[tests] Stop the HttpListener as part of teardown

### DIFF
--- a/src/Tests/Tests.MonoTorrent.IntegrationTests/IntegrationTests.cs
+++ b/src/Tests/Tests.MonoTorrent.IntegrationTests/IntegrationTests.cs
@@ -22,7 +22,7 @@ namespace Tests.MonoTorrent.IntegrationTests
         [OneTimeSetUp]
         public void FixtureSetup ()
         {
-            _tracker = GetTracker (_trackerPort);
+            (_tracker, _trackerListener) = GetTracker (_trackerPort);
         }
 
         [SetUp]
@@ -45,6 +45,7 @@ namespace Tests.MonoTorrent.IntegrationTests
         public void Cleanup ()
         {
             _tracker.Dispose ();
+            _trackerListener.Stop ();
         }
 
         const int _trackerPort = 40000;
@@ -52,6 +53,7 @@ namespace Tests.MonoTorrent.IntegrationTests
         const int _leecherPort = 40002;
 
         private TrackerServer _tracker;
+        private ITrackerListener _trackerListener;
         private DirectoryInfo _directory;
 
         [Test]
@@ -153,7 +155,7 @@ namespace Tests.MonoTorrent.IntegrationTests
             Assert.AreEqual (createEmptyFile, leecherEmptyFile.Exists, "Empty file should exist when created");
         }
 
-        private TrackerServer GetTracker (int port)
+        private (TrackerServer, ITrackerListener) GetTracker (int port)
         {
             var tracker = new TrackerServer ();
             tracker.AllowUnregisteredTorrents = true;
@@ -162,7 +164,7 @@ namespace Tests.MonoTorrent.IntegrationTests
             var listener = TrackerListenerFactory.CreateHttp (listenAddress);
             tracker.RegisterListener (listener);
             listener.Start ();
-            return tracker;
+            return (tracker, listener);
         }
 
         private ClientEngine GetEngine (int port)


### PR DESCRIPTION
Maybe there's a bug in the finalizer chain and it's causing this crash during app shutdown:

The active test run was aborted. Reason: Test host process crashed : Unhandled exception. System.ObjectDisposedException: Safe handle has been closed. Object name: 'SafeHandle'.
   at System.Runtime.InteropServices.SafeHandle.DangerousAddRef(Boolean& success)
   at System.StubHelpers.StubHelpers.SafeHandleAddRef(SafeHandle pHandle, Boolean& success)
   at Interop.HttpApi.HttpCancelHttpRequest(SafeHandle requestQueueHandle, UInt64 requestId, IntPtr pOverlapped)
   at System.Net.HttpListenerContext.ForceCancelRequest(SafeHandle requestQueueHandle, UInt64 requestId)
   at System.Net.HttpListenerContext.Abort()
   at System.Net.HttpResponseStream.EndWriteCore(IAsyncResult asyncResult)
   at System.Net.HttpResponseStream.EndWrite(IAsyncResult asyncResult)
   at System.Net.HttpListenerResponse.NonBlockingCloseCallback(IAsyncResult asyncResult)
   at System.Net.LazyAsyncResult.Complete(IntPtr userToken)
   at System.Net.LazyAsyncResult.ProtectedInvokeCallback(Object result, IntPtr userToken)
   at System.Net.HttpResponseStreamAsyncResult.IOCompleted(HttpResponseStreamAsyncResult asyncResult, UInt32 errorCode, UInt32 numBytes)
   at System.Net.HttpResponseStreamAsyncResult.Callback(UInt32 errorCode, UInt32 numBytes, NativeOverlapped* nativeOverlapped)
   at System.Threading.ThreadPoolBoundHandleOverlapped.CompletionCallback(UInt32 errorCode, UInt32 numBytes, NativeOverlapped* nativeOverlapped)
   at System.Threading._IOCompletionCallback.IOCompletionCallback_Context(Object state)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading._IOCompletionCallback.PerformIOCompletionCallback(UInt32 errorCode, UInt32 numBytes, NativeOverlapped* pNativeOverlapped)

Try to work around https://github.com/dotnet/core/issues/7961