### PR TITLE
Fixup modes

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/ErrorMode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/ErrorMode.cs
@@ -37,7 +37,6 @@ namespace MonoTorrent.Client.Modes
 {
     class ErrorMode : IMode
     {
-        bool ranOnce = false;
         public bool CanAcceptConnections => false;
         public bool CanHandleMessages => false;
         public bool CanHashCheck => true;
@@ -47,6 +46,7 @@ namespace MonoTorrent.Client.Modes
         CancellationTokenSource Cancellation { get; }
         ConnectionManager ConnectionManager { get; }
         TorrentManager Manager { get; }
+        bool RanOnce { get; set; }
 
         public ErrorMode (TorrentManager manager, ConnectionManager connectionManager)
             => (Cancellation, Manager, ConnectionManager) = (new CancellationTokenSource (), manager, connectionManager);
@@ -70,10 +70,10 @@ namespace MonoTorrent.Client.Modes
 
         public void Tick (int counter)
         {
-            if (ranOnce)
+            if (RanOnce)
                 return;
 
-            ranOnce = true;
+            RanOnce = true;
             Manager.SetNeedsHashCheck ();
             Manager.Monitor.Reset ();
             foreach (PeerId id in new List<PeerId> (Manager.Peers.ConnectedPeers))

--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/HashingMode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/HashingMode.cs
@@ -44,18 +44,16 @@ namespace MonoTorrent.Client.Modes
         public bool CanHandleMessages => false;
         public bool CanHashCheck => false;
         public TorrentState State => PausedCompletionSource.Task.IsCompleted ? TorrentState.Hashing : TorrentState.HashingPaused;
+        public CancellationToken Token => Cancellation.Token;
 
         CancellationTokenSource Cancellation { get; }
         DiskManager DiskManager { get; }
         TorrentManager Manager { get; }
-        EngineSettings Settings { get; }
-        public CancellationToken Token => Cancellation.Token;
 
-        public HashingMode (TorrentManager manager, DiskManager diskManager, EngineSettings settings)
+        public HashingMode (TorrentManager manager, DiskManager diskManager)
         {
-            (Manager, DiskManager, Settings) = (manager, diskManager, settings);
+            (Cancellation, Manager, DiskManager) = (new CancellationTokenSource (), manager, diskManager);
 
-            Cancellation = new CancellationTokenSource ();
             // Mark it as completed so we are *not* paused by default;
             PausedCompletionSource = new TaskCompletionSource<object?> ();
             PausedCompletionSource.SetResult (null);
@@ -127,7 +125,6 @@ namespace MonoTorrent.Client.Modes
                     Manager.OnPieceHashed (i, false, i + 1, Manager.Torrent.PieceCount);
             }
         }
-
 
         public void Dispose ()
             => Cancellation.Cancel ();

--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/HashingMode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/HashingMode.cs
@@ -38,8 +38,6 @@ namespace MonoTorrent.Client.Modes
 {
     class HashingMode : IMode
     {
-        TaskCompletionSource<object?> PausedCompletionSource { get; set; }
-
         public bool CanAcceptConnections => false;
         public bool CanHandleMessages => false;
         public bool CanHashCheck => false;
@@ -49,6 +47,7 @@ namespace MonoTorrent.Client.Modes
         CancellationTokenSource Cancellation { get; }
         DiskManager DiskManager { get; }
         TorrentManager Manager { get; }
+        TaskCompletionSource<object?> PausedCompletionSource { get; set; }
 
         public HashingMode (TorrentManager manager, DiskManager diskManager)
         {

--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/IMode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/IMode.cs
@@ -1,0 +1,51 @@
+﻿//
+// IMode.cs
+//
+// Authors:
+//   Alan McGovern alan.mcgovern@gmail.com
+//
+// Copyright (C) 2022 Alan McGovern
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+
+using System;
+using System.Threading;
+
+using MonoTorrent.Messages.Peer;
+
+namespace MonoTorrent.Client.Modes
+{
+    interface IMode : IDisposable
+    {
+        bool CanAcceptConnections { get; }
+        bool CanHandleMessages { get; }
+        bool CanHashCheck { get; }
+        TorrentState State { get; }
+        CancellationToken Token { get; }
+
+        void HandleMessage (PeerId id, PeerMessage message, PeerMessage.Releaser releaser);
+        void HandlePeerConnected (PeerId id);
+        void HandlePeerDisconnected (PeerId id);
+        bool ShouldConnect (Peer peer);
+        void Tick (int counter);
+    }
+}

--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/MetadataMode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/MetadataMode.cs
@@ -147,13 +147,11 @@ namespace MonoTorrent.Client.Modes
 
         public override void Tick (int counter)
         {
-            SendAnnounces ();
+            PreLogicTick (counter);
 
             foreach (PeerId id in Manager.Peers.ConnectedPeers)
                 if (id.SupportsLTMessages && id.ExtensionSupports.Supports (LTMetadata.Support.Name))
                     RequestNextNeededPiece (id);
-
-            CloseConnectionsForStalePeers ();
         }
 
         protected override void HandleLtMetadataMessage (PeerId id, LTMetadata message)

--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/MetadataMode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/MetadataMode.cs
@@ -118,7 +118,6 @@ namespace MonoTorrent.Client.Modes
         string savePath;
         bool stopWhenDone;
 
-        bool HasAnnounced { get; set; }
         MetadataData? RequesterData { get; set; }
         IPieceRequester? Requester { get; set; }
         byte[]? Stream { get; set; }
@@ -148,29 +147,13 @@ namespace MonoTorrent.Client.Modes
 
         public override void Tick (int counter)
         {
-            if (!HasAnnounced) {
-                HasAnnounced = true;
-                SendAnnounces ();
-            }
+            SendAnnounces ();
 
             foreach (PeerId id in Manager.Peers.ConnectedPeers)
                 if (id.SupportsLTMessages && id.ExtensionSupports.Supports (LTMetadata.Support.Name))
                     RequestNextNeededPiece (id);
 
             CloseConnectionsForStalePeers ();
-        }
-
-        async void SendAnnounces ()
-        {
-            try {
-                Manager.DhtAnnounce ();
-                await Task.WhenAll (
-                    Manager.TrackerManager.AnnounceAsync (CancellationToken.None).AsTask (),
-                    Manager.LocalPeerAnnounceAsync ()
-                );
-            } catch {
-                // Nothing.
-            }
         }
 
         protected override void HandleLtMetadataMessage (PeerId id, LTMetadata message)

--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/Mode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/Mode.cs
@@ -46,7 +46,7 @@ using ReusableTasks;
 
 namespace MonoTorrent.Client.Modes
 {
-    abstract class Mode
+    abstract class Mode : IMode
     {
         static readonly Logger logger = Logger.Create (nameof (Mode));
         static readonly SHA1 AllowedFastHasher = SHA1.Create ();
@@ -170,7 +170,7 @@ namespace MonoTorrent.Client.Modes
                 bufferReleaser.Dispose ();
 
                 (var message, var releaser) = PeerMessage.Rent<HashRejectMessage> ();
-                message.Initialize(hashRequest.PiecesRoot, hashRequest.BaseLayer, hashRequest.Index, hashRequest.Length, hashRequest.ProofLayers);
+                message.Initialize (hashRequest.PiecesRoot, hashRequest.BaseLayer, hashRequest.Index, hashRequest.Length, hashRequest.ProofLayers);
                 id.MessageQueue.Enqueue (message, releaser);
             }
         }

--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/PieceHashesMode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/PieceHashesMode.cs
@@ -260,7 +260,7 @@ namespace MonoTorrent.Client.Modes
                     foreach (var p in pickers)
                         p.Value.Item1.CancelRequests (p.Value.Item2.Wrap (peer), 0, p.Key.EndPieceIndex - p.Key.StartPieceIndex + 1);
                 if (StopWhenDone)
-                    Manager.Mode = new StoppedMode (Manager, DiskManager, ConnectionManager, Settings);
+                    Manager.Mode = new StoppedMode ();
                 else
                     Manager.Mode = new DownloadMode (Manager, DiskManager, ConnectionManager, Settings);
             }

--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/PieceHashesMode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/PieceHashesMode.cs
@@ -144,9 +144,9 @@ namespace MonoTorrent.Client.Modes
 
         public override void Tick (int counter)
         {
-            SendAnnounces ();
+            PreLogicTick (counter);
+
             MaybeRequestNext ();
-            CloseConnectionsForStalePeers ();
         }
 
         void MaybeRequestNext ()

--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/StartingMode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/StartingMode.cs
@@ -144,7 +144,7 @@ namespace MonoTorrent.Client.Modes
                 Manager.Mode = new DownloadMode (Manager, DiskManager, ConnectionManager, Settings);
             }
 
-            Manager.DhtAnnounce ();
+            await Manager.DhtAnnounceAsync ();
             await Manager.LocalPeerAnnounceAsync ();
         }
 

--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/StartingMode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/StartingMode.cs
@@ -45,13 +45,13 @@ namespace MonoTorrent.Client.Modes
     {
         static readonly Logger Log = Logger.Create (nameof (StartingMode));
 
-        CancellationTokenSource Cancellation { get; }
         public bool CanAcceptConnections => false;
         public bool CanHandleMessages => false;
         public bool CanHashCheck => true;
         public TorrentState State => TorrentState.Starting;
         public CancellationToken Token => Cancellation.Token;
 
+        CancellationTokenSource Cancellation { get; }
         ConnectionManager ConnectionManager { get; }
         DiskManager DiskManager { get; }
         TorrentManager Manager { get; }

--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/StartingMode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/StartingMode.cs
@@ -94,7 +94,7 @@ namespace MonoTorrent.Client.Modes
 
             if (!Manager.HashChecked) {
                 if (Manager.Mode == this)
-                    Manager.Mode = new StoppedMode (Manager, DiskManager, ConnectionManager, Settings);
+                    Manager.Mode = new StoppedMode ();
                 return;
             }
 

--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/StartingMode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/StartingMode.cs
@@ -35,26 +35,47 @@ using System.Threading.Tasks;
 
 using MonoTorrent.BEncoding;
 using MonoTorrent.Logging;
+using MonoTorrent.Messages.Peer;
 
 using ReusableTasks;
 
 namespace MonoTorrent.Client.Modes
 {
-    class StartingMode : Mode
+    class StartingMode : IMode
     {
         static readonly Logger Log = Logger.Create (nameof (StartingMode));
 
-        public override bool CanAcceptConnections => false;
-        public override bool CanHandleMessages => false;
-        public override bool CanHashCheck => true;
-        public override TorrentState State => TorrentState.Starting;
+        CancellationTokenSource Cancellation { get; }
+        public bool CanAcceptConnections => false;
+        public bool CanHandleMessages => false;
+        public bool CanHashCheck => true;
+        public TorrentState State => TorrentState.Starting;
+        public CancellationToken Token => Cancellation.Token;
+
+        ConnectionManager ConnectionManager { get; }
+        DiskManager DiskManager { get; }
+        TorrentManager Manager { get; }
+        EngineSettings Settings { get; }
 
         public StartingMode (TorrentManager manager, DiskManager diskManager, ConnectionManager connectionManager, EngineSettings settings)
-            : base (manager, diskManager, connectionManager, settings)
-        {
-        }
+           => (Cancellation, Manager, DiskManager, ConnectionManager, Settings) = (new CancellationTokenSource (), manager, diskManager, connectionManager, settings);
 
-        public override void Tick (int counter)
+        public void Dispose ()
+            => Cancellation.Cancel ();
+
+        public void HandleMessage (PeerId id, PeerMessage message, PeerMessage.Releaser releaser)
+            => throw new NotSupportedException ();
+
+        public void HandlePeerConnected (PeerId id)
+            => throw new NotSupportedException ();
+
+        public void HandlePeerDisconnected (PeerId id)
+            => throw new NotSupportedException ();
+
+        public bool ShouldConnect (Peer peer)
+            => false;
+
+        public void Tick (int counter)
         {
         }
 
@@ -153,12 +174,12 @@ namespace MonoTorrent.Client.Modes
                     Manager.TrackerManager.ScrapeAsync (CancellationToken.None).AsTask (),
                     Manager.TrackerManager.AnnounceAsync (TorrentEvent.Started, CancellationToken.None).AsTask ()
                 );
-            } catch {
-                // Ignore
+            } catch (Exception ex) {
+                Log.Exception (ex, "Error announcing/scraping while starting the torrent");
             }
         }
 
-        async Task TryLoadV2HashesFromCache()
+        async Task TryLoadV2HashesFromCache ()
         {
             try {
                 await MainLoop.SwitchThread ();

--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/StoppedMode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/StoppedMode.cs
@@ -36,13 +36,13 @@ namespace MonoTorrent.Client.Modes
 {
     class StoppedMode : IMode
     {
-        CancellationTokenSource Cancellation { get; }
         public bool CanAcceptConnections => false;
         public bool CanHandleMessages => false;
         public bool CanHashCheck => true;
         public TorrentState State => TorrentState.Stopped;
-
         public CancellationToken Token => Cancellation.Token;
+
+        CancellationTokenSource Cancellation { get; }
 
         public StoppedMode ()
             => (Cancellation) = (new CancellationTokenSource ());

--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/StoppedMode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/StoppedMode.cs
@@ -1,5 +1,5 @@
 //
-// StoppingMode.cs
+// StoppedMode.cs
 //
 // Authors:
 //   Alan McGovern <alan.mcgovern@gmail.com>
@@ -27,21 +27,42 @@
 //
 
 
+using System;
+using System.Threading;
+
+using MonoTorrent.Messages.Peer;
+
 namespace MonoTorrent.Client.Modes
 {
-    class StoppedMode : Mode
+    class StoppedMode : IMode
     {
-        public override bool CanAcceptConnections => false;
-        public override bool CanHandleMessages => false;
-        public override bool CanHashCheck => true;
-        public override TorrentState State => TorrentState.Stopped;
+        CancellationTokenSource Cancellation { get; }
+        public bool CanAcceptConnections => false;
+        public bool CanHandleMessages => false;
+        public bool CanHashCheck => true;
+        public TorrentState State => TorrentState.Stopped;
 
-        public StoppedMode (TorrentManager manager, DiskManager diskManager, ConnectionManager connectionManager, EngineSettings settings)
-            : base (manager, diskManager, connectionManager, settings)
-        {
-        }
+        public CancellationToken Token => Cancellation.Token;
 
-        public override void Tick (int counter)
+        public StoppedMode ()
+            => (Cancellation) = (new CancellationTokenSource ());
+
+        public void Dispose ()
+            => Cancellation.Cancel ();
+
+        public void HandleMessage (PeerId id, PeerMessage message, PeerMessage.Releaser releaser)
+            => throw new NotSupportedException ();
+
+        public void HandlePeerConnected (PeerId id)
+            => throw new NotSupportedException ();
+
+        public void HandlePeerDisconnected (PeerId id)
+            => throw new NotSupportedException ();
+
+        public bool ShouldConnect (Peer peer)
+            => false;
+
+        public void Tick (int counter)
         {
             // Do not run any of the default 'Tick' logic as nothing happens during 'Stopped' mode.
         }

--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/StoppingMode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/StoppingMode.cs
@@ -33,34 +33,53 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using MonoTorrent.Logging;
+using MonoTorrent.Messages.Peer;
 
 namespace MonoTorrent.Client.Modes
 {
-    class StoppingMode : Mode
+    class StoppingMode : IMode
     {
         static readonly Logger logger = Logger.Create (nameof (StoppingMode));
 
-        public override bool CanAcceptConnections => false;
-        public override bool CanHandleMessages => false;
-        public override bool CanHashCheck => false;
-        public override TorrentState State => TorrentState.Stopping;
+        public bool CanAcceptConnections => false;
+        public bool CanHandleMessages => false;
+        public bool CanHashCheck => false;
+        public TorrentState State => TorrentState.Stopping;
+        public CancellationToken Token => Cancellation.Token;
 
-        public StoppingMode (TorrentManager manager, DiskManager diskManager, ConnectionManager connectionManager, EngineSettings settings)
-            : base (manager, diskManager, connectionManager, settings)
-        {
-        }
+        CancellationTokenSource Cancellation { get; }
+        ConnectionManager ConnectionManager { get; }
+        DiskManager DiskManager { get; }
+        TorrentManager Manager { get; }
 
-        public Task WaitForStoppingToComplete ()
+        public StoppingMode (TorrentManager manager, DiskManager diskManager, ConnectionManager connectionManager)
+            => (Cancellation, Manager, DiskManager, ConnectionManager) = (new CancellationTokenSource (), manager, diskManager, connectionManager);
+
+        public void Dispose ()
+            => Cancellation.Dispose ();
+
+        public void HandleMessage (PeerId id, PeerMessage message, PeerMessage.Releaser releaser)
+            => throw new NotSupportedException ();
+
+        public void HandlePeerConnected (PeerId id)
+            => throw new NotSupportedException ();
+
+        public void HandlePeerDisconnected (PeerId id)
+            => throw new NotSupportedException ();
+
+        public bool ShouldConnect (Peer peer)
+            => false;
+
+        public void Tick (int counter)
         {
-            return WaitForStoppingToComplete (Timeout.InfiniteTimeSpan);
         }
 
         public async Task WaitForStoppingToComplete (TimeSpan timeout)
         {
             try {
-                Manager.Engine!.ConnectionManager.CancelPendingConnects (Manager);
+                ConnectionManager.CancelPendingConnects (Manager);
                 foreach (PeerId id in new List<PeerId> (Manager.Peers.ConnectedPeers))
-                    Manager.Engine.ConnectionManager.CleanupSocket (Manager, id);
+                    ConnectionManager.CleanupSocket (Manager, id);
 
                 Manager.Monitor.Reset ();
                 Manager.PieceManager.Initialise ();
@@ -69,7 +88,7 @@ namespace MonoTorrent.Client.Modes
                 var stoppingTasks = new List<Task> ();
                 // We could be in metadata download mode
                 if (Manager.Torrent != null)
-                    stoppingTasks.Add (Manager.Engine.DiskManager.CloseFilesAsync (Manager));
+                    stoppingTasks.Add (DiskManager.CloseFilesAsync (Manager));
 
                 Task announceTask = Manager.TrackerManager.AnnounceAsync (TorrentEvent.Stopped, CancellationToken.None).AsTask ();
                 if (timeout != Timeout.InfiniteTimeSpan)

--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/StoppingMode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/StoppingMode.cs
@@ -65,7 +65,9 @@ namespace MonoTorrent.Client.Modes
             => throw new NotSupportedException ();
 
         public void HandlePeerDisconnected (PeerId id)
-            => throw new NotSupportedException ();
+        {
+            // Peers which are disconnected at this point don't need any extra cleanup
+        }
 
         public bool ShouldConnect (Peer peer)
             => false;

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -562,7 +562,7 @@ namespace MonoTorrent.Client
             // will not be hashed, or downloaded.
             UnhashedPieces.SetAll (true);
 
-            var hashingMode = new HashingMode (this, Engine!.DiskManager, Engine.Settings);
+            var hashingMode = new HashingMode (this, Engine!.DiskManager);
             Mode = hashingMode;
 
             try {

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -728,7 +728,7 @@ namespace MonoTorrent.Client
             }
         }
 
-        public async Task LocalPeerAnnounceAsync ()
+        public async ReusableTask LocalPeerAnnounceAsync ()
         {
             await ClientEngine.MainLoop;
 
@@ -750,14 +750,10 @@ namespace MonoTorrent.Client
         /// returned task completes as soon as the Dht announce begins.
         /// </summary>
         /// <returns></returns>
-        public async Task DhtAnnounceAsync ()
+        public async ReusableTask DhtAnnounceAsync ()
         {
             await ClientEngine.MainLoop;
-            DhtAnnounce ();
-        }
 
-        internal void DhtAnnounce ()
-        {
             if (CanUseDht && Engine != null && (!LastDhtAnnounceTimer.IsRunning || LastDhtAnnounceTimer.Elapsed > Engine.DhtEngine.MinimumAnnounceInterval)) {
                 LastDhtAnnounce = DateTime.UtcNow;
                 LastDhtAnnounceTimer.Restart ();

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -1159,7 +1159,7 @@ namespace MonoTorrent.Client
                 return false;
 
             Error = new Error (reason, ex);
-            Mode = new ErrorMode (this, Engine!.DiskManager, Engine.ConnectionManager, Engine.Settings);
+            Mode = new ErrorMode (this, Engine!.ConnectionManager);
             return true;
         }
 

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -441,7 +441,7 @@ namespace MonoTorrent.Client
             Peers = new PeerManager ();
             PieceManager = new PieceManager (this);
 
-            mode = new StoppedMode (this, engine.DiskManager, engine.ConnectionManager, engine.Settings);
+            mode = new StoppedMode ();
             DownloadLimiter = new RateLimiter ();
             DownloadLimiters = new RateLimiterGroup {
                 new PauseLimiter(this),
@@ -581,7 +581,7 @@ namespace MonoTorrent.Client
             } else if (setStoppedModeWhenDone) {
                 await MaybeWriteFastResumeAsync ();
 
-                Mode = new StoppedMode (this, Engine.DiskManager, Engine.ConnectionManager, Engine.Settings);
+                Mode = new StoppedMode ();
             }
         }
 
@@ -789,15 +789,15 @@ namespace MonoTorrent.Client
 
             if (State == TorrentState.Error) {
                 Error = null;
-                Mode = new StoppedMode (this, Engine!.DiskManager, Engine.ConnectionManager, Engine.Settings);
-                await Engine.StopAsync ();
+                Mode = new StoppedMode ();
+                await Engine!.StopAsync ();
             } else if (State != TorrentState.Stopped) {
                 var stoppingMode = new StoppingMode (this, Engine!.DiskManager, Engine.ConnectionManager, Engine.Settings);
                 Mode = stoppingMode;
                 await stoppingMode.WaitForStoppingToComplete (timeout);
 
                 stoppingMode.Token.ThrowIfCancellationRequested ();
-                Mode = new StoppedMode (this, Engine.DiskManager, Engine.ConnectionManager, Engine.Settings);
+                Mode = new StoppedMode ();
                 await MaybeWriteFastResumeAsync ();
                 await Engine.StopAsync ();
             }

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -792,7 +792,7 @@ namespace MonoTorrent.Client
                 Mode = new StoppedMode ();
                 await Engine!.StopAsync ();
             } else if (State != TorrentState.Stopped) {
-                var stoppingMode = new StoppingMode (this, Engine!.DiskManager, Engine.ConnectionManager, Engine.Settings);
+                var stoppingMode = new StoppingMode (this, Engine!.DiskManager, Engine.ConnectionManager);
                 Mode = stoppingMode;
                 await stoppingMode.WaitForStoppingToComplete (timeout);
 

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -73,7 +73,7 @@ namespace MonoTorrent.Client
         /// <summary>
         /// This event is raised synchronously and is only used supposed to be used by tests.
         /// </summary>
-        internal event Action<Mode, Mode>? ModeChanged;
+        internal event Action<IMode, IMode>? ModeChanged;
 
         /// <summary>
         /// Raised whenever new peers are discovered and added. The object will be of type
@@ -130,7 +130,7 @@ namespace MonoTorrent.Client
         #region Member Variables
 
         internal Queue<int> finishedPieces;     // The list of pieces which we should send "have" messages for
-        Mode mode;
+        IMode mode;
         internal DateTime lastCalledInactivePeerManager = DateTime.Now;
         TaskCompletionSource<Torrent> MetadataTask { get; }
         #endregion Member Variables
@@ -164,10 +164,10 @@ namespace MonoTorrent.Client
 
         public IList<ITorrentManagerFile> Files { get; private set; }
 
-        internal Mode Mode {
+        internal IMode Mode {
             get => mode;
             set {
-                Mode oldMode = mode;
+                IMode oldMode = mode;
                 mode = value;
                 ModeChanged?.Invoke (oldMode, mode);
                 if (oldMode != null)
@@ -562,7 +562,7 @@ namespace MonoTorrent.Client
             // will not be hashed, or downloaded.
             UnhashedPieces.SetAll (true);
 
-            var hashingMode = new HashingMode (this, Engine!.DiskManager, Engine.ConnectionManager, Engine.Settings);
+            var hashingMode = new HashingMode (this, Engine!.DiskManager, Engine.Settings);
             Mode = hashingMode;
 
             try {

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/HashingModeTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/HashingModeTests.cs
@@ -101,7 +101,7 @@ namespace MonoTorrent.Client.Modes
             mode.Pause ();
 
             var hashingTask = mode.WaitForHashingToComplete ();
-            var stoppedMode = new StoppedMode (Manager, DiskManager, ConnectionManager, Settings);
+            var stoppedMode = new StoppedMode ();
             Manager.Mode = stoppedMode;
 
             // Ensure the hashing mode ends and does not throw exceptions.

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/HashingModeTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/HashingModeTests.cs
@@ -87,7 +87,7 @@ namespace MonoTorrent.Client.Modes
         [Test]
         public void AddConnection ()
         {
-            Manager.Mode = new HashingMode (Manager, DiskManager, Settings);
+            Manager.Mode = new HashingMode (Manager, DiskManager);
 
             Assert.IsFalse (Peer.Connection.Disposed, "#1");
             Assert.Throws<NotSupportedException> (() => Manager.Mode.HandlePeerConnected (Peer));
@@ -96,7 +96,7 @@ namespace MonoTorrent.Client.Modes
         [Test]
         public void CancelHashing ()
         {
-            var mode = new HashingMode (Manager, DiskManager, Settings);
+            var mode = new HashingMode (Manager, DiskManager);
             Manager.Mode = mode;
             mode.Pause ();
 
@@ -216,7 +216,7 @@ namespace MonoTorrent.Client.Modes
                 ((TorrentFileInfo) f).BitField.SetAll (true);
             }
 
-            var hashingMode = new HashingMode (Manager, DiskManager, Settings);
+            var hashingMode = new HashingMode (Manager, DiskManager);
             Manager.Mode = hashingMode;
             await hashingMode.WaitForHashingToComplete ().WithTimeout ();
 
@@ -249,7 +249,7 @@ namespace MonoTorrent.Client.Modes
                 await Manager.SetFilePriorityAsync (f, Priority.DoNotDownload);
             }
 
-            var hashingMode = new HashingMode (Manager, DiskManager, Settings);
+            var hashingMode = new HashingMode (Manager, DiskManager);
             Manager.Mode = hashingMode;
             await hashingMode.WaitForHashingToComplete ();
             Assert.IsTrue (Manager.UnhashedPieces.AllTrue, "#1");
@@ -341,7 +341,7 @@ namespace MonoTorrent.Client.Modes
                 await Manager.SetFilePriorityAsync (f, Priority.DoNotDownload);
             }
 
-            var hashingMode = new HashingMode (Manager, DiskManager, Settings);
+            var hashingMode = new HashingMode (Manager, DiskManager);
             Manager.Mode = hashingMode;
             await hashingMode.WaitForHashingToComplete ();
 
@@ -376,7 +376,7 @@ namespace MonoTorrent.Client.Modes
             foreach (var file in Manager.Files)
                 Assert.IsTrue (file.BitField.AllTrue, "#2." + file.Path);
 
-            var mode = new HashingMode (Manager, DiskManager, Settings);
+            var mode = new HashingMode (Manager, DiskManager);
             Manager.Mode = mode;
             await mode.WaitForHashingToComplete ();
 
@@ -388,7 +388,7 @@ namespace MonoTorrent.Client.Modes
         [Test]
         public async Task StopWhileHashing ()
         {
-            var mode = new HashingMode (Manager, DiskManager, Settings);
+            var mode = new HashingMode (Manager, DiskManager);
             Manager.Mode = mode;
             mode.Pause ();
 

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/StartingModeTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/StartingModeTests.cs
@@ -115,7 +115,7 @@ namespace MonoTorrent.Client.Modes
         [Test]
         public async Task StateChanges_AlreadyHashed ()
         {
-            var modeChanged = new List<Mode> ();
+            var modeChanged = new List<IMode> ();
             Manager.ModeChanged += (oldMode, newMode) => modeChanged.Add (newMode);
 
             var mode = new StartingMode (Manager, DiskManager, ConnectionManager, Settings);
@@ -131,7 +131,7 @@ namespace MonoTorrent.Client.Modes
         [Test]
         public async Task StateChanges_NeedsHashing ()
         {
-            var modeChanged = new List<Mode> ();
+            var modeChanged = new List<IMode> ();
             Manager.ModeChanged += (oldMode, newMode) => modeChanged.Add (newMode);
 
             var mode = new StartingMode (Manager, DiskManager, ConnectionManager, Settings);

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/StoppedModeTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/StoppedModeTests.cs
@@ -78,12 +78,10 @@ namespace MonoTorrent.Client.Modes
         [Test]
         public void AddConnection ()
         {
-            Manager.Mode = new StoppedMode (Manager, DiskManager, ConnectionManager, Settings);
+            Manager.Mode = new StoppedMode ();
 
             Assert.IsFalse (Peer.Connection.Disposed, "#1");
-            Manager.Mode.HandlePeerConnected (Peer);
-            Assert.IsTrue (Peer.Connection.Disposed, "#2");
-            Assert.IsFalse (Manager.Peers.ConnectedPeers.Contains (Peer), "#3");
+            Assert.Throws<NotSupportedException> (() => Manager.Mode.HandlePeerConnected (Peer));
         }
     }
 }


### PR DESCRIPTION
Refactor Mode/IMode to make it clearer what logic is being executed as part of each mode. As part of this ensure that announcing and peer maintenance is handled the same way for DownloadMode, MetadataMode and PieceHashesMode.

Addresses https://github.com/alanmcgovern/monotorrent/issues/447