### PR TITLE
Start web seed if the speed trigger is 0

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/Mode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/Mode.cs
@@ -680,7 +680,7 @@ namespace MonoTorrent.Client.Modes
 
         void DownloadLogic (int counter)
         {
-            if (ClientEngine.SupportsWebSeed && (DateTime.Now - Manager.StartTime) > Settings.WebSeedDelay && Manager.Monitor.DownloadRate < Settings.WebSeedSpeedTrigger) {
+            if (ClientEngine.SupportsWebSeed && (DateTime.Now - Manager.StartTime) > Settings.WebSeedDelay && (Manager.Monitor.DownloadRate < Settings.WebSeedSpeedTrigger || Settings.WebSeedSpeedTrigger == 0)) {
                 foreach (Uri uri in Manager.Torrent!.HttpSeeds) {
                     var peer = new Peer (new PeerInfo (uri, CreatePeerId ()), Manager.InfoHashes.V1OrV2);
 


### PR DESCRIPTION
From EngineSettingsBuilder.cs
```
        /// <summary>
        /// The download speed under which a torrent will start using web seeds. A value of
        /// 0 means webseeds will be added regardless of how fast the torrent is downloading.
        /// </summary>
        public int WebSeedSpeedTrigger {
```