### PR TITLE
[core] Properly specify the System.Memory reference

### DIFF
--- a/src/MonoTorrent.BEncoding/MonoTorrent.BEncoding.csproj
+++ b/src/MonoTorrent.BEncoding/MonoTorrent.BEncoding.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Condition="$(TargetFramework) == 'netstandard2.0'" Include="System.Memory" Version="4.5.4" />
+    <PackageReference Condition="$(TargetFramework) == 'netstandard2.0'" Include="System.Memory" Version="4.5.0" />
   </ItemGroup>
 
 </Project>

--- a/src/MonoTorrent.Client/MonoTorrent.Client.csproj
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.csproj
@@ -74,6 +74,11 @@
     <ProjectReference Include="..\MonoTorrent.BEncoding\MonoTorrent.BEncoding.csproj" PrivateAssets="all" />
     <ProjectReference Include="..\MonoTorrent.Factories\MonoTorrent.Factories.csproj" PrivateAssets="all" />
     <ProjectReference Include="..\MonoTorrent.Messages\MonoTorrent.Messages.csproj" PrivateAssets="all" />
+    <ProjectReference Include="..\MonoTorrent.PieceWriter\MonoTorrent.PieceWriter.csproj" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Condition="$(TargetFramework) == 'netstandard2.0'" Include="System.Memory" Version="4.5.0" />
   </ItemGroup>
 
    <Target Name="CopyProjectReferencesToPackage" DependsOnTargets="BuildOnlySettings;ResolveReferences">

--- a/src/MonoTorrent/MonoTorrent.csproj
+++ b/src/MonoTorrent/MonoTorrent.csproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\MonoTorrent.BEncoding\MonoTorrent.BEncoding.csproj" />
-    <PackageReference Condition="$(TargetFramework) == 'netstandard2.0'" Include="System.Memory" Version="4.5.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Samples/Directory.Build.props
+++ b/src/Samples/Directory.Build.props
@@ -6,5 +6,8 @@
       <UseGitInfo>false</UseGitInfo>
       <Nullable></Nullable>
     </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Condition="$(TargetFramework) == 'netstandard2.0'" Include="System.Memory" Version="4.5.5" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This should explicitly reference System.Memory, fixing the issue experienced here: https://github.com/alanmcgovern/monotorrent/issues/581