### PR TITLE
[core] Allow creation dates with a length of 0

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent/Torrent.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/Torrent.cs
@@ -531,6 +531,9 @@ namespace MonoTorrent
                         break;
 
                     case ("creation date"):
+                        if (keypair.Value.ToString () == String.Empty)
+                            break;
+
                         try {
                             try {
                                 CreationDate = UnixEpoch.AddSeconds (long.Parse (keypair.Value.ToString ()!));

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/TorrentTest.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/TorrentTest.cs
@@ -480,5 +480,15 @@ namespace MonoTorrent.Common
                 (Torrent.SupportsV1V2Torrents, Torrent.SupportsV2Torrents) = (before1, before2);
             }
         }
+
+        [Test]
+        public void EmptyCreationDate ()
+        {
+            var info = torrentInfo;
+            info.Remove ("creation date");
+            info.Add ("creation date", new BEncodedString (""));
+
+            Assert.DoesNotThrow (() => Torrent.Load (torrentInfo));
+        }
     }
 }


### PR DESCRIPTION
Some torrents contain a creation date key with a zero-length string as its value. Currently, MonoTorrent will throw an exception when trying to parse these.

Let me know if there's another way you'd want to handle this (I'm guessing invalid) case. I'm not sure if a tool creates these or what, but I've seen it enough that I think something should be done here. I know torrent clients don't choke on this like MonoTorrent does, so maybe we can handle this more generically (e.g. skip parsing a key if its value's length is 0) rather than special casing the creation date.