### PR TITLE
[core] Skip parsing key if value is an empty string

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent/Torrent.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/Torrent.cs
@@ -520,6 +520,9 @@ namespace MonoTorrent
             PieceHashesV1? hashesV1 = null;
             PieceHashesV2? hashesV2 = null;
             foreach (KeyValuePair<BEncodedString, BEncodedValue> keypair in torrentInformation) {
+                if (keypair.Value is BEncodedString && keypair.Value.ToString () == String.Empty)
+                    continue;
+
                 switch (keypair.Key.Text) {
                     case ("announce"):
                         // Ignore this if we have an announce-list

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/TorrentTest.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/TorrentTest.cs
@@ -480,5 +480,15 @@ namespace MonoTorrent.Common
                 (Torrent.SupportsV1V2Torrents, Torrent.SupportsV2Torrents) = (before1, before2);
             }
         }
+
+        [Test]
+        public void EmptyCreationDate ()
+        {
+            var info = torrentInfo;
+            info.Remove ("creation date");
+            info.Add ("creation date", new BEncodedString (String.Empty));
+
+            Assert.DoesNotThrow (() => Torrent.Load (torrentInfo));
+        }
     }
 }


### PR DESCRIPTION
Let me know if you'd like a more descriptive commit message, or if I should add a description like I did in #583.