### PR TITLE
[IPV6] Support setting multiple listeners and reported endpoints

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/Mode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/Mode.cs
@@ -539,7 +539,7 @@ namespace MonoTorrent.Client.Modes
         protected virtual void AppendExtendedHandshake (PeerId id, MessageBundle bundle)
         {
             if (id.SupportsLTMessages)
-                bundle.Add (new ExtendedHandshakeMessage (Manager.Torrent?.IsPrivate ?? false, Manager.Torrent != null ? Manager.Torrent.InfoMetadata.Length : (int?) null, Settings.ListenEndPoint?.Port ?? -1), default);
+                bundle.Add (new ExtendedHandshakeMessage (Manager.Torrent?.IsPrivate ?? false, Manager.Torrent != null ? Manager.Torrent.InfoMetadata.Length : (int?) null, Manager.Engine!.GetListenEndPoint (id.Connection.Uri.Scheme)?.Port ?? -1), default);
         }
 
         protected virtual void AppendFastPieces (PeerId id, MessageBundle bundle)

--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/Mode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/Mode.cs
@@ -539,7 +539,7 @@ namespace MonoTorrent.Client.Modes
         protected virtual void AppendExtendedHandshake (PeerId id, MessageBundle bundle)
         {
             if (id.SupportsLTMessages)
-                bundle.Add (new ExtendedHandshakeMessage (Manager.Torrent?.IsPrivate ?? false, Manager.Torrent != null ? Manager.Torrent.InfoMetadata.Length : (int?) null, Manager.Engine!.GetReportedListenEndPoint (id.Connection.Uri.Scheme)?.Port ?? -1), default);
+                bundle.Add (new ExtendedHandshakeMessage (Manager.Torrent?.IsPrivate ?? false, Manager.Torrent != null ? Manager.Torrent.InfoMetadata.Length : (int?) null, Manager.Engine!.GetOverrideOrActualListenPort (id.Connection.Uri.Scheme) ?? -1), default);
         }
 
         protected virtual void AppendFastPieces (PeerId id, MessageBundle bundle)

--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/Mode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/Mode.cs
@@ -539,7 +539,7 @@ namespace MonoTorrent.Client.Modes
         protected virtual void AppendExtendedHandshake (PeerId id, MessageBundle bundle)
         {
             if (id.SupportsLTMessages)
-                bundle.Add (new ExtendedHandshakeMessage (Manager.Torrent?.IsPrivate ?? false, Manager.Torrent != null ? Manager.Torrent.InfoMetadata.Length : (int?) null, Manager.Engine!.GetListenEndPoint (id.Connection.Uri.Scheme)?.Port ?? -1), default);
+                bundle.Add (new ExtendedHandshakeMessage (Manager.Torrent?.IsPrivate ?? false, Manager.Torrent != null ? Manager.Torrent.InfoMetadata.Length : (int?) null, Manager.Engine!.GetReportedListenEndPoint (id.Connection.Uri.Scheme)?.Port ?? -1), default);
         }
 
         protected virtual void AppendFastPieces (PeerId id, MessageBundle bundle)

--- a/src/MonoTorrent.Client/MonoTorrent.Client.Tracker/TrackerRequestFactory.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Tracker/TrackerRequestFactory.cs
@@ -51,22 +51,11 @@ namespace MonoTorrent.Trackers
             requireEncryption = requireEncryption && ClientEngine.SupportsEncryption;
             supportsEncryption = supportsEncryption && ClientEngine.SupportsEncryption;
 
-            string? ip = null;
-            int port;
             // IPV6 support - If we need to do an ipv4 announce *and* an ipv6 announce, where's the best place for this to live?
-            if (engine.Settings.ReportedListenEndPoints.TryGetValue ("ipv4", out var reportedAddress)) {
+            string? ip = null;
+            int port = engine.GetOverrideOrActualListenPort ("ipv4").GetValueOrDefault (-1);
+            if (engine.Settings.ReportedListenEndPoints.TryGetValue ("ipv4", out var reportedAddress))
                 ip = reportedAddress.Address.ToString ();
-                port = reportedAddress.Port;
-            } else if (engine.GetReportedListenEndPoint ("ipv4") != null) {
-                port = engine.GetReportedListenEndPoint ("ipv4")!.Port;
-            } else {
-                // FIXME: Announce via ipv4 *and* via ipv6 endpoints. Use the correct scheme then.
-                // FIXME: This shouldn't be needed? ENgine.GetListeEndPoint should always return non-null?
-                // port = engine.Settings.GetListenEndPoint ("ipv4")?.Port ?? -1;
-
-                // If all else fails, report -1.
-                port = -1;
-            }
 
             // FIXME: In metadata mode we need to pretend we need to download data otherwise
             // tracker optimisations might result in no peers being sent back.

--- a/src/MonoTorrent.Client/MonoTorrent.Client.Tracker/TrackerRequestFactory.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Tracker/TrackerRequestFactory.cs
@@ -53,11 +53,12 @@ namespace MonoTorrent.Trackers
 
             string? ip = null;
             int port;
-            if (engine.Settings.ReportedAddress != null) {
-                ip = engine.Settings.ReportedAddress.Address.ToString ();
-                port = engine.Settings.ReportedAddress.Port;
-            } else if (engine.GetListenEndPoint ("ipv4") != null) {
-                port = engine.GetListenEndPoint ("ipv4")!.Port;
+            // IPV6 support - If we need to do an ipv4 announce *and* an ipv6 announce, where's the best place for this to live?
+            if (engine.Settings.ReportedListenEndPoints.TryGetValue ("ipv4", out var reportedAddress)) {
+                ip = reportedAddress.Address.ToString ();
+                port = reportedAddress.Port;
+            } else if (engine.GetReportedListenEndPoint ("ipv4") != null) {
+                port = engine.GetReportedListenEndPoint ("ipv4")!.Port;
             } else {
                 // FIXME: Announce via ipv4 *and* via ipv6 endpoints. Use the correct scheme then.
                 // FIXME: This shouldn't be needed? ENgine.GetListeEndPoint should always return non-null?

--- a/src/MonoTorrent.Client/MonoTorrent.Client.Tracker/TrackerRequestFactory.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Tracker/TrackerRequestFactory.cs
@@ -56,10 +56,15 @@ namespace MonoTorrent.Trackers
             if (engine.Settings.ReportedAddress != null) {
                 ip = engine.Settings.ReportedAddress.Address.ToString ();
                 port = engine.Settings.ReportedAddress.Port;
-            } else if (engine.PeerListener.LocalEndPoint != null) {
-                port = engine.PeerListener.LocalEndPoint.Port;
+            } else if (engine.GetListenEndPoint ("ipv4") != null) {
+                port = engine.GetListenEndPoint ("ipv4")!.Port;
             } else {
-                port = engine.Settings.ListenEndPoint?.Port ?? -1;
+                // FIXME: Announce via ipv4 *and* via ipv6 endpoints. Use the correct scheme then.
+                // FIXME: This shouldn't be needed? ENgine.GetListeEndPoint should always return non-null?
+                // port = engine.Settings.GetListenEndPoint ("ipv4")?.Port ?? -1;
+
+                // If all else fails, report -1.
+                port = -1;
             }
 
             // FIXME: In metadata mode we need to pretend we need to download data otherwise

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/ListenManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/ListenManager.cs
@@ -48,14 +48,14 @@ namespace MonoTorrent.Client
 
         ClientEngine Engine { get; set; }
 
-        IPeerConnectionListener Listener { get; set; }
+        IList<IPeerConnectionListener> Listeners { get; set; }
 
         InfoHash[] SKeys { get; set; }
 
         internal ListenManager (ClientEngine engine)
         {
             Engine = engine ?? throw new ArgumentNullException (nameof (engine));
-            Listener = new NullPeerListener ();
+            Listeners = Array.Empty<IPeerConnectionListener> ();
             SKeys = Array.Empty<InfoHash> ();
         }
 
@@ -79,11 +79,13 @@ namespace MonoTorrent.Client
             SKeys = clone.ToArray ();
         }
 
-        public void SetListener (IPeerConnectionListener listener)
+        public void SetListeners (IList<IPeerConnectionListener> listeners)
         {
-            Listener.ConnectionReceived -= ConnectionReceived;
-            Listener = listener ?? new NullPeerListener ();
-            Listener.ConnectionReceived += ConnectionReceived;
+            foreach (var v in Listeners)
+                v.ConnectionReceived -= ConnectionReceived;
+            Listeners = Array.AsReadOnly (listeners.ToArray ());
+            foreach (var v in Listeners)
+                v.ConnectionReceived += ConnectionReceived;
         }
 
         async void ConnectionReceived (object? sender, PeerConnectionEventArgs e)

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -733,14 +733,15 @@ namespace MonoTorrent.Client
             await ClientEngine.MainLoop;
 
             if (Engine != null && CanUseLocalPeerDiscovery && (!LastLocalPeerAnnounceTimer.IsRunning || LastLocalPeerAnnounceTimer.Elapsed > Engine.LocalPeerDiscovery.MinimumAnnounceInternal)) {
-                if (Engine.PeerListener.LocalEndPoint != null) {
-                    LastLocalPeerAnnounce = DateTime.Now;
-                    LastLocalPeerAnnounceTimer.Restart ();
+                LastLocalPeerAnnounce = DateTime.Now;
+                LastLocalPeerAnnounceTimer.Restart ();
 
+                var endPoints = Engine.PeerListeners.Select (t => t.LocalEndPoint!).Where (t => t != null);
+                foreach (var endpoint in endPoints) { 
                     if (InfoHashes.V1 != null)
-                        await Engine.LocalPeerDiscovery.Announce (InfoHashes.V1, Engine.PeerListener.LocalEndPoint!);
+                        await Engine.LocalPeerDiscovery.Announce (InfoHashes.V1, endpoint);
                     if (InfoHashes.V2 != null)
-                        await Engine.LocalPeerDiscovery.Announce (InfoHashes.V2.Truncate (), Engine.PeerListener.LocalEndPoint!);
+                        await Engine.LocalPeerDiscovery.Announce (InfoHashes.V2.Truncate (), endpoint);
                 }
             }
         }

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Settings/EngineSettings.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Settings/EngineSettings.cs
@@ -339,7 +339,8 @@ namespace MonoTorrent.Client
                    && DiskCachePolicy == other.DiskCachePolicy
                    && FastResumeMode == other.FastResumeMode
                    && HttpStreamingPrefix == other.HttpStreamingPrefix
-                   && ListenEndPoints.SequenceEqual (other.ListenEndPoints)
+                   && AreEquivalent (ListenEndPoints, other.ListenEndPoints)
+                   && AreEquivalent (ReportedListenEndPoints, other.ReportedListenEndPoints)
                    && MaximumConnections == other.MaximumConnections
                    && MaximumDiskReadRate == other.MaximumDiskReadRate
                    && MaximumDiskWriteRate == other.MaximumDiskWriteRate
@@ -347,13 +348,22 @@ namespace MonoTorrent.Client
                    && MaximumHalfOpenConnections == other.MaximumHalfOpenConnections
                    && MaximumOpenFiles == other.MaximumOpenFiles
                    && MaximumUploadRate == other.MaximumUploadRate
-                   && ReportedListenEndPoints.SequenceEqual (other.ReportedListenEndPoints)
                    && StaleRequestTimeout == other.StaleRequestTimeout
                    && UsePartialFiles == other.UsePartialFiles
                    && WebSeedConnectionTimeout == other.WebSeedConnectionTimeout
                    && WebSeedDelay == other.WebSeedDelay
                    && WebSeedSpeedTrigger == other.WebSeedSpeedTrigger
                    ;
+        }
+
+        bool AreEquivalent (IDictionary<string, IPEndPoint> first, IDictionary<string, IPEndPoint> second)
+        {
+            if (first.Count != second.Count)
+                return false;
+            foreach (var v in first)
+                if (!second.TryGetValue (v.Key, out var value) || !v.Value.Equals (value))
+                    return false;
+            return true;
         }
 
         public override int GetHashCode ()

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Settings/EngineSettings.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Settings/EngineSettings.cs
@@ -216,7 +216,7 @@ namespace MonoTorrent.Client
         /// Announce or Scrape requests are sent from, specify it here. Typically this should not be set.
         /// Defaults to <see langword="null" />
         /// </summary>
-        public IPEndPoint? ReportedAddress { get; }
+        public IDictionary<string, IPEndPoint> ReportedListenEndPoints { get; } = new ReadOnlyDictionary<string, IPEndPoint> (new Dictionary<string, IPEndPoint> ());
 
         /// <summary>
         /// When blocks have been requested from a peer, the connection to that peer will be closed and the
@@ -267,7 +267,7 @@ namespace MonoTorrent.Client
             bool autoSaveLoadDhtCache, bool autoSaveLoadFastResume, bool autoSaveLoadMagnetLinkMetadata, string cacheDirectory,
             TimeSpan connectionTimeout, IPEndPoint? dhtEndPoint, int diskCacheBytes, CachePolicy diskCachePolicy, FastResumeMode fastResumeMode, Dictionary<string, IPEndPoint> listenEndPoints,
             int maximumConnections, int maximumDiskReadRate, int maximumDiskWriteRate, int maximumDownloadRate, int maximumHalfOpenConnections,
-            int maximumOpenFiles, int maximumUploadRate, IPEndPoint? reportedAddress, bool usePartialFiles,
+            int maximumOpenFiles, int maximumUploadRate, IDictionary<string, IPEndPoint> reportedListenEndPoints, bool usePartialFiles,
             TimeSpan webSeedConnectionTimeout, TimeSpan webSeedDelay, int webSeedSpeedTrigger, TimeSpan staleRequestTimeout,
             string httpStreamingPrefix)
         {
@@ -294,7 +294,7 @@ namespace MonoTorrent.Client
             MaximumHalfOpenConnections = maximumHalfOpenConnections;
             MaximumOpenFiles = maximumOpenFiles;
             MaximumUploadRate = maximumUploadRate;
-            ReportedAddress = reportedAddress;
+            ReportedListenEndPoints = new ReadOnlyDictionary<string, IPEndPoint> (new Dictionary<string, IPEndPoint> (reportedListenEndPoints));
             StaleRequestTimeout = staleRequestTimeout;
             UsePartialFiles = usePartialFiles;
             WebSeedConnectionTimeout = webSeedConnectionTimeout;
@@ -347,7 +347,7 @@ namespace MonoTorrent.Client
                    && MaximumHalfOpenConnections == other.MaximumHalfOpenConnections
                    && MaximumOpenFiles == other.MaximumOpenFiles
                    && MaximumUploadRate == other.MaximumUploadRate
-                   && ReportedAddress == other.ReportedAddress
+                   && ReportedListenEndPoints.SequenceEqual (other.ReportedListenEndPoints)
                    && StaleRequestTimeout == other.StaleRequestTimeout
                    && UsePartialFiles == other.UsePartialFiles
                    && WebSeedConnectionTimeout == other.WebSeedConnectionTimeout

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Settings/EngineSettingsBuilder.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Settings/EngineSettingsBuilder.cs
@@ -50,7 +50,7 @@ namespace MonoTorrent.Client
             bool automaticFastResume = false,
             bool autoSaveLoadMagnetLinkMetadata = true,
             IPEndPoint? dhtEndPoint = null,
-            IPEndPoint? listenEndPoint = null,
+            Dictionary<string, IPEndPoint>? listenEndPoints = null,
             string? cacheDirectory = null,
             bool usePartialFiles = false)
         {
@@ -61,7 +61,7 @@ namespace MonoTorrent.Client
                 AutoSaveLoadMagnetLinkMetadata = autoSaveLoadMagnetLinkMetadata,
                 CacheDirectory = cacheDirectory ?? Path.Combine (Path.GetDirectoryName (typeof (EngineSettingsBuilder).Assembly.Location)!, "test_cache_dir"),
                 DhtEndPoint = dhtEndPoint,
-                ListenEndPoint = listenEndPoint,
+                ListenEndPoints = new Dictionary<string, IPEndPoint> (listenEndPoints ?? new Dictionary<string, IPEndPoint> ()),
                 UsePartialFiles = usePartialFiles,
             }.ToSettings ();
         }
@@ -87,7 +87,7 @@ namespace MonoTorrent.Client
         /// Connections will be attempted in the same order as they are in the list. Defaults to <see cref="EncryptionType.RC4Header"/>,
         /// <see cref="EncryptionType.RC4Full"/> and <see cref="EncryptionType.PlainText"/>.
         /// </summary>
-        public IList<EncryptionType> AllowedEncryption { get; set; }
+        public List<EncryptionType> AllowedEncryption { get; set; }
 
         /// <summary>
         /// Have suppression reduces the number of Have messages being sent by only sending Have messages to peers
@@ -218,7 +218,7 @@ namespace MonoTorrent.Client
         /// The TCP port the engine should listen on for incoming connections. Use 0 to choose a random
         /// available port. Choose -1 to disable listening for incoming connections. Defaults to 0.
         /// </summary>
-        public IPEndPoint? ListenEndPoint { get; set; }
+        public Dictionary<string, IPEndPoint> ListenEndPoints { get; set; }
 
         /// <summary>
         /// The maximum number of concurrent open connections overall. Defaults to 150.
@@ -356,7 +356,7 @@ namespace MonoTorrent.Client
             DiskCachePolicy = settings.DiskCachePolicy;
             FastResumeMode = settings.FastResumeMode;
             httpStreamingPrefix = settings.HttpStreamingPrefix;
-            ListenEndPoint = settings.ListenEndPoint;
+            ListenEndPoints = new Dictionary<string, IPEndPoint> (settings.ListenEndPoints);
             MaximumConnections = settings.MaximumConnections;
             MaximumDiskReadRate = settings.MaximumDiskReadRate;
             MaximumDiskWriteRate = settings.MaximumDiskWriteRate;
@@ -396,7 +396,7 @@ namespace MonoTorrent.Client
                 diskCachePolicy: DiskCachePolicy,
                 fastResumeMode: FastResumeMode,
                 httpStreamingPrefix: HttpStreamingPrefix,
-                listenEndPoint: ListenEndPoint,
+                listenEndPoints: ListenEndPoints,
                 maximumConnections: MaximumConnections,
                 maximumDiskReadRate: MaximumDiskReadRate,
                 maximumDiskWriteRate: MaximumDiskWriteRate,

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Settings/EngineSettingsBuilder.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Settings/EngineSettingsBuilder.cs
@@ -288,7 +288,7 @@ namespace MonoTorrent.Client
         /// Announce or Scrape requests are sent from, specify it here. Typically this should not be set.
         /// Defaults to <see langword="null" />
         /// </summary>
-        public IPEndPoint? ReportedAddress { get; set; }
+        public Dictionary<string, IPEndPoint> ReportedListenEndPoints { get; set; }
 
         /// <summary>
         /// When blocks have been requested from a peer, the connection to that peer will be closed and the
@@ -357,6 +357,7 @@ namespace MonoTorrent.Client
             FastResumeMode = settings.FastResumeMode;
             httpStreamingPrefix = settings.HttpStreamingPrefix;
             ListenEndPoints = new Dictionary<string, IPEndPoint> (settings.ListenEndPoints);
+            ReportedListenEndPoints = new Dictionary<string, IPEndPoint> (settings.ReportedListenEndPoints);
             MaximumConnections = settings.MaximumConnections;
             MaximumDiskReadRate = settings.MaximumDiskReadRate;
             MaximumDiskWriteRate = settings.MaximumDiskWriteRate;
@@ -364,7 +365,6 @@ namespace MonoTorrent.Client
             MaximumHalfOpenConnections = settings.MaximumHalfOpenConnections;
             MaximumOpenFiles = settings.MaximumOpenFiles;
             MaximumUploadRate = settings.MaximumUploadRate;
-            ReportedAddress = settings.ReportedAddress;
             StaleRequestTimeout = settings.StaleRequestTimeout;
             UsePartialFiles = settings.UsePartialFiles;
             WebSeedConnectionTimeout = settings.WebSeedConnectionTimeout;
@@ -404,7 +404,7 @@ namespace MonoTorrent.Client
                 maximumHalfOpenConnections: MaximumHalfOpenConnections,
                 maximumOpenFiles: MaximumOpenFiles,
                 maximumUploadRate: MaximumUploadRate,
-                reportedAddress: ReportedAddress,
+                reportedListenEndPoints: ReportedListenEndPoints,
                 staleRequestTimeout: StaleRequestTimeout,
                 usePartialFiles: UsePartialFiles,
                 webSeedConnectionTimeout: WebSeedConnectionTimeout,

--- a/src/MonoTorrent.Connections/MonoTorrent.Connections.Peer/SocketPeerConnection.cs
+++ b/src/MonoTorrent.Connections/MonoTorrent.Connections.Peer/SocketPeerConnection.cs
@@ -85,8 +85,8 @@ namespace MonoTorrent.Connections.Peer
             if (uri == null) {
                 var endpoint = (IPEndPoint) socket!.RemoteEndPoint!;
                 uri = socket.AddressFamily switch {
-                    AddressFamily.InterNetwork => new Uri ($"ipv4://{endpoint.Address.ToString ()}:{endpoint.Port}"),
-                    AddressFamily.InterNetworkV6 => new Uri ($"ipv6://[{endpoint.Address.ToString ()}]:{endpoint.Port}"),
+                    AddressFamily.InterNetwork => new Uri ($"ipv6://{endpoint}"),
+                    AddressFamily.InterNetworkV6 => new Uri ($"ipv6://{endpoint}"),
                     _ => throw new NotSupportedException ($"AddressFamily.{socket.AddressFamily} is unsupported")
                 };
             }

--- a/src/Samples/SampleClient/StandardDownloader.cs
+++ b/src/Samples/SampleClient/StandardDownloader.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Samples/SampleClient/StressTest.cs
+++ b/src/Samples/SampleClient/StressTest.cs
@@ -169,8 +169,8 @@ namespace ClientSample
             int port = 37000;
             var seeder = new ClientEngine (
                 new EngineSettingsBuilder {
-                    AllowedEncryption = new[] { EncryptionType.PlainText },
-                    ListenEndPoint = new IPEndPoint (IPAddress.Any, port++),
+                    AllowedEncryption = new List<EncryptionType> { EncryptionType.PlainText },
+                    ListenEndPoints = new Dictionary<string, IPEndPoint> { { "ipv4", new IPEndPoint (IPAddress.Any, port++) } },
                     DhtEndPoint = null,
                     AllowLocalPeerDiscovery = false,
                 }.ToSettings (),
@@ -189,9 +189,9 @@ namespace ClientSample
             var downloaders = Enumerable.Range (port, MaxDownloaders).Select (p => {
                 return new ClientEngine (
                     new EngineSettingsBuilder {
-                        AllowedEncryption = new[] { EncryptionType.PlainText },
+                        AllowedEncryption = new List<EncryptionType> { EncryptionType.PlainText },
                         DiskCacheBytes = DataSize,
-                        ListenEndPoint = new IPEndPoint (IPAddress.Any, p),
+                        ListenEndPoints = new Dictionary<string, IPEndPoint> { { "ipv4", new IPEndPoint (IPAddress.Any, p) } },
                         DhtEndPoint = null,
                         AllowLocalPeerDiscovery = false,
                         CacheDirectory = Path.Combine (DataDir, "Downloader_" + port + "_CacheDirectory")

--- a/src/Samples/SampleClient/main.cs
+++ b/src/Samples/SampleClient/main.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Threading;
@@ -50,7 +51,10 @@ namespace ClientSample
                 AutoSaveLoadMagnetLinkMetadata = true,
 
                 // Use a fixed port to accept incoming connections from other peers for testing purposes. Production usages should use a random port, 0, if possible.
-                ListenEndPoint = new IPEndPoint (IPAddress.Any, 55123),
+                ListenEndPoints = new Dictionary<string, IPEndPoint> {
+                    { "ipv4", new IPEndPoint (IPAddress.Any, 55123) },
+                    { "ipv6", new IPEndPoint (IPAddress.IPv6Any, 55123) }
+                },
 
                 // Use a fixed port for DHT communications for testing purposes. Production usages should use a random port, 0, if possible.
                 DhtEndPoint = new IPEndPoint (IPAddress.Any, 55123),

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/EngineSettingsTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/EngineSettingsTests.cs
@@ -51,5 +51,23 @@ namespace MonoTorrent.Client
             Assert.AreNotEqual (modified.HttpStreamingPrefix, new EngineSettings ().HttpStreamingPrefix);
             Assert.AreNotEqual (modified.ToSettings ().HttpStreamingPrefix, new EngineSettings ().HttpStreamingPrefix);
         }
+
+        [Test]
+        public void WithReportedAddress ()
+        {
+            var settings = new EngineSettingsBuilder {
+                ReportedListenEndPoints = new System.Collections.Generic.Dictionary<string, System.Net.IPEndPoint> {
+                    { "custom", new System.Net.IPEndPoint (System.Net.IPAddress.Any, 12345) },
+                    { "ipv6", new System.Net.IPEndPoint (System.Net.IPAddress.IPv6Any, 3456) },
+                    { "ipv4", new System.Net.IPEndPoint (System.Net.IPAddress.Loopback, 6798) },
+                }
+            }.ToSettings ();
+
+            Assert.AreEqual (settings, settings);
+
+            var deserialised = Serializer.DeserializeEngineSettings (Serializer.Serialize (settings));
+            Assert.AreEqual (deserialised, settings);
+
+        }
     }
 }

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/TestRig.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/TestRig.cs
@@ -333,7 +333,7 @@ namespace MonoTorrent.Client
 
         public ClientEngine Engine { get; }
 
-        public CustomListener Listener => (CustomListener) Engine.PeerListener;
+        public CustomListener Listener => (CustomListener) Engine.PeerListeners[0];
 
         public TorrentManager Manager { get; set; }
 
@@ -426,7 +426,7 @@ namespace MonoTorrent.Client
                 allowLocalPeerDiscovery: true,
                 dhtEndPoint: new IPEndPoint (IPAddress.Any, 12345),
                 cacheDirectory: cacheDir,
-                listenEndPoint: new IPEndPoint (IPAddress.Any, 12345)
+                listenEndPoints: new Dictionary<string, IPEndPoint> { { "ipv4", new IPEndPoint (IPAddress.Any, 12345) } }
             ), factories);
             if (Directory.Exists (Engine.Settings.MetadataCacheDirectory))
                 Directory.Delete (Engine.Settings.MetadataCacheDirectory, true);

--- a/src/Tests/Tests.MonoTorrent.IntegrationTests/IntegrationTests.cs
+++ b/src/Tests/Tests.MonoTorrent.IntegrationTests/IntegrationTests.cs
@@ -213,7 +213,7 @@ namespace Tests.MonoTorrent.IntegrationTests
             // Give an example of how settings can be modified for the engine.
             var settingBuilder = new EngineSettingsBuilder {
                 // Use a fixed port to accept incoming connections from other peers for testing purposes. Production usages should use a random port, 0, if possible.
-                ListenEndPoint = new IPEndPoint (IPAddress.Any, port),
+                ListenEndPoints = new Dictionary<string, IPEndPoint> { { "ipv4", new IPEndPoint (IPAddress.Any, port) } },
                 ReportedAddress = new IPEndPoint (IPAddress.Parse ("127.0.0.1"), port),
                 AutoSaveLoadFastResume = false,
                 CacheDirectory = _directory.FullName,

--- a/src/Tests/Tests.MonoTorrent.IntegrationTests/IntegrationTests.cs
+++ b/src/Tests/Tests.MonoTorrent.IntegrationTests/IntegrationTests.cs
@@ -214,7 +214,7 @@ namespace Tests.MonoTorrent.IntegrationTests
             var settingBuilder = new EngineSettingsBuilder {
                 // Use a fixed port to accept incoming connections from other peers for testing purposes. Production usages should use a random port, 0, if possible.
                 ListenEndPoints = new Dictionary<string, IPEndPoint> { { "ipv4", new IPEndPoint (IPAddress.Any, port) } },
-                ReportedAddress = new IPEndPoint (IPAddress.Parse ("127.0.0.1"), port),
+                ReportedListenEndPoints = new Dictionary<string, IPEndPoint> { { "ipv4", new IPEndPoint (IPAddress.Parse ("127.0.0.1"), 0) } },
                 AutoSaveLoadFastResume = false,
                 CacheDirectory = _directory.FullName,
                 DhtEndPoint = null,


### PR DESCRIPTION
Default to creating an IPV4 and IPV6 listener, bound to IPAddress.Any/IPV6Any, and port 0. Additionally, allow configuring an alternative reported IP address for both IPV4 and IPV6.

Partially fixes https://github.com/alanmcgovern/monotorrent/issues/588

