### PR TITLE
[core] Support ipv4 and ipv6 compact addresses

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/Mode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/Mode.cs
@@ -249,7 +249,7 @@ namespace MonoTorrent.Client.Modes
                 if ((Manager.Peers.Available + Manager.OpenConnections) >= Manager.Settings.MaximumConnections)
                     return;
 
-                var newPeers = PeerDecoder.Decode (BEncodedString.FromMemory (message.Added));
+                var newPeers = PeerInfo.FromCompact (message.Added.Span, id.Connection.AddressBytes.Length == 16 ? System.Net.Sockets.AddressFamily.InterNetworkV6 : System.Net.Sockets.AddressFamily.InterNetwork);
                 for (int i = 0; i < newPeers.Count && i < message.AddedDotF.Length; i++)
                     newPeers[i] = new PeerInfo (newPeers[i].ConnectionUri, newPeers[i].PeerId, (message.AddedDotF.Span[i] & 0x2) == 0x2);
 

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Peers/Peer.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Peers/Peer.cs
@@ -130,8 +130,8 @@ namespace MonoTorrent.Client
         internal byte[] CompactPeer ()
             => Info.CompactPeer ();
 
-        internal void CompactPeer (Span<byte> buffer)
-            => Info.CompactPeer (buffer);
+        internal bool TryWriteCompactPeer (Span<byte> buffer, out int written)
+            => Info.TryWriteCompactPeer (buffer, out written);
 
         internal static BEncodedList Encode (IEnumerable<Peer> peers)
         {

--- a/src/MonoTorrent.Dht/MonoTorrent.Dht.Tasks/GetPeersTask.cs
+++ b/src/MonoTorrent.Dht/MonoTorrent.Dht.Tasks/GetPeersTask.cs
@@ -84,7 +84,7 @@ namespace MonoTorrent.Dht.Tasks
                 // The response had some actual peers
                 if (response.Values != null) {
                     // We have actual peers!
-                    var peers = response.Values.OfType<BEncodedString> ().SelectMany (t => PeerInfo.FromCompact (t.Span)).ToArray ();
+                    var peers = response.Values.OfType<BEncodedString> ().SelectMany (t => PeerInfo.FromCompact (t.Span, Engine.AddressFamily)).ToArray ();
                     Engine.RaisePeersFound (InfoHash, peers);
                     foreach (var peer in peers)
                         FoundPeers.Add (peer);

--- a/src/MonoTorrent.Dht/MonoTorrent.Dht/DhtEngine.cs
+++ b/src/MonoTorrent.Dht/MonoTorrent.Dht/DhtEngine.cs
@@ -30,6 +30,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Sockets;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 
@@ -73,6 +74,9 @@ namespace MonoTorrent.Dht
         #endregion Events
 
         internal static MainLoop MainLoop { get; } = new MainLoop ("DhtLoop");
+
+        // IPV6 - create an IPV4 and an IPV6 dht engine
+        public AddressFamily AddressFamily { get; private set; } = AddressFamily.InterNetwork;
 
         public TimeSpan AnnounceInterval => DefaultAnnounceInternal;
 

--- a/src/MonoTorrent.Trackers/MonoTorrent.Client.Messages.UdpTracker/UdpTrackerMessage.cs
+++ b/src/MonoTorrent.Trackers/MonoTorrent.Client.Messages.UdpTracker/UdpTrackerMessage.cs
@@ -28,6 +28,7 @@
 
 
 using System;
+using System.Net.Sockets;
 
 namespace MonoTorrent.Messages.UdpTracker
 {
@@ -42,7 +43,7 @@ namespace MonoTorrent.Messages.UdpTracker
             TransactionId = transactionId;
         }
 
-        public static UdpTrackerMessage DecodeMessage (ReadOnlySpan<byte> buffer, MessageType type)
+        public static UdpTrackerMessage DecodeMessage (ReadOnlySpan<byte> buffer, MessageType type, AddressFamily addressFamily)
         {
             UdpTrackerMessage m;
             var actionBuffer = type == MessageType.Request ? buffer.Slice (8) : buffer;
@@ -58,7 +59,7 @@ namespace MonoTorrent.Messages.UdpTracker
                     if (type == MessageType.Request)
                         m = new AnnounceMessage ();
                     else
-                        m = new AnnounceResponseMessage ();
+                        m = new AnnounceResponseMessage (addressFamily);
                     break;
                 case 2:
                     if (type == MessageType.Request)

--- a/src/MonoTorrent.Trackers/MonoTorrent.Connections.Tracker/UdpTrackerConnection.cs
+++ b/src/MonoTorrent.Trackers/MonoTorrent.Connections.Tracker/UdpTrackerConnection.cs
@@ -188,7 +188,7 @@ namespace MonoTorrent.Connections.Tracker
         {
             while (!token.IsCancellationRequested) {
                 UdpReceiveResult received = await client.ReceiveAsync ();
-                var rsp = UdpTrackerMessage.DecodeMessage (received.Buffer.AsSpan (0, received.Buffer.Length), MessageType.Response);
+                var rsp = UdpTrackerMessage.DecodeMessage (received.Buffer.AsSpan (0, received.Buffer.Length), MessageType.Response, received.RemoteEndPoint.AddressFamily);
 
                 if (transactionId == rsp.TransactionId) {
                     if (rsp is ErrorMessage error) {

--- a/src/MonoTorrent/MonoTorrent.Connections.Peer/IPeerConnection.cs
+++ b/src/MonoTorrent/MonoTorrent.Connections.Peer/IPeerConnection.cs
@@ -29,6 +29,7 @@
 
 using System;
 using System.Net;
+using System.Net.Sockets;
 
 using ReusableTasks;
 

--- a/src/MonoTorrent/MonoTorrent.csproj
+++ b/src/MonoTorrent/MonoTorrent.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <UseMemoryExtensions>true</UseMemoryExtensions>
     <TargetFrameworks>net6.0;net5.0;netcoreapp3.0;netstandard2.1;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/UdpTrackerTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/UdpTrackerTests.cs
@@ -125,7 +125,7 @@ namespace MonoTorrent.Trackers
         public void AnnounceMessageTest ()
         {
             AnnounceMessage m = new AnnounceMessage (0, 12345, announceparams, announceparams.InfoHashes.V1OrV2);
-            AnnounceMessage d = (AnnounceMessage) UdpTrackerMessage.DecodeMessage (m.Encode (), MessageType.Request);
+            AnnounceMessage d = (AnnounceMessage) UdpTrackerMessage.DecodeMessage (m.Encode (), MessageType.Request, AddressFamily.InterNetwork);
             Check (m, MessageType.Request);
 
             Assert.AreEqual (1, m.Action);
@@ -138,8 +138,8 @@ namespace MonoTorrent.Trackers
         public void AnnounceResponseTest ()
         {
             var peers = peerEndpoints.Select (t => new PeerInfo (new Uri ($"ipv4://{t.Address}:{t.Port}"))).ToList ();
-            AnnounceResponseMessage m = new AnnounceResponseMessage (12345, TimeSpan.FromSeconds (10), 43, 65, peers);
-            AnnounceResponseMessage d = (AnnounceResponseMessage) UdpTrackerMessage.DecodeMessage (m.Encode (), MessageType.Response);
+            AnnounceResponseMessage m = new AnnounceResponseMessage (AddressFamily.InterNetwork, 12345, TimeSpan.FromSeconds (10), 43, 65, peers);
+            AnnounceResponseMessage d = (AnnounceResponseMessage) UdpTrackerMessage.DecodeMessage (m.Encode (), MessageType.Response, AddressFamily.InterNetwork);
             Check (m, MessageType.Response);
 
             Assert.AreEqual (1, m.Action);
@@ -152,7 +152,7 @@ namespace MonoTorrent.Trackers
         public void ConnectMessageTest ()
         {
             ConnectMessage m = new ConnectMessage ();
-            ConnectMessage d = (ConnectMessage) UdpTrackerMessage.DecodeMessage (m.Encode (), MessageType.Request);
+            ConnectMessage d = (ConnectMessage) UdpTrackerMessage.DecodeMessage (m.Encode (), MessageType.Request, AddressFamily.InterNetwork);
             Check (m, MessageType.Request);
 
             Assert.AreEqual (0, m.Action, "#0");
@@ -166,7 +166,7 @@ namespace MonoTorrent.Trackers
         public void ConnectResponseTest ()
         {
             ConnectResponseMessage m = new ConnectResponseMessage (5371, 12345);
-            ConnectResponseMessage d = (ConnectResponseMessage) UdpTrackerMessage.DecodeMessage (m.Encode (), MessageType.Response);
+            ConnectResponseMessage d = (ConnectResponseMessage) UdpTrackerMessage.DecodeMessage (m.Encode (), MessageType.Response, AddressFamily.InterNetwork);
             Check (m, MessageType.Response);
 
             Assert.AreEqual (0, m.Action, "#0");
@@ -195,7 +195,7 @@ namespace MonoTorrent.Trackers
             hashes.Add (InfoHash.FromMemory (hash3));
 
             ScrapeMessage m = new ScrapeMessage (12345, 123, hashes);
-            ScrapeMessage d = (ScrapeMessage) UdpTrackerMessage.DecodeMessage (m.Encode (), MessageType.Request);
+            ScrapeMessage d = (ScrapeMessage) UdpTrackerMessage.DecodeMessage (m.Encode (), MessageType.Request, AddressFamily.InterNetwork);
             Check (m, MessageType.Request);
 
             Assert.AreEqual (2, m.Action);
@@ -213,7 +213,7 @@ namespace MonoTorrent.Trackers
             };
 
             ScrapeResponseMessage m = new ScrapeResponseMessage (12345, details);
-            ScrapeResponseMessage d = (ScrapeResponseMessage) UdpTrackerMessage.DecodeMessage (m.Encode (), MessageType.Response);
+            ScrapeResponseMessage d = (ScrapeResponseMessage) UdpTrackerMessage.DecodeMessage (m.Encode (), MessageType.Response, AddressFamily.InterNetwork);
             Check (m, MessageType.Response);
 
             Assert.AreEqual (2, m.Action);
@@ -226,7 +226,7 @@ namespace MonoTorrent.Trackers
         {
             byte[] e = message.Encode ();
             Assert.AreEqual (e.Length, message.ByteLength, "#1");
-            Assert.IsTrue (Toolbox.ByteMatch (e, UdpTrackerMessage.DecodeMessage (e, type).Encode ()), "#2");
+            Assert.IsTrue (Toolbox.ByteMatch (e, UdpTrackerMessage.DecodeMessage (e, type, AddressFamily.InterNetwork).Encode ()), "#2");
         }
 
         [Test]


### PR DESCRIPTION
Augment `PeerInfo` to also support parsing IPV6 addresses. The format used to parse the compact peer notation into an actual IPAddress/Uri is still hardcoded to assume IPV4 in a few places, though that's primarily because more groundwork needs to be done to fully map IPv6 throughout dht, peer exchange, etc.

Some parts of the spec are written to allow sending `ipv4` and `ipv6` formats in the same message, others use the active connection type to discriminate. i.e. if you send a udp request over ipv4 you get ipv4 peers back, if you send it over ipv6 you get ipv6 peers.

It makes it a bit more complicated to support as a result.

https://github.com/alanmcgovern/monotorrent/issues/588