### PR TITLE
[core] Refresh the 'AmInterested' status regularly

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/DownloadMode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/DownloadMode.cs
@@ -59,6 +59,9 @@ namespace MonoTorrent.Client.Modes
             }
         }
 
+        public override void HandleFilePriorityChanged (ITorrentManagerFile file, Priority oldPriority)
+            => RefreshAmInterestedStatusForAllPeers ();
+
         public override bool ShouldConnect (Peer peer)
         {
             return !(peer.IsSeeder && Manager.HasMetadata && Manager.Complete);

--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/ErrorMode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/ErrorMode.cs
@@ -54,6 +54,11 @@ namespace MonoTorrent.Client.Modes
         public void Dispose ()
             => Cancellation.Cancel ();
 
+        public void HandleFilePriorityChanged (ITorrentManagerFile file, Priority oldPriority)
+        {
+            // Nothing
+        }
+
         public void HandleMessage (PeerId id, PeerMessage message, PeerMessage.Releaser releaser)
             => throw new NotSupportedException ();
 

--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/HashingMode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/HashingMode.cs
@@ -58,6 +58,11 @@ namespace MonoTorrent.Client.Modes
             PausedCompletionSource.SetResult (null);
         }
 
+        public void HandleFilePriorityChanged (ITorrentManagerFile file, Priority oldPriority)
+        {
+            // Nothing
+        }
+
         public void Pause ()
         {
             if (State == TorrentState.HashingPaused)

--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/IMode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/IMode.cs
@@ -42,6 +42,7 @@ namespace MonoTorrent.Client.Modes
         TorrentState State { get; }
         CancellationToken Token { get; }
 
+        void HandleFilePriorityChanged (ITorrentManagerFile file, Priority oldPriority);
         void HandleMessage (PeerId id, PeerMessage message, PeerMessage.Releaser releaser);
         void HandlePeerConnected (PeerId id);
         void HandlePeerDisconnected (PeerId id);

--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/PausedMode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/PausedMode.cs
@@ -41,6 +41,9 @@ namespace MonoTorrent.Client.Modes
             // does not need to do anything special.
         }
 
+        public override void HandleFilePriorityChanged (ITorrentManagerFile file, Priority oldPriority)
+            => RefreshAmInterestedStatusForAllPeers ();
+
         public override void Tick (int counter)
         {
             // TODO: In future maybe this can be made smarter by refactoring

--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/StartingMode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/StartingMode.cs
@@ -63,6 +63,11 @@ namespace MonoTorrent.Client.Modes
         public void Dispose ()
             => Cancellation.Cancel ();
 
+        public void HandleFilePriorityChanged (ITorrentManagerFile file, Priority oldPriority)
+        {
+            // Nothing
+        }
+
         public void HandleMessage (PeerId id, PeerMessage message, PeerMessage.Releaser releaser)
             => throw new NotSupportedException ();
 

--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/StoppedMode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/StoppedMode.cs
@@ -50,6 +50,11 @@ namespace MonoTorrent.Client.Modes
         public void Dispose ()
             => Cancellation.Cancel ();
 
+        public void HandleFilePriorityChanged (ITorrentManagerFile file, Priority oldPriority)
+        {
+            // Nothing
+        }
+
         public void HandleMessage (PeerId id, PeerMessage message, PeerMessage.Releaser releaser)
             => throw new NotSupportedException ();
 

--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/StoppingMode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/StoppingMode.cs
@@ -58,6 +58,11 @@ namespace MonoTorrent.Client.Modes
         public void Dispose ()
             => Cancellation.Dispose ();
 
+        public void HandleFilePriorityChanged (ITorrentManagerFile file, Priority oldPriority)
+        {
+            // Nothing
+        }
+
         public void HandleMessage (PeerId id, PeerMessage message, PeerMessage.Releaser releaser)
             => throw new NotSupportedException ();
 

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -95,6 +95,7 @@ namespace MonoTorrent.Client
 
             // If the old priority, or new priority, is 'DoNotDownload' then the selector needs to be refreshed
             bool needsToUpdateSelector = file.Priority == Priority.DoNotDownload || priority == Priority.DoNotDownload;
+            var oldPriority = file.Priority;
             ((TorrentFileInfo) file).Priority = priority;
 
             if (needsToUpdateSelector) {
@@ -109,6 +110,8 @@ namespace MonoTorrent.Client
                         PartialProgressSelector.SetTrue ((f.StartPieceIndex, f.EndPieceIndex));
                 }
             }
+
+            Mode.HandleFilePriorityChanged (file, oldPriority);
         }
 
         /// <summary>

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/DownloadModeTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/DownloadModeTests.cs
@@ -493,6 +493,21 @@ namespace MonoTorrent.Client.Modes
         }
 
         [Test]
+        public async Task SettingPriorityRefreshesAmInterestedStatus ()
+        {
+            Manager.OnPieceHashed (0, true);
+
+            var mode = new DownloadMode (Manager, DiskManager, ConnectionManager, Settings);
+            Manager.Mode = mode;
+
+            var peer = PeerId.CreateNull (Manager.Bitfield.Length, true, true, true, Manager.InfoHashes.V1OrV2);
+            Manager.Peers.ConnectedPeers.Add (peer);
+            foreach (var file in Manager.Files)
+                await Manager.SetFilePriorityAsync (file, Priority.DoNotDownload);
+            Assert.IsFalse (peer.AmInterested);
+        }
+
+        [Test]
         public async Task PartialProgress_UnrelatedDownloaded_AllDoNotDownload ()
         {
             Manager.OnPieceHashed (0, true);


### PR DESCRIPTION
There are several cases where the 'AmInterested' status can change for a given peer, and it's not easy to provide an event for each of these.

For example, the 'interested' status is dependent on each bitfield added as an 'IgnoringBitfield' to the piecepicker. These bitfields can change arbitrarily. This async check will ensure that things will refresh regularly.

As updating the priority of a file does have a pretty clear user action associated with it, special case this to cause an immediate refresh of the 'AmInterested' status.

Fixes https://github.com/alanmcgovern/monotorrent/issues/597