### PR TITLE
[core] Allow moving files at any point

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -784,9 +784,6 @@ namespace MonoTorrent.Client
         {
             await ClientEngine.MainLoop;
 
-            if (Mode is StoppingMode)
-                throw new TorrentException ("The manager cannot be stopped while it is already in the Stopping state.");
-
             if (State == TorrentState.Error) {
                 Error = null;
                 Mode = new StoppedMode ();

--- a/src/Tests/Tests.MonoTorrent.IntegrationTests/IntegrationTests.cs
+++ b/src/Tests/Tests.MonoTorrent.IntegrationTests/IntegrationTests.cs
@@ -239,8 +239,15 @@ namespace Tests.MonoTorrent.IntegrationTests
             if (!_httpSeeder.IsListening)
                 return;
 
-            HttpListenerContext ctx = _httpSeeder.EndGetContext (ar);
-            _httpSeeder.BeginGetContext (OnHttpContext, ar.AsyncState);
+            HttpListenerContext ctx;
+
+            try {
+                ctx = _httpSeeder.EndGetContext (ar);
+                _httpSeeder.BeginGetContext (OnHttpContext, ar.AsyncState);
+            } catch {
+                // Do nothing!
+                return;
+            }
 
             var localPath = ctx.Request.Url.LocalPath;
             string relativeSeedingPath = $"/{_webSeedPrefix}/{_torrentName}/";


### PR DESCRIPTION
The support to move files while the torrent is actively running was added as part of https://github.com/alanmcgovern/monotorrent/pull/445 .

Remove the code which prevents users from being able to do this.

Partially fixes: https://github.com/alanmcgovern/monotorrent/issues/598