### PR TITLE
[core] Fix several bugs with 'EngineSettings.UsePartialFiles'

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Client/ClientEngine.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/ClientEngine.cs
@@ -95,7 +95,11 @@ namespace MonoTorrent.Client
                         TorrentFileInfo torrentFile;
                         torrentFile = (TorrentFileInfo) manager.Files.Single (t => t.Path == ((BEncodedString) file[nameof (torrentFile.Path)]).Text);
                         torrentFile.Priority = (Priority) Enum.Parse (typeof (Priority), file[nameof (torrentFile.Priority)].ToString ()!);
-                        torrentFile.FullPath = ((BEncodedString) file[nameof (torrentFile.FullPath)]).Text;
+                        torrentFile.UpdatePaths ((
+                            newPath: ((BEncodedString) file[nameof (torrentFile.FullPath)]).Text,
+                            downloadCompletePath: ((BEncodedString) file[nameof (torrentFile.DownloadCompleteFullPath)]).Text,
+                            downloadIncompletePath: ((BEncodedString) file[nameof (torrentFile.DownloadIncompleteFullPath)]).Text
+                        ));
                     }
                 } else {
                     var magnetLink = MagnetLink.Parse (torrent[nameof (manager.MagnetLink)].ToString ()!);
@@ -127,6 +131,8 @@ namespace MonoTorrent.Client
                     dict[nameof (t.Files)] = new BEncodedList (t.Files.Select (file =>
                        new BEncodedDictionary {
                             { nameof(file.FullPath), (BEncodedString) file.FullPath },
+                            { nameof(file.DownloadCompleteFullPath), (BEncodedString) file.DownloadCompleteFullPath },
+                            { nameof(file.DownloadIncompleteFullPath), (BEncodedString) file.DownloadIncompleteFullPath },
                             { nameof(file.Path), (BEncodedString) file.Path },
                             { nameof(file.Priority), (BEncodedString) file.Priority.ToString () },
                        }

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentFileInfo.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentFileInfo.cs
@@ -29,6 +29,7 @@
 
 using System;
 using System.Linq;
+using System.Runtime;
 
 namespace MonoTorrent.Client
 {
@@ -36,11 +37,11 @@ namespace MonoTorrent.Client
     {
         public static string IncompleteFileSuffix => ".!mt";
 
-        public string DownloadCompleteFullPath { get; set; }
+        public string DownloadCompleteFullPath { get; private set; }
 
-        public string DownloadIncompleteFullPath { get; set; }
+        public string DownloadIncompleteFullPath { get; private set; }
 
-        public string FullPath { get; set; }
+        public string FullPath { get; private set; }
 
         ITorrentFile TorrentFile { get; }
 
@@ -108,6 +109,22 @@ namespace MonoTorrent.Client
             foreach (var illegal in System.IO.Path.GetInvalidFileNameChars ())
                 filename = filename.Replace ($"{illegal}", $"_{Convert.ToString (illegal, 16)}_");
             return System.IO.Path.Combine (dir, filename);
+        }
+
+        internal static (string path, string completePath, string incompletePath) GetNewPaths (string newPath, bool usePartialFiles, bool isComplete)
+        {
+            var downloadCompleteFullPath = newPath;
+            var downloadIncompleteFullPath = downloadCompleteFullPath + (usePartialFiles ? TorrentFileInfo.IncompleteFileSuffix : "");
+            newPath = isComplete ? downloadCompleteFullPath : downloadIncompleteFullPath;
+
+            return (newPath, downloadCompleteFullPath, downloadIncompleteFullPath);
+        }
+
+        internal void UpdatePaths ((string newPath, string downloadCompletePath, string downloadIncompletePath) paths)
+        {
+            FullPath = paths.newPath;
+            DownloadCompleteFullPath = paths.downloadCompletePath;
+            DownloadIncompleteFullPath = paths.downloadIncompletePath;
         }
     }
 }

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/DiskManagerExceptionTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/DiskManagerExceptionTests.cs
@@ -157,7 +157,7 @@ namespace MonoTorrent.Client
         public void MoveFileFail ()
         {
             writer.move = true;
-            Assert.ThrowsAsync<Exception> (() => diskManager.MoveFileAsync ((TorrentFileInfo) data.Files[0], "root"));
+            Assert.ThrowsAsync<Exception> (() => diskManager.MoveFileAsync ((TorrentFileInfo) data.Files[0], ("root", "bar", "baz")));
         }
 
         [Test]

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/DiskManagerTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/DiskManagerTests.cs
@@ -338,8 +338,10 @@ namespace MonoTorrent.Client
             var file = TorrentFileInfo.Create (Constants.BlockSize, 123456).Single ();
             Assert.IsFalse (File.Exists (file.FullPath));
 
-            await manager.MoveFileAsync (file, "NewPath");
+            await manager.MoveFileAsync (file, ("NewFullPath", "NewFullPath", "NewIncompletePath"));
             Assert.AreEqual (Path.GetFullPath ("NewPath"), file.FullPath);
+            Assert.AreEqual (Path.GetFullPath ("NewPath"), file.DownloadCompleteFullPath);
+            Assert.AreEqual (Path.GetFullPath ("NewPath"), file.DownloadIncompleteFullPath);
             Assert.IsFalse (File.Exists (file.FullPath));
         }
 
@@ -353,7 +355,7 @@ namespace MonoTorrent.Client
             using var writer = new TestPieceWriter ();
             using var manager = new DiskManager (new EngineSettings (), Factories.Default, writer);
 
-            await manager.MoveFileAsync (file, file.FullPath);
+            await manager.MoveFileAsync (file, (file.FullPath, file.FullPath, file.FullPath + TorrentFileInfo.IncompleteFileSuffix));
             Assert.IsTrue (File.Exists (file.FullPath));
         }
 
@@ -368,7 +370,7 @@ namespace MonoTorrent.Client
             using var manager = new DiskManager (new EngineSettings (), Factories.Default, writer);
 
             var fullPath = Path.Combine (tmp.Path, "New", "Path", "file.txt");
-            await manager.MoveFileAsync (file, fullPath);
+            await manager.MoveFileAsync (file, (fullPath, fullPath, fullPath + TorrentFileInfo.IncompleteFileSuffix));
             Assert.AreEqual (fullPath, file.FullPath);
         }
 

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/DiskManagerTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/DiskManagerTests.cs
@@ -338,10 +338,11 @@ namespace MonoTorrent.Client
             var file = TorrentFileInfo.Create (Constants.BlockSize, 123456).Single ();
             Assert.IsFalse (File.Exists (file.FullPath));
 
-            await manager.MoveFileAsync (file, ("NewFullPath", "NewFullPath", "NewIncompletePath"));
-            Assert.AreEqual (Path.GetFullPath ("NewPath"), file.FullPath);
-            Assert.AreEqual (Path.GetFullPath ("NewPath"), file.DownloadCompleteFullPath);
-            Assert.AreEqual (Path.GetFullPath ("NewPath"), file.DownloadIncompleteFullPath);
+            var newFullPath = Path.GetFullPath ("NewFullPath");
+            await manager.MoveFileAsync (file, (newFullPath, newFullPath, newFullPath));
+            Assert.AreEqual (newFullPath, file.FullPath);
+            Assert.AreEqual (newFullPath, file.DownloadCompleteFullPath);
+            Assert.AreEqual (newFullPath, file.DownloadIncompleteFullPath);
             Assert.IsFalse (File.Exists (file.FullPath));
         }
 


### PR DESCRIPTION
This adds several additional tests covering aspects of how this feature was intended to operate.

The 'Complete' and 'Incomplete' paths are now generated using a helper method. The choice of whether or not to use the 'Complete' or 'Incomplete' path as the current path is dependent on whether or not 'UsePartialFiles' is on, and if the file is already considered 'complete' or 'incomplete'.

This should keep everything in sync when toggling UsePartialFiles on and off, and also if the user uses 'MoveFileAsync', or 'MoveFilesASync' to move files.

The code docs should also be updated to clarify that if `UsePartialFiles` is enabled and someone moves an incomplete file to `some_directory/file.ext` then the engine will actually move the file to `some_directory/file.ext.!mt` as it is a *partial* file. Once the file is fully downloaded it will be placed at `some_directory/file.ext`. Similarly, if `UsePartialFiles` is disabled, all partial files will have `.!mt` removed from their filename.

Fixes https://github.com/alanmcgovern/monotorrent/issues/606