### PR TITLE
[core] Fix a BEP52 related regression

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent/TorrentCreator.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/TorrentCreator.cs
@@ -235,7 +235,7 @@ namespace MonoTorrent
             if (mappings.Count == 0)
                 throw new ArgumentException ("The file source must contain one or more files", nameof (fileSource));
 
-            mappings.Sort ((left, right) => left.Destination.CompareTo (right.Destination));
+            mappings.Sort ((left, right) => StringComparer.Ordinal.Compare (left.Destination, right.Destination));
             Validate (mappings);
 
             return await CreateAsync (fileSource.TorrentName, fileSource, token);
@@ -263,7 +263,7 @@ namespace MonoTorrent
             // Hybrid and V2 torrents *must* hash files in the same order as they end up being stored in the bencoded dictionary,
             // which means they must be alphabetical.
             if (Type.HasV2 ())
-                rawFiles = rawFiles.OrderBy (t => t.Destination).ToArray ();
+                rawFiles = rawFiles.OrderBy (t => t.Destination, StringComparer.Ordinal).ToArray ();
 
             // The last file never has padding bytes
             rawFiles[rawFiles.Length - 1].padding = 0;

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/TorrentCreatorBep47Tests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/TorrentCreatorBep47Tests.cs
@@ -74,6 +74,25 @@ namespace MonoTorrent.Common
         }
 
         [Test]
+        [TestCase(TorrentType.V1Only)]
+        [TestCase(TorrentType.V1OnlyWithPaddingFiles)]
+        [TestCase(TorrentType.V1V2Hybrid)]
+        [TestCase(TorrentType.V2Only)]
+        public async Task CreateHybridWithUnusualFilenames (TorrentType type)
+        {
+            var files = new Source {
+                TorrentName = "asd",
+                Files = new[] {
+                    new FileMapping("ASDkfsdjgsdSDFGsj.asd", "ASDkfsdjgsdSDFGsj.asd", (long)(PieceLength * 2.30)),
+                    new FileMapping("aSvzxkaSqp AZXDCaj asdASDjas ASDl.aaaaaa", "aSvzxkaSqp AZXDCaj asdASDjas ASDl.aaaaaa", (long)(PieceLength * 36.5)),
+                    new FileMapping("[aaaaa aaaaaaaaa]aaaaaa a aaaaaaaa.aaaaa", "[aaaaa aaaaaaaaa]aaaaaa a aaaaaaaa.aaaaa", (long)(PieceLength * 3.17)),
+                }
+            };
+            var torrent = await CreateTestBenc (type, files);
+            Assert.DoesNotThrow (() => Torrent.Load (torrent));
+        }
+
+        [Test]
         public async Task FileLengthSameAsPieceLength ([Values (TorrentType.V1Only, TorrentType.V1V2Hybrid)] TorrentType type)
         {
             var files = new Source {


### PR DESCRIPTION
When sorting files for BEP52 compatibility, use an ordinal comparison rather than the default culture aware comparison.

BitTorrent relies on ordinal comparisons when sorting keys inside BEncodedDictionaries, and that is the order which must be respected here.

Fixes a regression from https://github.com/alanmcgovern/monotorrent/commit/3d3937dbdfe44a81923db9d04c25c9c6a1ee0296

Fixes https://github.com/alanmcgovern/monotorrent/issues/610