### PR TITLE
[bep52|bep47] Fix file ordering sanity check and padding for empty files

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent/Torrent.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/Torrent.cs
@@ -629,7 +629,7 @@ namespace MonoTorrent
 
                         var merkleTrees = dict.ToDictionary (
                             key => MerkleRoot.FromMemory (key.Key.AsMemory ()),
-                            kvp => ReadOnlyMerkleLayers.FromLayer (PieceLength, MerkleRoot.FromMemory (kvp.Key.AsMemory ()), ((BEncodedString)kvp.Value).Span) ?? throw new TorrentException ($"Invalid merkle tree. A layer not produce the expected root hash.")
+                            kvp => ReadOnlyMerkleLayers.FromLayer (PieceLength, MerkleRoot.FromMemory (kvp.Key.AsMemory ()), ((BEncodedString) kvp.Value).Span) ?? throw new TorrentException ($"Invalid merkle tree. A layer not produce the expected root hash.")
                         );
 
                         hashesV2 = LoadHashesV2 (Files, merkleTrees, PieceLength);
@@ -778,7 +778,7 @@ namespace MonoTorrent
             if (key == "") {
                 var length = ((BEncodedNumber) data["length"]).Number;
                 if (length == 0) {
-                    files.Add (new TorrentFile (path, length, 0, 0, 0, TorrentFileAttributes.None, 0));
+                    files.Insert (0, new TorrentFile (path, length, 0, 0, 0, TorrentFileAttributes.None, 0));
                 } else {
                     totalPieces++;
                     var offsetInTorrent = (files.LastOrDefault ()?.OffsetInTorrent ?? 0) + (files.LastOrDefault ()?.Length ?? 0) + (files.LastOrDefault ()?.Padding ?? 0);

--- a/src/MonoTorrent.Client/MonoTorrent/TorrentCreator.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/TorrentCreator.cs
@@ -265,8 +265,10 @@ namespace MonoTorrent
             if (Type.HasV2 ())
                 rawFiles = rawFiles.OrderBy (t => t.Destination, StringComparer.Ordinal).ToArray ();
 
-            // The last file never has padding bytes
-            rawFiles[rawFiles.Length - 1].padding = 0;
+            // The last non-empty file never has padding bytes
+            var last = rawFiles.Where (t => t.length != 0).Last ();
+            var index = Array.IndexOf (rawFiles, last);
+            rawFiles[index].padding = 0;
 
             var files = TorrentFileInfo.Create (PieceLength, rawFiles);
             var manager = new TorrentManagerInfo (files,

--- a/src/MonoTorrent.Client/MonoTorrent/TorrentFile.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/TorrentFile.cs
@@ -156,6 +156,8 @@ namespace MonoTorrent
                         // Do not try to handle this, it would be very messy.
                         throw new ArgumentException ("Can not handle torrent that starts with padding");
                     } else {
+                        if (files[real].length == 0)
+                            throw new InvalidOperationException ("Attempted to add padding bytes to a file which should not have padding.");
                         // add the count to it will also work in case of consecutive padding files, also slightly edge-case-y
                         files[real].padding += files[t].length;
                     }


### PR DESCRIPTION
When torrents contain multiple sequential empty files, ensure padding data is applied to the closest non-empty file, rather than simply the closest file.