### PR TITLE
[ipv6] Use the correct prefix for IPv6 non-compact peers

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Client/Peers/PeerDecoder.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Peers/PeerDecoder.cs
@@ -29,6 +29,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Net.Sockets;
 
 using MonoTorrent.BEncoding;
@@ -71,7 +72,9 @@ namespace MonoTorrent
             else
                 peerId = BEncodedString.Empty;
 
-            var connectionUri = new Uri ($"ipv4://{dict[IPKey]}:{dict[PortKey]}");
+            var ipAddress = IPAddress.Parse (((BEncodedString)dict[IPKey]).Text);
+            int port = (int)((BEncodedNumber) dict[PortKey]).Number;
+            var connectionUri = new Uri ($"{(ipAddress.AddressFamily == AddressFamily.InterNetwork ? "ipv4" : "ipv6")}://{new IPEndPoint (ipAddress, port)}");
             return new PeerInfo (connectionUri, peerId);
         }
     }


### PR DESCRIPTION
When decoding a tracker response which contains non-compact data, ensure IPv6 peers are parsed with the 'ipv6' prefix.

Additionally, this data is now validated to ensure it's a valid IP address and port.