### PR TITLE
[core] Ratelimiters should allow requests larger than chunk size

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Client.RateLimiters/RateLimiter.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.RateLimiters/RateLimiter.cs
@@ -79,7 +79,7 @@ namespace MonoTorrent.Client.RateLimiters
             long c;
             do {
                 c = Interlocked.Read (ref chunks);
-                if (c < amount)
+                if (c < 0)
                     return false;
 
             } while (Interlocked.CompareExchange (ref chunks, c - amount, c) != c);

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.RateLimiters/RateLimiterTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.RateLimiters/RateLimiterTests.cs
@@ -1,0 +1,64 @@
+﻿//
+// RateLimiterTests.cs
+//
+// Authors:
+//   Alan McGovern alan.mcgovern@gmail.com
+//
+// Copyright (C) 2019 Alan McGovern
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+
+using MonoTorrent.BEncoding;
+using MonoTorrent.Connections;
+using MonoTorrent.Messages;
+using MonoTorrent.Messages.Peer;
+using MonoTorrent.Messages.Peer.Libtorrent;
+using MonoTorrent.Trackers;
+
+using NUnit.Framework;
+
+namespace MonoTorrent.Client.RateLimiters
+{
+    [TestFixture]
+    public class RateLimiterTests
+    {
+        [Test]
+        public void ChunkSizeLargerThanRateLimit ()
+        {
+            var rateLimiter = new RateLimiter ();
+            rateLimiter.UpdateChunks (10, 10, 10);
+
+            // We can process any size chunk as long as there's some rate limit left
+            Assert.IsTrue (rateLimiter.TryProcess (11));
+
+            // Once the entire rate limit has been consumed, no chunks can be processed
+            Assert.IsFalse (rateLimiter.TryProcess (1));
+
+        }
+    }
+}

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.RateLimiters/RateLimiterTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.RateLimiters/RateLimiterTests.cs
@@ -4,7 +4,7 @@
 // Authors:
 //   Alan McGovern alan.mcgovern@gmail.com
 //
-// Copyright (C) 2019 Alan McGovern
+// Copyright (C) 2023 Alan McGovern
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the


### PR DESCRIPTION
If the ratelimiter is set to download at 15kB/sec or less, the amount of data in the ratelimit will always be less than the size of one block. In this case, we should allow the request to succeed.

Once there's negative data left in the allowance, deny requests. As the ratelimiter is topped up over time, future requests will be unblocked.