### PR TITLE
[core] Tweak ratelimiting a little better for low rates

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Client.RateLimiters/IRateLimiter.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.RateLimiters/IRateLimiter.cs
@@ -32,13 +32,6 @@ namespace MonoTorrent.Client.RateLimiters
     interface IRateLimiter
     {
         /// <summary>
-        /// When this returns <see langword="null"/> there is no preference on
-        /// how large each chunk of work should be. Otherwise, work should be processed
-        /// in chunks of this size.
-        /// </summary>
-        int? PreferredChunkSize { get; }
-
-        /// <summary>
         /// Returns true if there is sufficient capacity left in the rate limiter to
         /// process the specified amount of data. Also returns true if
         /// <see cref="Unlimited"/> returns true.

--- a/src/MonoTorrent.Client/MonoTorrent.Client.RateLimiters/RateLimiter.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.RateLimiters/RateLimiter.cs
@@ -34,7 +34,6 @@ namespace MonoTorrent.Client.RateLimiters
 {
     sealed class RateLimiter : IRateLimiter
     {
-        long savedError;
         long chunks;
 
         public bool Unlimited { get; set; }

--- a/src/MonoTorrent.Client/MonoTorrent.Client.RateLimiters/RateLimiterGroup.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.RateLimiters/RateLimiterGroup.cs
@@ -37,16 +37,6 @@ namespace MonoTorrent.Client.RateLimiters
     {
         readonly List<IRateLimiter> limiters;
 
-        public int? PreferredChunkSize {
-            get {
-                int? preferredChunkSize = null;
-                for (int i = 0; i < limiters.Count; i++)
-                    if (limiters[i].PreferredChunkSize.HasValue)
-                        preferredChunkSize = preferredChunkSize.HasValue ? Math.Min (limiters[i].PreferredChunkSize!.Value, preferredChunkSize.Value) : limiters[i].PreferredChunkSize!.Value;
-                return preferredChunkSize;
-            }
-        }
-
         public bool Unlimited {
             get {
                 for (int i = 0; i < limiters.Count; i++)

--- a/src/MonoTorrent.Client/MonoTorrent.Client/ClientEngine.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/ClientEngine.cs
@@ -773,37 +773,13 @@ namespace MonoTorrent.Client
 
         #region Private/Internal methods
 
-
-        internal static int? PreferredChunkSize (int maxSpeedEngine, int maxSpeedTorrent)
-        {
-            // Unlimited
-            if (maxSpeedEngine == 0 && maxSpeedTorrent == 0)
-                return null;
-
-            int maxSpeed;
-            if (maxSpeedEngine != 0 && maxSpeedTorrent != 0)
-                maxSpeed = Math.Min (maxSpeedEngine, maxSpeedTorrent);
-            else
-                maxSpeed = Math.Max (maxSpeedEngine, maxSpeedTorrent);
-
-            // The max we transmit for a single socket call is 16kB as that is the size of a
-            // single block. If the transfer rate is unlimited, or we can transfer greater
-            // than 256kB/sec then continue using 'unlimited' sized chunks. Otherwise restrict
-            // individual calls to 4kB to try and keep things reasonably evenly distributed.
-            if (maxSpeed == 0 || maxSpeed > 16 * 16 * 1024)
-                return null;
-
-            // If the limit is below 256 kB/sec then we can communicate in 4kB chunks
-            return 4096 + 32;
-        }
-
         void LogicTick ()
         {
             tickCount++;
 
             if (tickCount % 2 == 0) {
-                downloadLimiter.UpdateChunks (Settings.MaximumDownloadRate, TotalDownloadRate, PreferredChunkSize (Settings.MaximumDownloadRate, 0));
-                uploadLimiter.UpdateChunks (Settings.MaximumUploadRate, TotalUploadRate, PreferredChunkSize (Settings.MaximumUploadRate, 0));
+                downloadLimiter.UpdateChunks (Settings.MaximumDownloadRate);
+                uploadLimiter.UpdateChunks (Settings.MaximumUploadRate);
             }
 
             ConnectionManager.CancelPendingConnects ();

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/DiskManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/DiskManager.cs
@@ -661,8 +661,8 @@ namespace MonoTorrent.Client
             WriterReadMonitor.Tick (delta);
             WriterWriteMonitor.Tick (delta);
 
-            WriteLimiter.UpdateChunks (Settings.MaximumDiskWriteRate, WriteRate, null);
-            ReadLimiter.UpdateChunks (Settings.MaximumDiskReadRate, ReadRate, null);
+            WriteLimiter.UpdateChunks (Settings.MaximumDiskWriteRate);
+            ReadLimiter.UpdateChunks (Settings.MaximumDiskReadRate);
 
             ReusableTask processTask = ProcessBufferedIOAsync ();
             return waitForBufferedIO ? processTask : ReusableTask.CompletedTask;

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -1034,8 +1034,8 @@ namespace MonoTorrent.Client
         internal void UpdateLimiters ()
         {
             if (Engine != null) {
-                DownloadLimiter.UpdateChunks (Settings.MaximumDownloadRate, Monitor.DownloadRate, ClientEngine.PreferredChunkSize (Engine.Settings.MaximumDownloadRate, Settings.MaximumDownloadRate));
-                UploadLimiter.UpdateChunks (Settings.MaximumUploadRate, Monitor.UploadRate, ClientEngine.PreferredChunkSize (Engine.Settings.MaximumUploadRate, Settings.MaximumUploadRate));
+                DownloadLimiter.UpdateChunks (Settings.MaximumDownloadRate);
+                UploadLimiter.UpdateChunks (Settings.MaximumUploadRate);
             }
         }
         #endregion Internal Methods

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -602,7 +602,7 @@ namespace MonoTorrent.Client
                 throw new TorrentException ("Cannot move files when the torrent is active");
 
             try {
-                var paths = TorrentFileInfo.GetNewPaths (Path.GetFullPath (path), Engine.Settings.UsePartialFiles, file.Path == file.DownloadCompleteFullPath);
+                var paths = TorrentFileInfo.GetNewPaths (Path.GetFullPath (path), Engine!.Settings.UsePartialFiles, file.Path == file.DownloadCompleteFullPath);
                 await Engine!.DiskManager.MoveFileAsync (file, paths);
             } catch (Exception ex) {
                 TrySetError (Reason.WriteFailure, ex);

--- a/src/MonoTorrent.Client/MonoTorrent.Client/NetworkIO.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/NetworkIO.cs
@@ -129,15 +129,14 @@ namespace MonoTorrent.Client
             while (buffer.Length > 0) {
                 int transferred;
                 bool unlimited = rateLimiter?.Unlimited ?? true;
-                int shouldRead = unlimited || !rateLimiter!.PreferredChunkSize.HasValue ? buffer.Length : Math.Min (rateLimiter.PreferredChunkSize.Value, buffer.Length);
 
-                if (rateLimiter != null && !unlimited && !rateLimiter.TryProcess (shouldRead)) {
+                if (rateLimiter != null && !unlimited && !rateLimiter.TryProcess (buffer.Length)) {
                     var tcs = new ReusableTaskCompletionSource<int> ();
                     lock (receiveQueue)
                         receiveQueue.Enqueue (new QueuedIO (connection, buffer, rateLimiter, tcs));
                     transferred = await tcs.Task.ConfigureAwait (false);
                 } else {
-                    transferred = await connection.ReceiveAsync (buffer.Slice (0, shouldRead)).ConfigureAwait (false);
+                    transferred = await connection.ReceiveAsync (buffer).ConfigureAwait (false);
                 }
 
                 if (transferred == 0)
@@ -162,15 +161,14 @@ namespace MonoTorrent.Client
             while (buffer.Length > 0) {
                 int transferred;
                 bool unlimited = rateLimiter?.Unlimited ?? true;
-                int shouldRead = unlimited || !rateLimiter!.PreferredChunkSize.HasValue ? buffer.Length : Math.Min (rateLimiter.PreferredChunkSize.Value, buffer.Length);
 
-                if (rateLimiter != null && !unlimited && !rateLimiter.TryProcess (shouldRead)) {
+                if (rateLimiter != null && !unlimited && !rateLimiter.TryProcess (buffer.Length)) {
                     var tcs = new ReusableTaskCompletionSource<int> ();
                     lock (sendQueue)
-                        sendQueue.Enqueue (new QueuedIO (connection, buffer.Slice (0, shouldRead), rateLimiter, tcs));
+                        sendQueue.Enqueue (new QueuedIO (connection, buffer, rateLimiter, tcs));
                     transferred = await tcs.Task.ConfigureAwait (false);
                 } else {
-                    transferred = await connection.SendAsync (buffer.Slice (0, shouldRead)).ConfigureAwait (false);
+                    transferred = await connection.SendAsync (buffer).ConfigureAwait (false);
                 }
 
                 if (transferred == 0)

--- a/src/MonoTorrent.Client/MonoTorrent.TrackerServer/SimpleTorrentManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.TrackerServer/SimpleTorrentManager.cs
@@ -146,6 +146,7 @@ namespace MonoTorrent.TrackerServer
         /// <param name="response">The bencoded dictionary to add the peers to</param>
         /// <param name="count">The number of peers to add</param>
         /// <param name="compact">True if the peers should be in compact form</param>
+        /// <param name="addressFamily"></param>
         internal void GetPeers (BEncodedDictionary response, int count, bool compact, AddressFamily addressFamily)
         {
             byte[]? compactResponse = null;

--- a/src/MonoTorrent.Client/MonoTorrent.TrackerServer/TrackerServer.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.TrackerServer/TrackerServer.cs
@@ -191,8 +191,7 @@ namespace MonoTorrent.TrackerServer
         /// <summary>
         /// Adds the trackable to the server
         /// </summary>
-        /// <param name="trackable">The trackable to add</param>
-        /// <param name="comparer">The comparer used to decide whether two peers are the same.</param>
+        /// <param name="manager">.</param>
         /// <returns></returns>
         internal bool Add (SimpleTorrentManager manager)
         {

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.RateLimiters/RateLimiterTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.RateLimiters/RateLimiterTests.cs
@@ -51,7 +51,7 @@ namespace MonoTorrent.Client.RateLimiters
         public void ChunkSizeLargerThanRateLimit ()
         {
             var rateLimiter = new RateLimiter ();
-            rateLimiter.UpdateChunks (10, 10, 10);
+            rateLimiter.UpdateChunks (10);
 
             // We can process any size chunk as long as there's some rate limit left
             Assert.IsTrue (rateLimiter.TryProcess (11));

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/NetworkIOTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/NetworkIOTests.cs
@@ -126,24 +126,6 @@ namespace MonoTorrent.Client
         }
 
         [Test]
-        public async Task ReceiveData_RateLimited ()
-        {
-            // Allow 1 megabyte worth of data
-            var oneMegabyte = 1 * 1024 * 1024;
-            var limiter = new RateLimiter ();
-            limiter.UpdateChunks (oneMegabyte, oneMegabyte, NetworkIO.ChunkLength);
-
-            using var r1 = MemoryPool.Default.Rent (oneMegabyte, out Memory<byte> sendBuffer);
-            using var r2 = MemoryPool.Default.Rent (oneMegabyte, out Memory<byte> receiveBuffer);
-
-            await Outgoing.SendAsync (sendBuffer);
-            await NetworkIO.ReceiveAsync (Incoming, receiveBuffer, limiter, null, null);
-
-            var expectedChunks = (int) Math.Ceiling (oneMegabyte / (double) NetworkIO.ChunkLength);
-            Assert.AreEqual (expectedChunks, Incoming.Receives.Count, "#1");
-        }
-
-        [Test]
         public async Task ReceiveData_Unlimited ()
         {
             var oneMegabyte = 1 * 1024 * 1024;
@@ -229,21 +211,6 @@ namespace MonoTorrent.Client
         public async Task SendData ()
         {
             await DoSend (false, false);
-        }
-
-        [Test]
-        public async Task SendData_RateLimited ()
-        {
-            // Allow 1 megabyte worth of data
-            var oneMegabyte = 1 * 1024 * 1024;
-            var limiter = new RateLimiter ();
-            limiter.UpdateChunks (oneMegabyte, oneMegabyte, NetworkIO.ChunkLength);
-
-            using var releaser = MemoryPool.Default.Rent (oneMegabyte, out Memory<byte> buffer);
-            await NetworkIO.SendAsync (Incoming, buffer, limiter, null, null);
-
-            var expectedChunks = (int) Math.Ceiling (oneMegabyte / (double) NetworkIO.ChunkLength);
-            Assert.AreEqual (expectedChunks, Incoming.Sends.Count, "#1");
         }
 
         [Test]


### PR DESCRIPTION
Fix another issue with a ratelimit of 1 byte/second. Hopefully no-one was actually trying to use a limit this low.

Additionally, simplify this logic now. Rate limits are much easier than they used to be as the engine works in bytes, not 'blocks' or 'chunks'.

Back in the day there had to be estimates made for the amount of data which would be received for a given 'ReceiveAsync' call. Now we're just counting the raw number of bytes sent/received, or read/written, so we don't need complicated math to account for over/under-shoot.