### PR TITLE
[core] Try harder to send a valid port to the tracker

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Client.Listeners/NullPeerListener.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Listeners/NullPeerListener.cs
@@ -42,6 +42,7 @@ namespace MonoTorrent.Client.Listeners
         public event EventHandler<EventArgs>? StatusChanged;
 #pragma warning restore 0067
 
+        public IPEndPoint PreferredLocalEndPoint { get; } = new IPEndPoint (IPAddress.None, 0);
         public IPEndPoint? LocalEndPoint => null;
 
         public ListenerStatus Status => ListenerStatus.NotListening;

--- a/src/MonoTorrent.Connections/MonoTorrent.Connections.Peer/LocalPeerDiscovery.cs
+++ b/src/MonoTorrent.Connections/MonoTorrent.Connections.Peer/LocalPeerDiscovery.cs
@@ -190,7 +190,7 @@ namespace MonoTorrent.Connections.Peer
         {
             base.Start (token);
 
-            var UdpClient = new UdpClient (OriginalEndPoint);
+            var UdpClient = new UdpClient (PreferredLocalEndPoint);
             LocalEndPoint = (IPEndPoint?) UdpClient.Client.LocalEndPoint;
 
             token.Register (() => UdpClient.Dispose ());

--- a/src/MonoTorrent.Connections/MonoTorrent.Connections.Peer/PeerConnectionListener.cs
+++ b/src/MonoTorrent.Connections/MonoTorrent.Connections.Peer/PeerConnectionListener.cs
@@ -50,14 +50,14 @@ namespace MonoTorrent.Connections.Peer
         {
             base.Start (token);
 
-            var listener = new Socket (OriginalEndPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+            var listener = new Socket (PreferredLocalEndPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
             var connectArgs = new SocketAsyncEventArgs ();
             token.Register (() => {
                 listener.Close ();
                 connectArgs.Dispose ();
             });
 
-            listener.Bind (OriginalEndPoint);
+            listener.Bind (PreferredLocalEndPoint);
             LocalEndPoint = (IPEndPoint?) listener.LocalEndPoint;
 
             listener.Listen (6);

--- a/src/MonoTorrent.Connections/MonoTorrent.Connections/SocketListener.cs
+++ b/src/MonoTorrent.Connections/MonoTorrent.Connections/SocketListener.cs
@@ -36,11 +36,11 @@ namespace MonoTorrent.Connections
     {
         public IPEndPoint? LocalEndPoint { get; protected set; }
 
-        protected IPEndPoint OriginalEndPoint { get; set; }
+        public IPEndPoint PreferredLocalEndPoint { get; set; }
 
         protected SocketListener (IPEndPoint endPoint)
         {
-            OriginalEndPoint = endPoint;
+            PreferredLocalEndPoint = endPoint;
         }
 
         protected override void Start (CancellationToken token)

--- a/src/MonoTorrent.Connections/MonoTorrent.Connections/UdpListener.cs
+++ b/src/MonoTorrent.Connections/MonoTorrent.Connections/UdpListener.cs
@@ -59,7 +59,7 @@ namespace MonoTorrent.Connections
         {
             base.Start (token);
 
-            UdpClient client = Client = new UdpClient (OriginalEndPoint);
+            UdpClient client = Client = new UdpClient (PreferredLocalEndPoint);
             LocalEndPoint = (IPEndPoint?) client.Client.LocalEndPoint;
             token.Register (() => {
                 client.Dispose ();

--- a/src/MonoTorrent/MonoTorrent.Connections.Peer/IPeerConnectionListener.cs
+++ b/src/MonoTorrent/MonoTorrent.Connections.Peer/IPeerConnectionListener.cs
@@ -34,7 +34,17 @@ namespace MonoTorrent.Connections.Peer
 {
     public interface IPeerConnectionListener : IListener
     {
+        /// <summary>
+        /// The EndPoint to which the Listener is bound.
+        /// </summary>
         IPEndPoint? LocalEndPoint { get; }
+
+        /// <summary>
+        /// The EndPoint to which the Listener will attempt to be bound. If the preferred endpoint has it's port set to 0, then
+        /// the actual port the listener is bound to will be set in the <see cref="LocalEndPoint"/> property after <see cref="IListener.Start"/>
+        /// has been invoked.
+        /// </summary>
+        IPEndPoint PreferredLocalEndPoint { get; }
 
         event EventHandler<PeerConnectionEventArgs> ConnectionReceived;
     }

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/TestRig.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/TestRig.cs
@@ -249,6 +249,7 @@ namespace MonoTorrent.Client
         public event EventHandler<EventArgs> StatusChanged;
 
         public IPEndPoint LocalEndPoint => null;
+        public IPEndPoint PreferredLocalEndPoint { get; } = new IPEndPoint (IPAddress.None, 0);
 
         public ListenerStatus Status { get; private set; }
 


### PR DESCRIPTION
The main part of this change is that the actual IPEndPoint which the listnener has been bound to is not the sole source of the 'port' value which should be sent to the tracker.

If the listener has been configured to bind to a specific port, but has (at the point in time when the announce is sent) not successfully bound to that port, the preferred port should be sent to the tracker.

If the user has configured the listener to port '0' *and* the listener isn't running, then we have a problem as 'port' is a required parameter and must be sent. In this scenario, send an invalid port and the tracker should still return a list of peers to connect to.

Fixes 1/2 of https://github.com/alanmcgovern/monotorrent/issues/613