### PR TITLE
Web seed request order

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Connections/HttpPeerConnection.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Connections/HttpPeerConnection.cs
@@ -357,9 +357,9 @@ namespace MonoTorrent.Connections.Peer
                     break;
 
                 // We want data from a later file
-                if (startOffset >= file.Length) {
-                    startOffset -= file.Length;
-                    endOffset -= file.Length;
+                if (startOffset >= file.Length + file.Padding) {
+                    startOffset -= file.Length + file.Padding;
+                    endOffset -= file.Length + file.Padding;
                 }
                 // We want data from the end of the current file and from the next few files
                 else if (endOffset >= file.Length) {

--- a/src/Tests/Tests.MonoTorrent.IntegrationTests/IntegrationTests.cs
+++ b/src/Tests/Tests.MonoTorrent.IntegrationTests/IntegrationTests.cs
@@ -152,6 +152,9 @@ namespace Tests.MonoTorrent.IntegrationTests
         public async Task WebSeedDownload_V1V2_BiggerFile () => await CreateAndDownloadTorrent (TorrentType.V1V2Hybrid, createEmptyFile: true, explitlyHashCheck: false, useWebSeedDownload: true, fileSize: 131_073);
 
         [Test]
+        public async Task WebSeedDownload_Padding () => await CreateAndDownloadTorrent (TorrentType.V1V2Hybrid, createEmptyFile: true, explitlyHashCheck: false, nonEmptyFileCount: 10, useWebSeedDownload: true, fileSize: 100_000);
+
+        [Test]
         public async Task WebSeedDownload_V1V2_RetryWebSeeder ()
         {
             _failHttpRequest = true;


### PR DESCRIPTION
Closes #638 

- Adds test for webseed with padding between files
- Takes padding into account when building http requests from blocks
- Fixes issue where `List<BlockInfo> bundle` is non-sequential and non-adjacent, leading to requests with negative byte ranges, negative `endIndex`, and extra requests for ranges that are already downloaded
  - I couldn't isolate this into a reproducible test that I could share, but by pre-populating some of the destination files, this would happen more often than not