### PR TITLE
Fixing "Contribute" links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ This project exists thanks to all the people who contribute. [[Contribute](CONTR
 
 ### Financial Contributors
 
-Become a financial contributor and help us sustain our community. [[Contribute](https://opencollective.com/monotorrent/contribute)]
+Become a financial contributor and help us sustain our community. [[Contribute](https://opencollective.com/monotorrent#category-CONTRIBUTE)]
 
 #### Individuals
 
@@ -108,7 +108,7 @@ Become a financial contributor and help us sustain our community. [[Contribute](
 
 #### Organizations
 
-Support this project with your organization. Your logo will show up here with a link to your website. [[Contribute](https://opencollective.com/monotorrent/contribute)]
+Support this project with your organization. Your logo will show up here with a link to your website. [[Contribute](https://opencollective.com/monotorrent#category-CONTRIBUTE)]
 
 <a href="https://opencollective.com/monotorrent/organization/0/website"><img src="https://opencollective.com/monotorrent/organization/0/avatar.svg"></a>
 <a href="https://opencollective.com/monotorrent/organization/1/website"><img src="https://opencollective.com/monotorrent/organization/1/avatar.svg"></a>


### PR DESCRIPTION
The old link sometimes shows "An Internal error occurred" error, maybe there's a problem with Open Collective redirections?
Very small change.