### PR TITLE
Temporary local peer IDs and connection gating

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Client/ClientEngine.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/ClientEngine.cs
@@ -301,7 +301,7 @@ namespace MonoTorrent.Client
             DiskManager = new DiskManager (Settings, Factories);
 
             ConnectionManager = new ConnectionManager (PeerId, Settings, Factories, DiskManager);
-            listenManager = new ListenManager (this);
+            listenManager = new ListenManager (this, Factories.CreatePeerConnectionGate());
             PortForwarder = Factories.CreatePortForwarder ();
 
             MainLoop.QueueTimeout (TimeSpan.FromMilliseconds (TickLength), delegate {

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/ConnectionManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/ConnectionManager.cs
@@ -195,7 +195,7 @@ namespace MonoTorrent.Client
                 return;
             }
 
-            BEncodedString connectAs = await Factories.CreateTemporaryLocalPeerIdAsync (LocalPeerId, id.ExpectedInfoHash, id.Uri);
+            BEncodedString connectAs = await Factories.CreateTemporaryLocalPeerIdAsync (LocalPeerId, id.PeerID, id.ExpectedInfoHash, id.Uri);
             if (connectAs is null || connectAs.Span.Length != 20) {
                 logger.Exception (
                     new ArgumentException ("Peer ID must be exactly 20 bytes long", paramName: "temporaryLocalPeerId"),

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/ConnectionManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/ConnectionManager.cs
@@ -254,7 +254,7 @@ namespace MonoTorrent.Client
                 logger.InfoFormatted (id.Connection, "[outgoing] Received handshake message with peer id '{0}'", handshake.PeerId);
                 manager.Mode.HandleMessage (id, handshake, default);
 
-                if (!await ConnectionGate.TryAcceptHandshakeAsync (LocalPeerId, id.Peer.Info, id.Connection, id.ExpectedInfoHash)) {
+                if (!await ConnectionGate.TryAcceptHandshakeAsync (LocalPeerId, id.Peer.Info, id.Connection, manager.InfoHashes.V1OrV2)) {
                     logger.InfoFormatted (id.Connection, "[outgoing] Handshake with peer_id '{0}' rejected by the connection gate", id.PeerID);
                     throw new TorrentException("Handshake rejected by the connection gate");
                 }

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/ConnectionManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/ConnectionManager.cs
@@ -199,7 +199,7 @@ namespace MonoTorrent.Client
                 return;
             }
 
-            BEncodedString connectAs = await Factories.CreateTemporaryLocalPeerIdAsync (LocalPeerId, id.PeerID, id.ExpectedInfoHash, id.Uri);
+            BEncodedString connectAs = await Factories.CreateTemporaryLocalPeerIdAsync (manager, LocalPeerId, id.PeerID, id.ExpectedInfoHash, id.Uri);
             if (connectAs is null || connectAs.Span.Length != 20) {
                 logger.Exception (
                     new ArgumentException ("Peer ID must be exactly 20 bytes long", paramName: "temporaryLocalPeerId"),

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/ListenManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/ListenManager.cs
@@ -146,7 +146,7 @@ namespace MonoTorrent.Client
                 return false;
 
             peerInfo = peerInfo.WithPeerId (message.PeerId);
-            if (!await ConnectionGate.TryAcceptHandshakeAsync (Engine.PeerId, peerInfo, connection, message.InfoHash)) {
+            if (!await ConnectionGate.TryAcceptHandshakeAsync (Engine.PeerId, peerInfo, connection, man.InfoHashes.V1OrV2)) {
                 logger.InfoFormatted (connection, "[incoming] Handshake with peer_id '{0}' rejected by the connection gate", message.PeerId);
                 return false;
             }

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/ListenManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/ListenManager.cs
@@ -13,10 +13,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -31,7 +31,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-using MonoTorrent.Client.Listeners;
 using MonoTorrent.Connections;
 using MonoTorrent.Connections.Peer;
 using MonoTorrent.Connections.Peer.Encryption;
@@ -50,11 +49,14 @@ namespace MonoTorrent.Client
 
         IList<IPeerConnectionListener> Listeners { get; set; }
 
+        IPeerConnectionGate ConnectionGate { get; set; }
+
         InfoHash[] SKeys { get; set; }
 
-        internal ListenManager (ClientEngine engine)
+        internal ListenManager (ClientEngine engine, IPeerConnectionGate connectionGate)
         {
             Engine = engine ?? throw new ArgumentNullException (nameof (engine));
+            ConnectionGate = connectionGate ?? throw new ArgumentNullException (nameof (connectionGate));
             Listeners = Array.Empty<IPeerConnectionListener> ();
             SKeys = Array.Empty<InfoHash> ();
         }
@@ -142,6 +144,12 @@ namespace MonoTorrent.Client
 
             if (!man.Mode.CanAcceptConnections)
                 return false;
+
+            peerInfo = peerInfo.WithPeerId (message.PeerId);
+            if (!await ConnectionGate.TryAcceptHandshakeAsync (Engine.PeerId, peerInfo, connection, message.InfoHash)) {
+                logger.InfoFormatted (connection, "[incoming] Handshake with peer_id '{0}' rejected by the connection gate", message.PeerId);
+                return false;
+            }
 
             var peer = new Peer (peerInfo, man.InfoHashes.Expand (message.InfoHash));
             peer.UpdatePeerId (message.PeerId);

--- a/src/MonoTorrent.Connections/MonoTorrent.Connections.Peer/NoGating.cs
+++ b/src/MonoTorrent.Connections/MonoTorrent.Connections.Peer/NoGating.cs
@@ -1,0 +1,14 @@
+﻿using MonoTorrent.BEncoding;
+
+using ReusableTasks;
+
+namespace MonoTorrent.Connections.Peer
+{
+    public sealed class NoGating : IPeerConnectionGate
+    {
+        public ReusableTask<bool> TryAcceptHandshakeAsync (BEncodedString localPeerId, PeerInfo remotePeer, IPeerConnection connection, InfoHash infoHash)
+        {
+            return ReusableTask.FromResult (true);
+        }
+    }
+}

--- a/src/MonoTorrent.Factories/MonoTorrent/Factories.cs
+++ b/src/MonoTorrent.Factories/MonoTorrent/Factories.cs
@@ -57,7 +57,7 @@ namespace MonoTorrent
         public delegate IDhtEngine DhtCreator ();
         public delegate IDhtListener DhtListenerCreator (IPEndPoint endpoint);
         public delegate HttpClient HttpClientCreator (AddressFamily family);
-        public delegate ReusableTask<BEncodedString> TemporaryLocalPeerIdGenerator (BEncodedString permanentLocalPeerId, InfoHash infoHash, Uri peerUri);
+        public delegate ReusableTask<BEncodedString> TemporaryLocalPeerIdGenerator (BEncodedString permanentLocalPeerId, BEncodedString peerId, InfoHash infoHash, Uri peerUri);
         public delegate ILocalPeerDiscovery LocalPeerDiscoveryCreator ();
         public delegate IPeerConnection PeerConnectionCreator (Uri uri);
         public delegate IPeerConnectionListener PeerConnectionListenerCreator (IPEndPoint endPoint);
@@ -99,7 +99,7 @@ namespace MonoTorrent
 
             HttpClientFunc = HttpRequestFactory.CreateHttpClient;
 
-            TemporaryLocalPeerIdGeneratorFunc = (permanentLocalPeerId, _, __) => ReusableTask.FromResult (permanentLocalPeerId);
+            TemporaryLocalPeerIdGeneratorFunc = (permanentLocalPeerId, _, __, ___) => ReusableTask.FromResult (permanentLocalPeerId);
             LocalPeerDiscoveryFunc = () => new LocalPeerDiscovery ();
             PeerConnectionFuncs = new ReadOnlyDictionary<string, PeerConnectionCreator> (
                 new Dictionary<string, PeerConnectionCreator> {
@@ -173,8 +173,9 @@ namespace MonoTorrent
             return dupe;
         }
 
-        public ReusableTask<BEncodedString> CreateTemporaryLocalPeerIdAsync (BEncodedString permanentLocalPeerId, InfoHash infoHash, Uri peerUri)
-            => TemporaryLocalPeerIdGeneratorFunc (permanentLocalPeerId, infoHash, peerUri);
+        public ReusableTask<BEncodedString> CreateTemporaryLocalPeerIdAsync (BEncodedString permanentLocalPeerId,
+            BEncodedString peerId, InfoHash infoHash, Uri peerUri)
+            => TemporaryLocalPeerIdGeneratorFunc (permanentLocalPeerId, peerId, infoHash, peerUri);
         public Factories WithTemporaryLocalPeerIdGenerator (TemporaryLocalPeerIdGenerator generator)
         {
             var dupe = MemberwiseClone ();

--- a/src/MonoTorrent.Factories/MonoTorrent/Factories.cs
+++ b/src/MonoTorrent.Factories/MonoTorrent/Factories.cs
@@ -57,7 +57,7 @@ namespace MonoTorrent
         public delegate IDhtEngine DhtCreator ();
         public delegate IDhtListener DhtListenerCreator (IPEndPoint endpoint);
         public delegate HttpClient HttpClientCreator (AddressFamily family);
-        public delegate ReusableTask<BEncodedString> TemporaryLocalPeerIdGenerator (BEncodedString permanentLocalPeerId, BEncodedString peerId, InfoHash infoHash, Uri peerUri);
+        public delegate ReusableTask<BEncodedString> TemporaryLocalPeerIdGenerator (ITorrentManagerInfo torrent, BEncodedString permanentLocalPeerId, BEncodedString peerId, InfoHash infoHash, Uri peerUri);
         public delegate ILocalPeerDiscovery LocalPeerDiscoveryCreator ();
         public delegate IPeerConnection PeerConnectionCreator (Uri uri);
         public delegate IPeerConnectionListener PeerConnectionListenerCreator (IPEndPoint endPoint);
@@ -99,7 +99,7 @@ namespace MonoTorrent
 
             HttpClientFunc = HttpRequestFactory.CreateHttpClient;
 
-            TemporaryLocalPeerIdGeneratorFunc = (permanentLocalPeerId, _, __, ___) => ReusableTask.FromResult (permanentLocalPeerId);
+            TemporaryLocalPeerIdGeneratorFunc = (_, permanentLocalPeerId, _, __, ___) => ReusableTask.FromResult (permanentLocalPeerId);
             LocalPeerDiscoveryFunc = () => new LocalPeerDiscovery ();
             PeerConnectionFuncs = new ReadOnlyDictionary<string, PeerConnectionCreator> (
                 new Dictionary<string, PeerConnectionCreator> {
@@ -173,9 +173,11 @@ namespace MonoTorrent
             return dupe;
         }
 
-        public ReusableTask<BEncodedString> CreateTemporaryLocalPeerIdAsync (BEncodedString permanentLocalPeerId,
+        public ReusableTask<BEncodedString> CreateTemporaryLocalPeerIdAsync (
+            ITorrentManagerInfo torrent,
+            BEncodedString permanentLocalPeerId,
             BEncodedString peerId, InfoHash infoHash, Uri peerUri)
-            => TemporaryLocalPeerIdGeneratorFunc (permanentLocalPeerId, peerId, infoHash, peerUri);
+            => TemporaryLocalPeerIdGeneratorFunc (torrent, permanentLocalPeerId, peerId, infoHash, peerUri);
         public Factories WithTemporaryLocalPeerIdGenerator (TemporaryLocalPeerIdGenerator generator)
         {
             var dupe = MemberwiseClone ();

--- a/src/MonoTorrent/MonoTorrent.Connections.Peer/IPeerConnectionGate.cs
+++ b/src/MonoTorrent/MonoTorrent.Connections.Peer/IPeerConnectionGate.cs
@@ -1,0 +1,12 @@
+﻿using MonoTorrent.BEncoding;
+
+using ReusableTasks;
+
+namespace MonoTorrent.Connections.Peer
+{
+    public interface IPeerConnectionGate
+    {
+        ReusableTask<bool> TryAcceptHandshakeAsync (BEncodedString localPeerId, PeerInfo remotePeer,
+            IPeerConnection connection, InfoHash infoHash);
+    }
+}

--- a/src/MonoTorrent/MonoTorrent/PeerInfo.cs
+++ b/src/MonoTorrent/MonoTorrent/PeerInfo.cs
@@ -68,6 +68,9 @@ namespace MonoTorrent
         internal PeerInfo (Uri connectionUri, BEncodedString peerId, bool maybeSeeder, IPEndPoint? endPoint)
             => (ConnectionUri, PeerId, MaybeSeeder, EndPoint) = (connectionUri ?? throw new ArgumentNullException (nameof (connectionUri)), peerId ?? throw new ArgumentNullException (nameof (BEncodedString)), maybeSeeder, endPoint);
 
+        public PeerInfo WithPeerId (BEncodedString peerId)
+            => new PeerInfo (ConnectionUri, peerId, MaybeSeeder, EndPoint);
+
         public override bool Equals (object? obj)
             => Equals (obj as PeerInfo);
 


### PR DESCRIPTION
Two new features:
- temporary local peer IDs (useful for masking identity or for any other scenario that needs specific peer IDs for specific torrents)
- connection gating: enables external plugins that execute immediately after a handshake and can drop the connection for any reason