### PR TITLE
MetadataMode - bep52

### DIFF
--- a/src/Logger.cs
+++ b/src/Logger.cs
@@ -100,6 +100,12 @@ namespace MonoTorrent.Logging
                 Writer.Info ($"{connection.Uri}: {string.Format (formatString, p1)}");
         }
 
+        internal void InfoFormatted (IPeerConnection connection, string formatString, int p1, int p2)
+        {
+            if (Writer != null)
+                Writer.Info ($"{connection.Uri}: {string.Format (formatString, p1, p2)}");
+        }
+
         internal void InfoFormatted (IPeerConnection connection, string formatString, object p1)
         {
             if (Writer != null)

--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/PieceHashesMode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/PieceHashesMode.cs
@@ -30,6 +30,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Numerics;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
@@ -46,28 +47,26 @@ namespace MonoTorrent.Client.Modes
 {
     class PieceHashesMode : Mode
     {
-        const int MaxHashesPerRequest = 512;
-
         class HashesRequesterData : IPieceRequesterData, IMessageEnqueuer
         {
             public ReadOnlyBitField AvailablePieces { get; }
             Dictionary<PeerId, IgnoringChokeStateRequester> WrappedPeers { get; }
             Dictionary<IgnoringChokeStateRequester, PeerId> UnwrappedPeers { get; }
             public BitField ValidatedPieces { get; }
-            public IList<ITorrentManagerFile> Files => Array.Empty<ITorrentManagerFile> ();
-            public int PieceCount => (totalHashes + PieceLength - 1) / PieceLength;
-            public int PieceLength => MaxHashesPerRequest;
+            IList<ITorrentManagerFile> IPieceRequesterData.Files => Array.Empty<ITorrentManagerFile> ();
+            public int PieceCount => (File.PieceCount + PieceLength - 1) / PieceLength;
+            public int PieceLength { get; }
+
+            public ITorrentManagerFile File { get; }
 
             readonly int actualPieceLength;
-            readonly MerkleRoot root;
-            readonly int totalHashes;
 
-            public HashesRequesterData (MerkleRoot root, int actualPieceLength, int totalHashes)
+            public HashesRequesterData (ITorrentManagerFile file, int actualPieceLength)
             {
+                File = file;
                 this.actualPieceLength = actualPieceLength;
-                this.root = root;
-                this.totalHashes = totalHashes;
 
+                PieceLength = Math.Min (512, (int) BitOps.RoundUpToPowerOf2 (file.PieceCount));
                 AvailablePieces = new BitField (PieceCount).SetAll (true);
                 ValidatedPieces = new BitField (PieceCount);
                 WrappedPeers = new Dictionary<PeerId, IgnoringChokeStateRequester> ();
@@ -90,12 +89,12 @@ namespace MonoTorrent.Client.Modes
                 => (int) (byteOffset / PieceLength);
 
             public int BytesPerPiece (int pieceIndex)
-                => pieceIndex == PieceCount - 1 ? totalHashes - pieceIndex * PieceLength : PieceLength;
+                => pieceIndex == PieceCount - 1 ? File.PieceCount - pieceIndex * PieceLength : PieceLength;
 
             void IMessageEnqueuer.EnqueueRequest (IRequester wrappedPeer, PieceSegment block)
             {
                 var peer = UnwrappedPeers[(IgnoringChokeStateRequester) wrappedPeer];
-                var message = HashRequestMessage.Create (root, totalHashes, actualPieceLength, block.PieceIndex * PieceLength, MaxHashesPerRequest);
+                var message = HashRequestMessage.CreateFromPieceLayer (File.PiecesRoot, File.PieceCount, actualPieceLength, block.PieceIndex * PieceLength, PieceLength);
                 peer.MessageQueue.Enqueue (message);
             }
 
@@ -120,8 +119,8 @@ namespace MonoTorrent.Client.Modes
 
         static readonly Logger logger = Logger.Create (nameof (PieceHashesMode));
         public override TorrentState State => TorrentState.FetchingHashes;
-        Dictionary<ITorrentFile, (IPieceRequester, HashesRequesterData)> pickers;
-        Dictionary<ITorrentFile, MerkleLayers> infoHashes;
+        Dictionary<MerkleRoot, (IPieceRequester, HashesRequesterData)> pickers;
+        Dictionary<MerkleRoot, MerkleLayers> infoHashes;
         HashSet<PeerId> IgnoredPeers { get; }
         bool StopWhenDone { get; }
 
@@ -131,13 +130,18 @@ namespace MonoTorrent.Client.Modes
             if (manager.Torrent is null)
                 throw new InvalidOperationException ($"{nameof (PieceHashesMode)} can only be used after the torrent metadata is available");
 
-            pickers = manager.Torrent!.Files.Where (t => t.StartPieceIndex != t.EndPieceIndex).ToDictionary (t => t, value => {
-                var data = new HashesRequesterData (value.PiecesRoot, manager.Torrent.PieceLength, value.EndPieceIndex - value.StartPieceIndex + 1);
+            infoHashes = new Dictionary<MerkleRoot, MerkleLayers> ();
+            pickers = new Dictionary<MerkleRoot, (IPieceRequester, HashesRequesterData)> ();
+            foreach (var file in manager.Files.Where (t => t.PieceCount > 1)) {
+                var data = new HashesRequesterData (file, manager.Torrent.PieceLength);
                 var request = Manager.Engine!.Factories.CreatePieceRequester (new PieceRequesterSettings (false, false, false, 3));
-                request.Initialise (data, data, new ReadOnlyBitField[] { data.ValidatedPieces } );
-                return (request, data);
-            });
-            infoHashes = manager.Torrent.Files.Where (t => t.EndPieceIndex != t.StartPieceIndex).ToDictionary (t => t, value => new MerkleLayers (value.PiecesRoot, manager.Torrent.PieceLength, value.EndPieceIndex - value.StartPieceIndex + 1));
+                request.Initialise (data, data, new ReadOnlyBitField[] { data.ValidatedPieces });
+
+                // Multiple files can have the same root hash if the files themselves are identical. What a waste of bandwidth that would be though :p
+                // Protect against it by constructing the dictionaries manually and using the index based setter instead of calling 'Add'.
+                infoHashes[file.PiecesRoot] = new MerkleLayers (file.PiecesRoot, manager.Torrent.PieceLength, file.PieceCount);
+                pickers[file.PiecesRoot] = (request, data);
+            }
             IgnoredPeers = new HashSet<PeerId> ();
             StopWhenDone = stopWhenDone;
         }
@@ -145,8 +149,15 @@ namespace MonoTorrent.Client.Modes
         public override void Tick (int counter)
         {
             PreLogicTick (counter);
-
             MaybeRequestNext ();
+
+            foreach (var peer in Manager.Peers.ConnectedPeers) {
+                if (peer.AmRequestingPiecesCount > 0 && (peer.LastMessageSent.Elapsed > Settings.StaleRequestTimeout)) {
+                    foreach (var picker in pickers)
+                        picker.Value.Item1.CancelRequests (peer, 0, picker.Value.Item2.PieceCount - 1);
+                    IgnoredPeers.Add (peer);
+                }
+            }
         }
 
         void MaybeRequestNext ()
@@ -171,19 +182,17 @@ namespace MonoTorrent.Client.Modes
         {
             base.HandlePeerDisconnected (id);
             foreach (var picker in pickers)
-                picker.Value.Item1.CancelRequests (picker.Value.Item2.Wrap (id), 0, picker.Key.EndPieceIndex - picker.Key.StartPieceIndex + 1);
+                picker.Value.Item1.CancelRequests (picker.Value.Item2.Wrap (id), 0, picker.Value.Item2.PieceCount);
         }
 
         protected override void HandleHashRejectMessage (PeerId id, HashRejectMessage hashRejectMessage)
         {
             // If someone rejects us, let's remove them from the list for now...
             base.HandleHashRejectMessage (id, hashRejectMessage);
-            var file = Manager.Torrent!.Files.FirstOrDefault (f => f.PiecesRoot.Span.SequenceEqual (hashRejectMessage.PiecesRoot.Span));
-            if (file == null)
-                return;
 
-            var picker = pickers[file];
-            if (!picker.Item1.ValidatePiece (picker.Item2.Wrap (id), new PieceSegment (hashRejectMessage.Index / MaxHashesPerRequest, 0), out _, new HashSet<IRequester> ()))
+            if (!pickers.TryGetValue (hashRejectMessage.PiecesRoot, out var picker))
+                return;
+            if (!picker.Item1.ValidatePiece (picker.Item2.Wrap (id), new PieceSegment (hashRejectMessage.Index / picker.Item2.PieceLength, 0), out _, new HashSet<IRequester> ()))
                 return;
 
             IgnoredPeers.Add (id);
@@ -193,12 +202,9 @@ namespace MonoTorrent.Client.Modes
         {
             base.HandleHashesMessage (id, hashesMessage);
 
-            var file = Manager.Torrent!.Files.FirstOrDefault (f => f.PiecesRoot.Span.SequenceEqual (hashesMessage.PiecesRoot.Span));
-            if (file == null)
+            if (!pickers.TryGetValue (hashesMessage.PiecesRoot, out var picker))
                 return;
-
-            var picker = pickers[file];
-            if (!picker.Item1.ValidatePiece (picker.Item2.Wrap (id), new PieceSegment (hashesMessage.Index / MaxHashesPerRequest, 0), out _, new HashSet<IRequester> ())) {
+            if (!picker.Item1.ValidatePiece (picker.Item2.Wrap (id), new PieceSegment (hashesMessage.Index / picker.Item2.PieceLength, 0), out _, new HashSet<IRequester> ())) {
                 ConnectionManager.CleanupSocket (Manager, id);
                 return;
             }
@@ -211,22 +217,22 @@ namespace MonoTorrent.Client.Modes
                 id.LastBlockReceived.Restart ();
             }
 
-            // NOTE: Tweak this so we validate the hash in-place, and ensure the data we've been given, provided with the ancestor
-            // hashes, combines to form the `PiecesRoot` value.
-            var success = infoHashes[file].TryAppend (hashesMessage.BaseLayer, hashesMessage.Index, hashesMessage.Length, hashesMessage.Hashes.Span.Slice (0, hashesMessage.Length * 32), hashesMessage.Hashes.Span.Slice (hashesMessage.Length * 32));
+            var success = infoHashes[hashesMessage.PiecesRoot].TryAppend (hashesMessage.BaseLayer, hashesMessage.Index, hashesMessage.Length, hashesMessage.Hashes.Span);
             if (success)
-                picker.Item2.ValidatedPieces[hashesMessage.Index / MaxHashesPerRequest] = true;
+                picker.Item2.ValidatedPieces[hashesMessage.Index / picker.Item2.PieceLength] = true;
+            else
+                logger.Info (id.Connection, "Requested piece hashes did not pass validation");
 
             if (picker.Item2.ValidatedPieces.AllTrue) {
                 using var hasher = IncrementalHash.CreateHash (HashAlgorithmName.SHA256);
 
-                if (!infoHashes[file].TryVerify (out ReadOnlyMerkleLayers? verifiedPieceHashes))
+                if (!infoHashes[hashesMessage.PiecesRoot].TryVerify (out ReadOnlyMerkleLayers? verifiedPieceHashes))
                     picker.Item2.ValidatedPieces.SetAll (false);
             }
 
             if (pickers.All (picker => picker.Value.Item2.ValidatedPieces.AllTrue)) {
-                var actualMerkleLayers = infoHashes.ToDictionary (t => t.Key.PiecesRoot, v => (v.Value.TryVerify (out var root) ? root : null)!);
-                Manager.PieceHashes = Manager.Torrent.CreatePieceHashes (actualMerkleLayers);
+                var actualMerkleLayers = infoHashes.ToDictionary (t => t.Key, v => (v.Value.TryVerify (out var root) ? root : null)!);
+                Manager.PieceHashes = Manager.Torrent!.CreatePieceHashes (actualMerkleLayers);
                 Manager.PendingV2PieceHashes.SetAll (false);
 
                 // Cache the data for future re-use
@@ -240,13 +246,12 @@ namespace MonoTorrent.Client.Modes
                 // Cancel any duplicate requests
                 foreach (var peer in Manager.Peers.ConnectedPeers)
                     foreach (var p in pickers)
-                        p.Value.Item1.CancelRequests (p.Value.Item2.Wrap (peer), 0, p.Key.EndPieceIndex - p.Key.StartPieceIndex + 1);
+                        p.Value.Item1.CancelRequests (p.Value.Item2.Wrap (peer), 0, p.Value.Item2.PieceCount);
                 if (StopWhenDone)
                     Manager.Mode = new StoppedMode ();
                 else
                     Manager.Mode = new DownloadMode (Manager, DiskManager, ConnectionManager, Settings);
             }
-
             MaybeRequestNext ();
         }
     }

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentFileInfo.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentFileInfo.cs
@@ -62,6 +62,8 @@ namespace MonoTorrent.Client
 
         public long Padding => TorrentFile.Padding;
 
+        public int PieceCount => TorrentFile.PieceCount;
+
         public MerkleRoot PiecesRoot => TorrentFile.PiecesRoot;
 
         public TorrentFileInfo (ITorrentFile torrentFile, string fullPath)

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Settings/EngineSettings.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Settings/EngineSettings.cs
@@ -30,6 +30,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -109,7 +110,7 @@ namespace MonoTorrent.Client
         /// a connection can be attempted with a new peer. Defaults to 10 seconds. It is highly recommended
         /// to keep this value within a range of 7-15 seconds unless absolutely necessary.
         /// </summary>
-        public TimeSpan ConnectionTimeout { get; } = TimeSpan.FromSeconds (10);
+        public TimeSpan ConnectionTimeout { get; } = Debugger.IsAttached ? TimeSpan.FromSeconds (120) : TimeSpan.FromSeconds (10);
 
         /// <summary>
         /// Creates a cache which buffers data before it's written to the disk, or after it's been read from disk.

--- a/src/MonoTorrent.Client/MonoTorrent/IPieceHashes.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/IPieceHashes.cs
@@ -28,6 +28,7 @@
 
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace MonoTorrent
 {
@@ -39,7 +40,7 @@ namespace MonoTorrent
 
         ReadOnlyPieceHash GetHash (int hashIndex);
         bool IsValid (ReadOnlyPieceHash hashes, int hashIndex);
-        ReadOnlyMerkleLayers TryGetV2Hashes (MerkleRoot piecesRoot);
-        bool TryGetV2Hashes (MerkleRoot piecesRoot, int baseLayer, int index, int length, Span<byte> hashesBuffer, Span<byte> proofsBuffer, out int actualProofLayers);
+        bool TryGetV2Hashes (MerkleRoot piecesRoot, [NotNullWhen (true)] out ReadOnlyMerkleLayers? layers);
+        bool TryGetV2Hashes (MerkleRoot piecesRoot, int layer, int index, int count, int proofCount, Span<byte> hashesAndProofsBuffer, out int bytesWritten);
     }
 }

--- a/src/MonoTorrent.Client/MonoTorrent/MerkleHash.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/MerkleHash.cs
@@ -51,7 +51,7 @@ namespace MonoTorrent
             results[0] = buffer.ToArray ();
 
             // Generate 49 layers worth... though no real world torrent should ever use that many layers. Right???
-            for (int i = 1; results.Count < 49; i ++) {
+            for (int i = 1; results.Count < 49; i++) {
                 hasher.AppendData (buffer);
                 hasher.AppendData (buffer);
                 if (!hasher.TryGetHashAndReset (buffer, out int written) || written != 32)
@@ -94,18 +94,19 @@ namespace MonoTorrent
             // treat it as being a request of length '2' as we *should* have a padding hash to the right of the node we fetched.
             length = Math.Max (2, length);
             int proofLayerOffset = checked(index / (int) BitOps.RoundUpToPowerOf2 (length));
-            for (int i = 0; i < proofLayers.Length; i += 32) {
+            while (proofLayers.Length >= 32) {
                 if ((proofLayerOffset & 1) == 1)
-                    hasher.AppendData (proofLayers.Slice (i, 32));
+                    hasher.AppendData (proofLayers.Slice (0, 32));
 
                 hasher.AppendData (src);
 
                 if ((proofLayerOffset & 1) == 0)
-                    hasher.AppendData (proofLayers.Slice (i, 32));
+                    hasher.AppendData (proofLayers.Slice (0, 32));
 
                 if (!hasher.TryGetHashAndReset (dest.Span, out written) || written != 32)
                     return false;
                 proofLayerOffset /= 2;
+                proofLayers = proofLayers.Slice (32);
             }
 
             written = 32;

--- a/src/MonoTorrent.Client/MonoTorrent/PieceHashes.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/PieceHashes.cs
@@ -28,6 +28,7 @@
 
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace MonoTorrent
 {
@@ -58,14 +59,15 @@ namespace MonoTorrent
                 && (V2 is null || V2.IsValid (hashes, hashIndex))
                 && !(V1 is null && V2 is null);
         }
-        public ReadOnlyMerkleLayers TryGetV2Hashes (MerkleRoot piecesRoot)
+        public bool TryGetV2Hashes (MerkleRoot piecesRoot, [NotNullWhen (true)] out ReadOnlyMerkleLayers? layers)
         {
-            return V2?.TryGetV2Hashes (piecesRoot)!;
+            layers = null;
+            return V2 == null ? false : V2.TryGetV2Hashes (piecesRoot, out layers);
         }
-        public bool TryGetV2Hashes (MerkleRoot piecesRoot, int baseLayer, int index, int length, Span<byte> hashesBuffer, Span<byte> proofsBuffer, out int actualProofLayers)
+        public bool TryGetV2Hashes (MerkleRoot piecesRoot, int baseLayer, int index, int count, int proofCount, Span<byte> hashesAndProofsBuffer, out int bytesWritten)
         {
-            actualProofLayers = 0;
-            return V2 == null ? false : V2.TryGetV2Hashes (piecesRoot, baseLayer, index, length, hashesBuffer, proofsBuffer, out actualProofLayers);
+            bytesWritten = 0;
+            return V2 == null ? false : V2.TryGetV2Hashes (piecesRoot, baseLayer, index, count, proofCount, hashesAndProofsBuffer, out bytesWritten);
         }
     }
 }

--- a/src/MonoTorrent.Client/MonoTorrent/PieceHashesV1.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/PieceHashesV1.cs
@@ -28,6 +28,7 @@
 
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace MonoTorrent
 {
@@ -59,13 +60,14 @@ namespace MonoTorrent
         public bool IsValid (ReadOnlyPieceHash hashes, int hashIndex)
             => GetHash (hashIndex).V1Hash.Span.SequenceEqual (hashes.V1Hash.Span);
 
-        public ReadOnlyMerkleLayers TryGetV2Hashes (MerkleRoot piecesRoot)
+        public bool TryGetV2Hashes (MerkleRoot piecesRoot, [NotNullWhen (true)] out ReadOnlyMerkleLayers? layers)
         {
-            return null!;
+            layers = null;
+            return false;
         }
-        public bool TryGetV2Hashes (MerkleRoot piecesRoot, int baseLayer, int index, int length, Span<byte> hashesBuffer, Span<byte> proofsBuffer, out int actualProofLayers)
+        public bool TryGetV2Hashes (MerkleRoot piecesRoot, int baseLayer, int index, int count, int proofCount, Span<byte> hasheAndProofsBuffer, out int bytesWritten)
         {
-            actualProofLayers = 0;
+            bytesWritten = 0;
             return false;
         }
     }

--- a/src/MonoTorrent.Client/MonoTorrent/Torrent.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/Torrent.cs
@@ -629,7 +629,7 @@ namespace MonoTorrent
 
                         var merkleTrees = dict.ToDictionary (
                             key => MerkleRoot.FromMemory (key.Key.AsMemory ()),
-                            kvp => ReadOnlyMerkleLayers.FromLayer (PieceLength, MerkleRoot.FromMemory (kvp.Key.AsMemory ()), ((BEncodedString) kvp.Value).Span)!
+                            kvp => ReadOnlyMerkleLayers.FromLayer (PieceLength, ((BEncodedString) kvp.Value).Span, MerkleRoot.FromMemory (kvp.Key.AsMemory ()))
                         );
 
                         hashesV2 = LoadHashesV2 (Files, merkleTrees, PieceLength);

--- a/src/MonoTorrent.Client/MonoTorrent/Torrent.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/Torrent.cs
@@ -656,6 +656,10 @@ namespace MonoTorrent
             if (!hasV1Data && !hasV2Data)
                 throw new NotSupportedException ("The supplied torrent did not contain BitTorrent V1 or BitTorrent V2 metadata.");
 
+            // If all files are 1 piece long, then their root hash is all we need. Create the hashes object now!
+            if (hashesV2 == null && Files.All (t => t.StartPieceIndex == t.EndPieceIndex))
+                hashesV2 = LoadHashesV2 (Files, new Dictionary<MerkleRoot, ReadOnlyMerkleLayers> (), PieceLength);
+
             if (SupportsV2Torrents && SupportsV1V2Torrents) {
                 InfoHashes = new InfoHashes (hasV1Data ? InfoHash.FromMemory (infoHashes.SHA1) : default, hasV2Data ? InfoHash.FromMemory (infoHashes.SHA256) : default);
             } else if (SupportsV2Torrents) {

--- a/src/MonoTorrent.Client/MonoTorrent/TorrentFile.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/TorrentFile.cs
@@ -83,9 +83,15 @@ namespace MonoTorrent
         public string Path { get; }
 
         /// <summary>
+        /// Returns the number of pieces for this file. This is the same as `<see cref="EndPieceIndex"/> - <see cref="StartPieceIndex"/> + 1`.
+        /// </summary>
+        public int PieceCount => EndPieceIndex - StartPieceIndex + 1;
+
+        /// <summary>
         /// The index of the first piece of this file
         /// </summary>
         public int StartPieceIndex { get; }
+
 
         /// <summary>
         /// The offset to the start point of the files data within the torrent, in bytes.

--- a/src/MonoTorrent.Messages/MonoTorrent.Messages.Peer/HashRejectMessage.cs
+++ b/src/MonoTorrent.Messages/MonoTorrent.Messages.Peer/HashRejectMessage.cs
@@ -93,5 +93,16 @@ namespace MonoTorrent.Messages.Peer
 
         public override int GetHashCode ()
             => PiecesRoot.GetHashCode ();
+
+        public override string ToString ()
+        {
+            var title = $"{nameof (HashRejectMessage)}";
+            title += $"{Environment.NewLine}\t File: {BitConverter.ToString (PiecesRoot.Span.ToArray ()).Replace ("-", "")}";
+            title += $"{Environment.NewLine}\t BaseLayer: {BaseLayer}";
+            title += $"{Environment.NewLine}\t Index: {Index}";
+            title += $"{Environment.NewLine}\t Length: {Length}";
+            title += $"{Environment.NewLine}\t ProofLayers: {ProofLayers}";
+            return title;
+        }
     }
 }

--- a/src/MonoTorrent.Messages/MonoTorrent.Messages.Peer/HashesMessage.cs
+++ b/src/MonoTorrent.Messages/MonoTorrent.Messages.Peer/HashesMessage.cs
@@ -121,8 +121,18 @@ namespace MonoTorrent.Messages.Peer
 
         public override string ToString ()
         {
-            var title = $"{BitConverter.ToString (PiecesRoot.Span.ToArray ())} - {BaseLayer} - {Index} - {Length} - {ProofLayers}" + Environment.NewLine;
-            title += String.Join (Environment.NewLine, Enumerable.Range (0, Hashes.Length / 32).Select (t => BitConverter.ToString (Hashes.Slice (t, t + 32).ToArray ())).ToArray ());
+            var title = $"{nameof (HashesMessage)}";
+            title += $"{Environment.NewLine}\t File: {BitConverter.ToString (PiecesRoot.Span.ToArray ()).Replace ("-", "")}";
+            title += $"{Environment.NewLine}\t BaseLayer: {BaseLayer}";
+            title += $"{Environment.NewLine}\t Index: {Index}";
+            title += $"{Environment.NewLine}\t Length: {Length}";
+            title += $"{Environment.NewLine}\t ProofLayers: {ProofLayers}";
+            title += $"{Environment.NewLine}\t Data length: {Hashes.Length} ({Hashes.Length / 32} hashes)";
+#if NETSTANDARD2_0 || NET472
+            title += $"{Environment.NewLine}\t Full message: {Convert.ToBase64String(Encode().ToArray ())})";
+#else
+            title += $"{Environment.NewLine}\t Full message: {Convert.ToBase64String (Encode ().Span)})";
+#endif
             return title;
         }
     }

--- a/src/MonoTorrent.Messages/MonoTorrent.Messages.csproj
+++ b/src/MonoTorrent.Messages/MonoTorrent.Messages.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <UseBitOps>true</UseBitOps>
     <UseSimpleSpinLock>true</UseSimpleSpinLock>
   </PropertyGroup>
 

--- a/src/MonoTorrent.PieceWriter/MonoTorrent.PieceWriter/RandomFileStream.cs
+++ b/src/MonoTorrent.PieceWriter/MonoTorrent.PieceWriter/RandomFileStream.cs
@@ -57,8 +57,8 @@ namespace MonoTorrent.PieceWriter
             Handle = new FileStream (fullPath, fileMode, access, share, 1, FileOptions.None);
 #else
             try {
-                if (!File.Exists (fullPath))
-                    File.OpenHandle (fullPath, fileMode, access, share, FileOptions.None, length).Dispose ();
+                if (!File.Exists (fullPath) && (fileMode == FileMode.Create || fileMode == FileMode.CreateNew || fileMode == FileMode.OpenOrCreate))
+                    File.OpenHandle (fullPath, FileMode.CreateNew, access, share, FileOptions.None, length).Dispose ();
             } catch {
                 // who cares if we can't pre-allocate a sparse file.
             }

--- a/src/MonoTorrent/MonoTorrent/ITorrentFile.cs
+++ b/src/MonoTorrent/MonoTorrent/ITorrentFile.cs
@@ -49,6 +49,11 @@ namespace MonoTorrent
         int EndPieceIndex { get; }
 
         /// <summary>
+        /// Returns the number of pieces for this file. This is the same as `<see cref="EndPieceIndex"/> - <see cref="StartPieceIndex"/> + 1`.
+        /// </summary>
+        int PieceCount { get; }
+
+        /// <summary>
         /// The size of this file in bytes.
         /// </summary>
         long Length { get; }

--- a/src/MonoTorrent/MonoTorrent/ITorrentInfo.cs
+++ b/src/MonoTorrent/MonoTorrent/ITorrentInfo.cs
@@ -29,6 +29,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace MonoTorrent
 {

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/PieceHashesModeTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/PieceHashesModeTests.cs
@@ -133,10 +133,8 @@ namespace MonoTorrent.Client.Modes
         static HashesMessage FulfillRequest(HashRequestMessage hashRequest, PieceHashesV2 layers)
         {
             Memory<byte> totalBuffer = new byte[(hashRequest.Length + hashRequest.ProofLayers) * 32];
-            var hashBuffer = totalBuffer.Slice (0, hashRequest.Length * 32);
-            var proofBuffer = totalBuffer.Slice (hashRequest.Length * 32, hashRequest.ProofLayers * 32);
-            Assert.IsTrue (layers.TryGetV2Hashes (hashRequest.PiecesRoot, hashRequest.BaseLayer, hashRequest.Index, hashRequest.Length, hashBuffer.Span, proofBuffer.Span, out int proofs));
-            return new HashesMessage (hashRequest.PiecesRoot, hashRequest.BaseLayer, hashRequest.Index, hashRequest.Length, proofs, totalBuffer.Slice (0, (hashRequest.Length + proofs) * 32), default);
+            Assert.IsTrue (layers.TryGetV2Hashes (hashRequest.PiecesRoot, hashRequest.BaseLayer, hashRequest.Index, hashRequest.Length, hashRequest.ProofLayers, totalBuffer.Span, out int bytesWritten));
+            return new HashesMessage (hashRequest.PiecesRoot, hashRequest.BaseLayer, hashRequest.Index, hashRequest.Length, hashRequest.ProofLayers, totalBuffer.Slice (0, bytesWritten), default);
         }
     }
 }

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/MerkleLayersTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/MerkleLayersTests.cs
@@ -29,6 +29,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Numerics;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -45,8 +46,29 @@ namespace MonoTorrent.Client
             // 3 million 16kB pieces... because why not?
             var layers = new MerkleLayers (MerkleRoot.FromMemory (new byte[32]), 16_384, 10_000_000);
             Assert.IsFalse (layers.TryVerify (out _));
-            Assert.IsFalse (layers.TryAppend (layers.PieceLayerIndex, 0, 1, new byte[16784], ReadOnlySpan<byte>.Empty));
-            Assert.IsFalse (layers.TryAppend (20, 0, 1, new byte[16784], ReadOnlySpan<byte>.Empty));
+
+            Span<byte> proofs = new byte[(BitOps.CeilLog2 (10_000_000) - 10) * 32];
+            Assert.IsFalse (layers.TryAppend (layers.PieceLayerIndex, 0, 1, proofs));
+        }
+
+        [Test]
+        public void IncompleteProofLayers ()
+        {
+            // 3 million 16kB pieces... because why not?
+            var layers = new MerkleLayers (MerkleRoot.FromMemory (new byte[32]), 16_384, 1 << 11);
+
+            // 1 byte short of 2 proofs
+            Assert.IsFalse (layers.TryAppend (layers.PieceLayerIndex, 0, 1, new byte[63]));
+            // 1 byte short of 100 proofs
+            Assert.IsFalse (layers.TryAppend (layers.PieceLayerIndex, 0, 1, new byte[(100 * 32) - 1]));
+        }
+
+        [Test]
+        public void NotPieceLayer ()
+        {
+            var layers = new MerkleLayers (MerkleRoot.FromMemory (new byte[32]), 16_384, 100);
+            Assert.Throws<NotSupportedException> (() => layers.TryAppend (layers.PieceLayerIndex - 1, 0, 1, default));
+            Assert.Throws<NotSupportedException> (() => layers.TryAppend (layers.PieceLayerIndex + 1, 0, 1, default));
         }
 
         [Test]

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/MerkleTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/MerkleTests.cs
@@ -15,12 +15,14 @@ namespace MonoTorrent.Client
     [TestFixture]
     public class MerkleTests
     {
+        static string HybridTorrentPath => Path.Combine (Path.GetDirectoryName (typeof (MerkleTests).Assembly.Location), "MonoTorrent", "bittorrent-v2-hybrid-test.torrent");
         static string V2OnlyTorrentPath => Path.Combine (Path.GetDirectoryName (typeof (MerkleTests).Assembly.Location), "MonoTorrent", "bittorrent-v2-test.torrent");
 
+        Torrent HybridTorrent { get; } = Torrent.Load (HybridTorrentPath);
         Torrent V2OnlyTorrent { get; } = Torrent.Load (V2OnlyTorrentPath);
 
         ReadOnlyMerkleLayers CreateMerkleTree (int pieceLength, MerkleRoot expectedRoot, ReadOnlySpan<byte> layerHashes)
-            => ReadOnlyMerkleLayers.FromLayer (pieceLength, expectedRoot, layerHashes);
+            => ReadOnlyMerkleLayers.FromLayer (pieceLength, layerHashes, expectedRoot);
 
         [Test]
         public void CreateTree_OneRootHash ([Values (1)] int hashes)
@@ -32,7 +34,7 @@ namespace MonoTorrent.Client
         }
 
         [Test]
-        public void CreateTree_2Hashes ([Values(2)] int hashes)
+        public void CreateTree_2Hashes ([Values (2)] int hashes)
         {
             var expectedRoot = MerkleRoot.FromMemory (MerkleHash.PaddingHashesByLayer[BitOps.CeilLog2 (Constants.BlockSize * 2)]);
             var leafHashes = Replicate (MerkleHash.PaddingHashesByLayer[BitOps.CeilLog2 (Constants.BlockSize)], hashes);
@@ -68,30 +70,70 @@ namespace MonoTorrent.Client
         }
 
         [Test]
-        public void ReplicateMerkleTree ([Values (2, 4, 8, 16, 32, 64, 512)] int requestSize)
+        public void ReplicateMerkleTree_FixedChunks_Hybrid ([Values (2, 4, 8, 16, 32, 64, 512)] int preferredRequestSize)
+            => ReplicateMerkleTree_FixedChunks(HybridTorrent, preferredRequestSize);
+
+        [Test]
+        public void ReplicateMerkleTree_FixedChunks_V2Only ([Values (2, 4, 8, 16, 32, 64, 512)] int preferredRequestSize)
+            => ReplicateMerkleTree_FixedChunks (V2OnlyTorrent, preferredRequestSize);
+
+        static void ReplicateMerkleTree_FixedChunks (Torrent torrent,int preferredRequestSize)
         {
-            var originalHashes = V2OnlyTorrent.CreatePieceHashes ();
+            var originalHashes = torrent.CreatePieceHashes ();
 
             var result = new Dictionary<MerkleRoot, ReadOnlyMerkleLayers> ();
-            foreach (var file in V2OnlyTorrent.Files.Where (t => t.EndPieceIndex > t.StartPieceIndex)) {
-                var piecesInFile = file.EndPieceIndex - file.StartPieceIndex + 1;
-                var currentFileLayers = new MerkleLayers (file.PiecesRoot, V2OnlyTorrent.PieceLength, piecesInFile);
-                for (int i = 0; i < piecesInFile; i += requestSize) {
-                    var requestMessage = HashRequestMessage.Create (file.PiecesRoot, piecesInFile, V2OnlyTorrent.PieceLength, i, requestSize);
-                    var hashBytesRequested = requestMessage.Length * 32;
-                    var proofBytesRequested = requestMessage.ProofLayers * 32;
-                    Memory<byte> buffer = new byte[hashBytesRequested + proofBytesRequested];
-                    Assert.IsTrue (originalHashes.TryGetV2Hashes (file.PiecesRoot, requestMessage.BaseLayer, i, requestMessage.Length, buffer.Span.Slice (0, hashBytesRequested), buffer.Span.Slice (hashBytesRequested, proofBytesRequested), out int actualProofLayers));
-                    Assert.IsTrue (currentFileLayers.TryAppend (requestMessage.BaseLayer, i, requestMessage.Length, buffer.Span.Slice (0, hashBytesRequested), buffer.Span.Slice (hashBytesRequested, actualProofLayers * 32)));
+            foreach (var file in torrent.Files.Where (t => t.PieceCount > 1)) {
+                // Create the merkle layer with the precise number of pieces
+                var currentFileLayers = new MerkleLayers (file.PiecesRoot, torrent.PieceLength, file.PieceCount);
+
+                // But we always round up to the layer size when making requests. Layers are always a power of 2.
+                var piecesInLayer = (int) BitOps.RoundUpToPowerOf2 (file.PieceCount);
+
+                // However if we try to request 512 hashes for a file which is only 17 hashes long, clamp to the size of
+                // the pieces layer (i.e. the 32 hash layer in this case)
+                var requestSize = Math.Min (preferredRequestSize, piecesInLayer);
+
+                for (int i = 0; i < file.PieceCount; i += requestSize) {
+                    var requestMessage = HashRequestMessage.CreateFromPieceLayer (file.PiecesRoot, file.PieceCount, torrent.PieceLength, i, requestSize);
+                    var hashBytesRequested = (requestMessage.Length + requestMessage.ProofLayers) * 32;
+                    Memory<byte> buffer = new byte[hashBytesRequested];
+                    Assert.IsTrue (originalHashes.TryGetV2Hashes (file.PiecesRoot, requestMessage.BaseLayer, requestMessage.Index, requestMessage.Length, requestMessage.ProofLayers, buffer.Span, out int bytesWritten));
+                    Assert.IsTrue (currentFileLayers.TryAppend (requestMessage.BaseLayer, requestMessage.Index, requestMessage.Length, buffer.Span.Slice (0, bytesWritten)));
                 }
                 if (currentFileLayers.TryVerify (out var verifiedTree))
                     result.Add (file.PiecesRoot, verifiedTree);
+                else
+                    Assert.Fail ("Hash did not match");
             }
 
-            var newHashes = new PieceHashesV2 (V2OnlyTorrent.PieceLength, V2OnlyTorrent.Files, result);
+            var newHashes = new PieceHashesV2 (torrent.PieceLength, torrent.Files, result);
             for (int i = 0; i < originalHashes.Count; i++)
                 Assert.IsTrue (newHashes.IsValid (originalHashes.GetHash (i), i));
         }
+
+        [Test]
+        public void ReplicateMerkleTree_OptimalChunks_27551708 ()
+        {
+            const int PieceLength = 4 * 1024 * 1024;
+            var msg = HashRequestMessage.CreateFromPieceLayer (MerkleRoot.Empty, 7, PieceLength, 0, null);
+            Assert.AreEqual (new HashRequestMessage (MerkleRoot.Empty, 8, 0, 8, 2), msg);
+
+            msg = HashRequestMessage.CreateFromPieceLayer (MerkleRoot.Empty, 22, PieceLength, 0, null);
+            Assert.AreEqual (new HashRequestMessage (MerkleRoot.Empty, 8, 0, 32, 4), msg);
+
+            msg = HashRequestMessage.CreateFromPieceLayer (MerkleRoot.Empty, 2, PieceLength, 0, null);
+            Assert.AreEqual (new HashRequestMessage (MerkleRoot.Empty, 8, 0, 2, 0), msg);
+
+            msg = HashRequestMessage.CreateFromPieceLayer (MerkleRoot.Empty, 34, PieceLength, 0, null);
+            Assert.AreEqual (new HashRequestMessage (MerkleRoot.Empty, 8, 0, 64, 5), msg);
+
+            msg = HashRequestMessage.CreateFromPieceLayer (MerkleRoot.Empty, 63, PieceLength, 0, null);
+            Assert.AreEqual (new HashRequestMessage (MerkleRoot.Empty, 8, 0, 64, 5), msg);
+
+            msg = HashRequestMessage.CreateFromPieceLayer (MerkleRoot.Empty, 82, PieceLength, 0, null);
+            Assert.AreEqual (new HashRequestMessage (MerkleRoot.Empty, 8, 0, 128, 6), msg);
+        }
+
 
         static ReadOnlyMemory<byte> Replicate (ReadOnlyMemory<byte> hash, int count)
             => Enumerable.Repeat (hash.ToArray (), count)

--- a/src/Tests/TorrentInfoHelpers.cs
+++ b/src/Tests/TorrentInfoHelpers.cs
@@ -151,6 +151,7 @@ namespace MonoTorrent
         public long Length { get; }
         public int StartPieceIndex { get; }
         public int EndPieceIndex { get; }
+        public int PieceCount => EndPieceIndex - StartPieceIndex + 1;
         public long OffsetInTorrent { get; }
         public MerkleRoot PiecesRoot { get; }
         public long Padding { get; }


### PR DESCRIPTION
Fixed several bugs around requesting piece hashes for BEP52 torrents. Such as:
* Correct handling for requesting piece hashes when the piece layer is not an exact power of 2 in length.
* Correct handling of torrents which consist of files small enough to fit inside 1 piece.
* Correct handling of torrents containing duplicate files (which have the same underlying hash!)
* Improved logging for debugging purposes
