### PR TITLE
Embed debug info into DLLs

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -42,7 +42,7 @@
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
 
     <LangVersion>8.0</LangVersion>
-    <DebugType>portable</DebugType>
+    <DebugType>embedded</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <Deterministic>true</Deterministic>
     <RestorePackagesWithLockFile>false</RestorePackagesWithLockFile>


### PR DESCRIPTION
This greatly simplifies debugging.

These days storage is cheap, and debug symbols are small.

Removes the need to upload debug symbols separately, setting up debuggers to download them from NuGet (or you name it), etc etc etc