### PR TITLE
Fix two issues affecting webseeds

### DIFF
--- a/src/MonoTorrent.PiecePicking/MonoTorrent.PiecePicking/StandardPieceRequester.cs
+++ b/src/MonoTorrent.PiecePicking/MonoTorrent.PiecePicking/StandardPieceRequester.cs
@@ -96,8 +96,6 @@ namespace MonoTorrent.PiecePicking
 
         public void AddRequests (IRequester peer, ReadOnlyBitField available, ReadOnlySpan<ReadOnlyBitField> allPeers)
         {
-            int maxRequests = peer.MaxPendingRequests;
-
             if (!peer.CanRequestMorePieces || Picker == null || TorrentData == null || Enqueuer == null)
                 return;
 
@@ -105,7 +103,7 @@ namespace MonoTorrent.PiecePicking
             // continue a piece they have initiated. If they're choking then the only piece they can continue
             // will be a fast piece (if one exists!)
             if (!peer.IsChoking || peer.SupportsFastPeer) {
-                while (peer.AmRequestingPiecesCount < maxRequests) {
+                while (peer.CanRequestMorePieces) {
                     if (Picker.ContinueExistingRequest (peer, 0, available.Length - 1, out PieceSegment segment))
                         Enqueuer.EnqueueRequest (peer, segment);
                     else
@@ -123,7 +121,7 @@ namespace MonoTorrent.PiecePicking
             if (!peer.IsChoking || (peer.SupportsFastPeer && peer.IsAllowedFastPieces.Count > 0)) {
                 ReadOnlyBitField? filtered = null;
 
-                while (peer.AmRequestingPiecesCount < maxRequests) {
+                while (peer.CanRequestMorePieces) {
                     filtered ??= ApplyIgnorables (available);
 
                     int requests = Picker.PickPiece (peer, filtered, allPeers, 0, TorrentData.PieceCount - 1, requestBuffer);
@@ -137,7 +135,7 @@ namespace MonoTorrent.PiecePicking
             if (!peer.IsChoking && peer.AmRequestingPiecesCount == 0) {
                 ReadOnlyBitField? filtered = null;
                 PieceSegment segment;
-                while (peer.AmRequestingPiecesCount < maxRequests) {
+                while (peer.CanRequestMorePieces) {
                     filtered ??= ApplyIgnorables (available);
 
                     if (Picker.ContinueAnyExistingRequest (peer, filtered, 0, TorrentData.PieceCount - 1, 1, out segment)) {

--- a/src/MonoTorrent.PiecePicking/MonoTorrent.PiecePicking/StreamingPieceRequester.cs
+++ b/src/MonoTorrent.PiecePicking/MonoTorrent.PiecePicking/StreamingPieceRequester.cs
@@ -160,17 +160,13 @@ namespace MonoTorrent.PiecePicking
                 return;
 
             int preferredRequestAmount = peer.PreferredRequestAmount (TorrentData.PieceLength);
-            var maxRequests = Math.Min (preferredMaxRequests, peer.MaxPendingRequests);
-
-            if (peer.AmRequestingPiecesCount >= maxRequests)
-                return;
-
+            int maxTotalRequests = Math.Min (preferredMaxRequests, peer.MaxPendingRequests);
             // FIXME: Add a test to ensure we do not unintentionally request blocks off peers which are choking us.
             // This used to say if (!peer.IsChoing || peer.SupportsFastPeer), and with the recent changes we might
             // not actually guarantee that 'ContinueExistingRequest' or 'ContinueAnyExistingRequest' properly takes
             // into account that a peer which is choking us can *only* resume a 'fast piece' in the 'AmAllowedfastPiece' list.
             if (!peer.IsChoking) {
-                while (peer.AmRequestingPiecesCount < maxRequests) {
+                while (peer.CanRequestMorePieces && peer.AmRequestingPiecesCount < maxTotalRequests) {
                     if (LowPriorityPicker!.ContinueAnyExistingRequest (peer, available, startPieceIndex, endPieceIndex, maxDuplicates, out PieceSegment request))
                         Enqueuer.EnqueueRequest(peer, request);
                     else
@@ -180,7 +176,7 @@ namespace MonoTorrent.PiecePicking
 
             // If the peer supports fast peer and they are choking us, they'll still send pieces in the allowed fast set.
             if (peer.SupportsFastPeer && peer.IsChoking) {
-                while (peer.AmRequestingPiecesCount < maxRequests) {
+                while (peer.CanRequestMorePieces && peer.AmRequestingPiecesCount < maxTotalRequests) {
                     if (LowPriorityPicker!.ContinueExistingRequest (peer, startPieceIndex, endPieceIndex, out PieceSegment segment))
                         Enqueuer.EnqueueRequest (peer, segment);
                     else
@@ -193,9 +189,9 @@ namespace MonoTorrent.PiecePicking
             // FIXME add a test for this.
             if (!peer.IsChoking || (peer.SupportsFastPeer && peer.IsAllowedFastPieces.Count > 0)) {
                 BitField filtered = null!;
-                while (peer.AmRequestingPiecesCount < maxRequests) {
+                while (peer.CanRequestMorePieces && peer.AmRequestingPiecesCount < maxTotalRequests) {
                     filtered ??= GenerateAlreadyHaves ().Not ().And (available);
-                    Span<PieceSegment> buffer = stackalloc PieceSegment[preferredRequestAmount];
+                    Span<PieceSegment> buffer = stackalloc PieceSegment[maxTotalRequests - peer.AmRequestingPiecesCount];
                     int requested = PriorityPick (peer, filtered, allPeers, startPieceIndex, endPieceIndex, buffer);
                     if (requested > 0) {
                         Enqueuer.EnqueueRequests (peer, buffer.Slice (0, requested));

--- a/src/Tests/Tests.MonoTorrent.IntegrationTests/Tests.MonoTorrent.IntegrationTests.csproj
+++ b/src/Tests/Tests.MonoTorrent.IntegrationTests/Tests.MonoTorrent.IntegrationTests.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\MonoTorrent.Client\MonoTorrent.Client.csproj" />
     <ProjectReference Include="..\..\MonoTorrent.Factories\MonoTorrent.Factories.csproj" />
+    <ProjectReference Include="..\..\MonoTorrent.PiecePicking\MonoTorrent.PiecePicking.csproj" />
     <ProjectReference Include="..\..\MonoTorrent.Trackers\MonoTorrent.Trackers.csproj" />
   </ItemGroup>
 

--- a/src/Tests/Tests.MonoTorrent.PiecePicking/StandardPieceRequesterTests.cs
+++ b/src/Tests/Tests.MonoTorrent.PiecePicking/StandardPieceRequesterTests.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using MonoTorrent.Client;
+
+using NUnit.Framework;
+
+namespace MonoTorrent.PiecePicking
+{
+    [TestFixture]
+    public class StandardPieceRequesterTests
+    {
+        class TestRequester : IRequester
+        {
+            public int AmRequestingPiecesCount { get; set; }
+            public bool CanRequestMorePieces => CanRequestMorePiecesOverride ();
+            public long DownloadSpeed { get; set; }
+            public List<int> IsAllowedFastPieces { get; } = new List<int> ();
+            public bool IsChoking { get; set; }
+            public int MaxPendingRequests { get; set; }
+            public int RepeatedHashFails { get; set; }
+            public List<int> SuggestedPieces { get; } = new List<int> ();
+            public bool SupportsFastPeer { get; set; }
+            public bool CanCancelRequests { get; set; }
+
+            public int PreferredRequestAmountOverride { get; set; } = 1;
+            public Func<bool> CanRequestMorePiecesOverride = () => true;
+
+            public int PreferredRequestAmount (int pieceLength)
+                => PreferredRequestAmountOverride;
+        }
+
+        class Enqueuer : IMessageEnqueuer
+        {
+            public int RequestsEnqueued = 0;
+            public void EnqueueCancellation (IRequester peer, PieceSegment segment)
+            {
+            }
+
+            public void EnqueueCancellations (IRequester peer, Span<PieceSegment> segments)
+            {
+            }
+
+            public void EnqueueRequest (IRequester peer, PieceSegment block)
+            {
+                RequestsEnqueued++;
+            }
+
+            public void EnqueueRequests (IRequester peer, Span<PieceSegment> blocks)
+            {
+                RequestsEnqueued += blocks.Length;
+            }
+        }
+
+        [Test]
+        public void CannotRequestMoreThanOne ()
+        {
+            // Http connections are *supposed* to request data in chunks, and fully complete one
+            // chunk before beginning the next. This makes webrequests easier to manage
+            var peer = new TestRequester ();
+            peer.CanRequestMorePiecesOverride = () => peer.AmRequestingPiecesCount == 0;
+            peer.PreferredRequestAmountOverride = 1;
+            peer.MaxPendingRequests = 8;
+
+            int pieceCount = 40;
+            int pieceLength = 256 * 1024;
+            var bitfield = new BitField (pieceCount).SetAll (true);
+            var torrentData = TestTorrentManagerInfo.Create (
+                files: TorrentFileInfo.Create (pieceLength, ("File", pieceLength * pieceCount, "Full/Path/File")),
+                pieceLength: pieceLength,
+                size: pieceLength * pieceCount
+            );
+
+            var enqueuer = new Enqueuer ();
+            var requester = new StandardPieceRequester (new PieceRequesterSettings ());
+
+            requester.Initialise (torrentData, enqueuer, Span<ReadOnlyBitField>.Empty);
+            requester.AddRequests (peer, new BitField (bitfield).SetAll (true), Span<ReadOnlyBitField>.Empty);
+            Assert.AreEqual (1, peer.AmRequestingPiecesCount);
+            Assert.AreEqual (1, enqueuer.RequestsEnqueued);
+
+            requester.AddRequests (peer, new BitField (bitfield).SetAll (true), Span<ReadOnlyBitField>.Empty);
+            Assert.AreEqual (1, peer.AmRequestingPiecesCount);
+            Assert.AreEqual (1, enqueuer.RequestsEnqueued);
+        }
+    }
+}


### PR DESCRIPTION
1) Ensure web requests request data in-order by fixing the piecepicker
   to correctly use 'CanRequestMorePieces'

2) Fix a bug in the handling of padding files. A request for some data
   from a webseed needs to take padding files into account in all cases.
   A request can begin or end inside padding, it can also begin/end in
   regular files while optionally crossing one stretch of padding. This
   means the existing logic to insert synethic requests to the padding
   file are broken in a number of cases.