### PR TITLE
[dht] Allow bootstrapping from additional bootstrap routers

### DIFF
--- a/src/MonoTorrent.Dht/MonoTorrent.Dht/DhtEngine.cs
+++ b/src/MonoTorrent.Dht/MonoTorrent.Dht/DhtEngine.cs
@@ -185,11 +185,11 @@ namespace MonoTorrent.Dht
             }
         }
 
-        async void InitializeAsync (IEnumerable<Node> nodes)
+        async void InitializeAsync (IEnumerable<Node> nodes, string[] bootstrapRouters)
         {
             await MainLoop;
 
-            var initTask = new InitialiseTask (this, nodes);
+            var initTask = new InitialiseTask (this, nodes, bootstrapRouters);
             await initTask.ExecuteAsync ();
             if (RoutingTable.NeedsBootstrap)
                 RaiseStateChanged (DhtState.NotReady);
@@ -272,9 +272,15 @@ namespace MonoTorrent.Dht
             => StartAsync (ReadOnlyMemory<byte>.Empty);
 
         public Task StartAsync (ReadOnlyMemory<byte> initialNodes)
-            => StartAsync (Node.FromCompactNode (BEncodedString.FromMemory (initialNodes)).Concat (PendingNodes));
+            => StartAsync (Node.FromCompactNode (BEncodedString.FromMemory (initialNodes)).Concat (PendingNodes), Array.Empty<string> ());
 
-        async Task StartAsync (IEnumerable<Node> nodes)
+        public Task StartAsync (params string[] bootstrapRouters)
+            => StartAsync (Array.Empty<Node> (), bootstrapRouters);
+
+        public Task StartAsync (ReadOnlyMemory<byte> initialNodes, params string[] bootstrapRouters)
+            => StartAsync (Node.FromCompactNode (BEncodedString.FromMemory (initialNodes)).Concat (PendingNodes), bootstrapRouters);
+
+        async Task StartAsync (IEnumerable<Node> nodes, string[] bootstrapRouters)
         {
             CheckDisposed ();
 
@@ -282,7 +288,7 @@ namespace MonoTorrent.Dht
             MessageLoop.Start ();
             if (RoutingTable.NeedsBootstrap) {
                 RaiseStateChanged (DhtState.Initialising);
-                InitializeAsync (nodes);
+                InitializeAsync (nodes, bootstrapRouters);
             } else {
                 RaiseStateChanged (DhtState.Ready);
             }

--- a/src/Samples/DhtSampleClient/Program.cs
+++ b/src/Samples/DhtSampleClient/Program.cs
@@ -1,17 +1,24 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 
 using MonoTorrent;
 using MonoTorrent.Connections.Dht;
 using MonoTorrent.Dht;
+using MonoTorrent.Messages;
 
 namespace ClientSample
 {
     class Program
     {
-        static async Task Main (string[] args)
+        static void Main (string[] args)
+        {
+            MainAsync ().Wait ();
+        }
+
+        static async Task MainAsync ()
         {
             // Create a DHT engine, and register a listener on port 15000
             var engine = new DhtEngine ();
@@ -20,35 +27,51 @@ namespace ClientSample
 
             // Load up the node cache from the prior invocation (if there is any)
             var nodes = ReadOnlyMemory<byte>.Empty;
-            if (File.Exists ("mynodes"))
+            if (File.Exists ("mynodes")) {
                 nodes = File.ReadAllBytes ("mynodes");
+            }
+
+            // Listen to some events
+            engine.PeersFound += (o, e) => {
+                Console.WriteLine ("Found peers: {0}", e.Peers.Count);
+            };
+
+            // Whenever the table has been initialised, store the node data on-disk.
+            // This makes rejoining the DHT table in future significantly easier and faster.
+            engine.StateChanged += async (o, e) => {
+                Console.WriteLine ("Current state: {0}", engine.State);
+
+                if (engine.State == DhtState.Ready)
+                    File.WriteAllBytes ("mynodes", (await engine.SaveNodesAsync ()).ToArray ());
+            };
 
             // Bootstrap into the DHT engine.
+            // If a custom router is available, you can pass it in addition to, or instead of, the list
+            // of nodes. e.g.
+            //      await engine.StartAsync ("router.yourproject.com", "other_router.backup.yourproject.org");
+            //      await engine.StartAsync (nodes, "router.yourproject.com", "other_router.backup.yourproject.org");
+            //
             await engine.StartAsync (nodes);
 
-            // Begin querying for random 20 byte infohashes
-            Random random = new Random (5);
-            byte[] b = new byte[20];
-            lock (random)
-                random.NextBytes (b);
+            // Begin querying for a ubuntu torrent
+            var infoHash = InfoHash.FromBase32 ("FKSPLJ7CBHSUWMUAHVBWOCLRYTEMVKQF");
 
             // Kick off the firs search. Discovered peers will be returned via the 'PeersFound'
             // event in batches, as they're discovered.
-            engine.GetPeers (new InfoHash (b));
+            engine.GetPeers (infoHash);
 
-            engine.PeersFound += async delegate (object o, PeersFoundEventArgs e) {
-                Console.WriteLine ("Found peers: {0}", e.Peers.Count);
-                while (Console.ReadLine () != "q") {
-                    for (int i = 0; i < 30; i++) {
-                        Console.WriteLine ("Waiting: {0} seconds left", (30 - i));
-                        System.Threading.Thread.Sleep (1000);
-                    }
-                    // Get some peers for the torrent
-                    engine.GetPeers (new InfoHash (b));
-                    random.NextBytes (b);
+            Console.Write ("Press enter to fetch some peers. press 'q' and enter to quit");
+            while (Console.ReadLine () != "q") {
+                Console.WriteLine ("Getting some peers...");
+
+                // Get some peers for the torrent
+                engine.GetPeers (infoHash);
+                for (int i = 0; i < 5; i++) {
+                    Console.WriteLine ("Waiting: {0} seconds left", (30 - i));
+                    System.Threading.Thread.Sleep (1000);
                 }
-                File.WriteAllBytes ("mynodes", (await engine.SaveNodesAsync ()).ToArray ());
-            };
+                Console.Write ("Press enter to fetch some peers. press 'q' and enter to quit");
+            }
         }
     }
 }


### PR DESCRIPTION
Add support for transmissions router (in the event the others are offline) while also add a public API so custom routers can be supplied when initialising a DhtEngine directly.