### PR TITLE
Ensure hash checking a file is a purely read-only operation

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/DownloadMode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/DownloadMode.cs
@@ -88,8 +88,6 @@ namespace MonoTorrent.Client.Modes
 
         internal async Task UpdateSeedingDownloadingState ()
         {
-            // FIXME: Ensure this properly handles the case where files are missing.
-
             //If download is fully complete, set state to 'Seeding' and send an announce to the tracker.
             if (Manager.Complete && state == TorrentState.Downloading) {
                 state = TorrentState.Seeding;

--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/DownloadMode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/DownloadMode.cs
@@ -88,6 +88,8 @@ namespace MonoTorrent.Client.Modes
 
         internal async Task UpdateSeedingDownloadingState ()
         {
+            // FIXME: Ensure this properly handles the case where files are missing.
+
             //If download is fully complete, set state to 'Seeding' and send an announce to the tracker.
             if (Manager.Complete && state == TorrentState.Downloading) {
                 state = TorrentState.Seeding;

--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/HashingMode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/HashingMode.cs
@@ -128,6 +128,8 @@ namespace MonoTorrent.Client.Modes
                 for (int i = 0; i < Manager.Torrent!.PieceCount; i++)
                     Manager.OnPieceHashed (i, false, i + 1, Manager.Torrent.PieceCount);
             }
+
+            await Manager.RefreshAllFilesCorrectLengthAsync ();
         }
 
         public void Dispose ()

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/DiskManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/DiskManager.cs
@@ -720,5 +720,23 @@ namespace MonoTorrent.Client
                 await Cache.SetCapacityAsync (settings.DiskCacheBytes);
             }
         }
+
+        internal async ReusableTask<bool> CreateAsync (ITorrentManagerFile file, FileCreationOptions fileCreationOptions)
+        {
+            await IOLoop;
+            return await Cache.Writer.CreateAsync (file, fileCreationOptions);
+        }
+
+        internal async ReusableTask<long?> GetLengthAsync (ITorrentManagerFile file)
+        {
+            await IOLoop;
+            return await Cache.Writer.GetLengthAsync (file);
+        }
+
+        internal async ReusableTask<bool> SetLengthAsync (ITorrentManagerFile file, long length)
+        {
+            await IOLoop;
+            return await Cache.Writer.SetLengthAsync (file, length);
+        }
     }
 }

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Settings/EngineSettings.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Settings/EngineSettings.cs
@@ -154,6 +154,11 @@ namespace MonoTorrent.Client
         public FastResumeMode FastResumeMode { get; } = FastResumeMode.BestEffort;
 
         /// <summary>
+        /// Sets the preferred approach to creating new files.
+        /// </summary>
+        public FileCreationOptions FileCreationOptions { get; } = FileCreationOptions.PreferSparse;
+
+        /// <summary>
         /// The list of HTTP(s) endpoints which the engine should bind to when a <see cref="TorrentManager"/> is set up
         /// to stream data from the torrent and <see cref="TorrentManager.StreamProvider"/> is non-null. Should be of
         /// the form "http://ip-address-or-hostname:port". Defaults to 'http://127.0.0.1:5555'.
@@ -266,7 +271,8 @@ namespace MonoTorrent.Client
         internal EngineSettings (
             IList<EncryptionType> allowedEncryption, bool allowHaveSuppression, bool allowLocalPeerDiscovery, bool allowPortForwarding,
             bool autoSaveLoadDhtCache, bool autoSaveLoadFastResume, bool autoSaveLoadMagnetLinkMetadata, string cacheDirectory,
-            TimeSpan connectionTimeout, IPEndPoint? dhtEndPoint, int diskCacheBytes, CachePolicy diskCachePolicy, FastResumeMode fastResumeMode, Dictionary<string, IPEndPoint> listenEndPoints,
+            TimeSpan connectionTimeout, IPEndPoint? dhtEndPoint, int diskCacheBytes, CachePolicy diskCachePolicy, FastResumeMode fastResumeMode,
+            FileCreationOptions fileCreationMode, Dictionary<string, IPEndPoint> listenEndPoints,
             int maximumConnections, int maximumDiskReadRate, int maximumDiskWriteRate, int maximumDownloadRate, int maximumHalfOpenConnections,
             int maximumOpenFiles, int maximumUploadRate, IDictionary<string, IPEndPoint> reportedListenEndPoints, bool usePartialFiles,
             TimeSpan webSeedConnectionTimeout, TimeSpan webSeedDelay, int webSeedSpeedTrigger, TimeSpan staleRequestTimeout,
@@ -286,6 +292,7 @@ namespace MonoTorrent.Client
             CacheDirectory = cacheDirectory;
             ConnectionTimeout = connectionTimeout;
             FastResumeMode = fastResumeMode;
+            FileCreationOptions = fileCreationMode;
             HttpStreamingPrefix = httpStreamingPrefix;
             ListenEndPoints = new ReadOnlyDictionary<string, IPEndPoint> (new Dictionary<string, IPEndPoint> (listenEndPoints));
             MaximumConnections = maximumConnections;

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Settings/EngineSettingsBuilder.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Settings/EngineSettingsBuilder.cs
@@ -191,6 +191,11 @@ namespace MonoTorrent.Client
         public FastResumeMode FastResumeMode { get; set; }
 
         /// <summary>
+        /// Sets the preferred approach to creating new files.
+        /// </summary>
+        public FileCreationOptions FileCreationMode { get; set; }
+
+        /// <summary>
         /// The HTTP(s) prefix which the engine should bind to when a <see cref="TorrentManager"/> is set up
         /// to stream data from the torrent and <see cref="TorrentManager.StreamProvider"/> is non-null. Should be of
         /// the form "http://ip-address-or-hostname:port". Defaults to 'http://127.0.0.1:5555'.
@@ -355,6 +360,7 @@ namespace MonoTorrent.Client
             DiskCacheBytes = settings.DiskCacheBytes;
             DiskCachePolicy = settings.DiskCachePolicy;
             FastResumeMode = settings.FastResumeMode;
+            FileCreationMode = settings.FileCreationOptions;
             httpStreamingPrefix = settings.HttpStreamingPrefix;
             ListenEndPoints = new Dictionary<string, IPEndPoint> (settings.ListenEndPoints);
             ReportedListenEndPoints = new Dictionary<string, IPEndPoint> (settings.ReportedListenEndPoints);
@@ -395,6 +401,7 @@ namespace MonoTorrent.Client
                 diskCacheBytes: DiskCacheBytes,
                 diskCachePolicy: DiskCachePolicy,
                 fastResumeMode: FastResumeMode,
+                fileCreationMode: FileCreationMode,
                 httpStreamingPrefix: HttpStreamingPrefix,
                 listenEndPoints: ListenEndPoints,
                 maximumConnections: MaximumConnections,

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Settings/Serializer.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Settings/Serializer.cs
@@ -77,6 +77,8 @@ namespace MonoTorrent.Client
                     property.SetValue (builder, new Uri (((BEncodedString) value).Text));
                 } else if (property.PropertyType == typeof (IPAddress)) {
                     property.SetValue (builder, IPAddress.Parse (((BEncodedString) value).Text));
+                } else if (property.PropertyType == typeof(FileCreationOptions)) {
+                    property.SetValue (builder, Enum.Parse (typeof (FileCreationOptions), ((BEncodedString) value).Text));
                 } else if (property.PropertyType == typeof (IPEndPoint)) {
                     var list = (BEncodedList) value;
                     IPEndPoint? endPoint = null;
@@ -115,6 +117,7 @@ namespace MonoTorrent.Client
                     FastResumeMode value => new BEncodedString (value.ToString ()),
                     CachePolicy value => new BEncodedString (value.ToString ()),
                     Uri value => new BEncodedString (value.OriginalString),
+                    FileCreationOptions value => new BEncodedString (value.ToString ()),
                     null => null,
                     Dictionary<string, IPEndPoint> value => FromIPAddressDictionary(value),
                     _ => throw new NotSupportedException ($"{property.Name} => type: ${property.PropertyType}"),

--- a/src/MonoTorrent.PieceWriter/MonoTorrent.PieceWriter/NtfsSparseFile.cs
+++ b/src/MonoTorrent.PieceWriter/MonoTorrent.PieceWriter/NtfsSparseFile.cs
@@ -36,7 +36,6 @@ using Microsoft.Win32.SafeHandles;
 
 namespace MonoTorrent.PieceWriter
 {
-#if NETSTANDARD2_0 || NETSTANDARD2_1 || NET5_0 || NETCOREAPP3_0 || NET472
     static class NtfsSparseFile
     {
         [StructLayout (LayoutKind.Sequential)]
@@ -155,5 +154,4 @@ namespace MonoTorrent.PieceWriter
             uint nFileSystemNameSize
         );
     }
-#endif
 }

--- a/src/MonoTorrent.PieceWriter/MonoTorrent.PieceWriter/RandomFileStream.cs
+++ b/src/MonoTorrent.PieceWriter/MonoTorrent.PieceWriter/RandomFileStream.cs
@@ -20,17 +20,6 @@ namespace MonoTorrent.PieceWriter
         ReusableTask WriteAsync (ReadOnlyMemory<byte> buffer, long offset);
     }
 
-    static class FileReaderWriterHelper
-    {
-        public static void MaybeTruncate (string fullPath, long length)
-        {
-            if (new FileInfo (fullPath).Length > length) {
-                using (var fileStream = new FileStream (fullPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite, 1, FileOptions.None))
-                    fileStream.SetLength (length);
-            }
-        }
-    }
-
 #if NETSTANDARD2_0 || NETSTANDARD2_1 || NET5_0 || NETCOREAPP3_0 || NET472
     class RandomFileReaderWriter : IFileReaderWriter
     {

--- a/src/MonoTorrent/MonoTorrent.PieceWriter/FileCreationOptions.cs
+++ b/src/MonoTorrent/MonoTorrent.PieceWriter/FileCreationOptions.cs
@@ -1,0 +1,46 @@
+﻿//
+// FileCreationOptions.cs
+//
+// Authors:
+//   Alan McGovern alan.mcgovern@gmail.com
+//
+// Copyright (C) 2024 Alan McGovern
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+
+namespace MonoTorrent.PieceWriter
+{
+    public enum FileCreationOptions
+    {
+        /// <summary>
+        /// On filesystems where sparse files can be created, an attempt will be made to create a sparse file.
+        /// Otherwise an empty file will be created.
+        /// </summary>
+        PreferSparse,
+        /// <summary>
+        /// On filesystems which support preallocation the space required for the file will be reserved as soon
+        /// as the file is created. Otherwise, a best effort to pre-allocate will be made by writing 1 byte at
+        /// the end of the file.
+        /// </summary>
+        PreferPreallocation,
+    }
+}

--- a/src/MonoTorrent/MonoTorrent.PieceWriter/IPieceWriter.cs
+++ b/src/MonoTorrent/MonoTorrent.PieceWriter/IPieceWriter.cs
@@ -38,13 +38,86 @@ namespace MonoTorrent.PieceWriter
         int OpenFiles { get; }
         int MaximumOpenFiles { get; }
 
+        /// <summary>
+        /// Releases all resources associated with the specified file.
+        /// </summary>
+        /// <param name="file"></param>
+        /// <returns></returns>
         ReusableTask CloseAsync (ITorrentManagerFile file);
+
+        /// <summary>
+        /// Returns false if the file already exists, otherwise creates the file and returns true.  
+        /// </summary>
+        /// <param name="file">The file to create</param>
+        /// <param name="options">Determines how new files will be created.</param>
+        /// <returns></returns>
+        ReusableTask<bool> CreateAsync (ITorrentManagerFile file, FileCreationOptions options);
+
+        /// <summary>
+        /// Returns true if the file exists.
+        /// </summary>
+        /// <param name="file"></param>
+        /// <returns></returns>
         ReusableTask<bool> ExistsAsync (ITorrentManagerFile file);
+
+        /// <summary>
+        /// Flush any cached data to the file.
+        /// </summary>
+        /// <param name="file"></param>
+        /// <returns></returns>
         ReusableTask FlushAsync (ITorrentManagerFile file);
+
+        /// <summary>
+        /// Returns null if the specified file does not exist, otherwise returns the length of the file in bytes.
+        /// </summary>
+        /// <param name="file"></param>
+        /// <returns></returns>
+        ReusableTask<long?> GetLengthAsync (ITorrentManagerFile file);
+
+        /// <summary>
+        /// Moves the specified file to the new location. Optionally overwrite any pre-existing files.
+        /// </summary>
+        /// <param name="file"></param>
+        /// <param name="fullPath"></param>
+        /// <param name="overwrite"></param>
+        /// <returns></returns>
         ReusableTask MoveAsync (ITorrentManagerFile file, string fullPath, bool overwrite);
+
+        /// <summary>
+        /// Reads the specified amount of data from the specified file.
+        /// </summary>
+        /// <param name="file"></param>
+        /// <param name="offset"></param>
+        /// <param name="buffer"></param>
+        /// <returns></returns>
         ReusableTask<int> ReadAsync (ITorrentManagerFile file, long offset, Memory<byte> buffer);
-        ReusableTask WriteAsync (ITorrentManagerFile file, long offset, ReadOnlyMemory<byte> buffer);
+
+        /// <summary>
+        /// Returns false and no action is taken if the file does not already exist. If the file does exist
+        /// it's length is set to the provided value.
+        /// </summary>
+        /// <param name="file"></param>
+        /// <param name="length"></param>
+        /// <returns></returns>
+        ReusableTask<bool> SetLengthAsync (ITorrentManagerFile file, long length);
+
+        /// <summary>
+        /// Optional limit to the maximum number of files this writer can have open concurrently.
+        /// </summary>
+        /// <param name="maximumOpenFiles"></param>
+        /// <returns></returns>
         ReusableTask SetMaximumOpenFilesAsync (int maximumOpenFiles);
+
+        /// <summary>
+        /// Writes all data in the provided buffer to the specified file. Some implementatations may
+        /// have an internal cache, which means <see cref="FlushAsync(ITorrentManagerFile)"/> should
+        /// be invoked to guarantee the data is written to it's final destination.
+        /// </summary>
+        /// <param name="file"></param>
+        /// <param name="offset"></param>
+        /// <param name="buffer"></param>
+        /// <returns></returns>
+        ReusableTask WriteAsync (ITorrentManagerFile file, long offset, ReadOnlyMemory<byte> buffer);
     }
 
     public static class PaddingAwareIPieceWriterExtensions

--- a/src/MonoTorrent/MonoTorrent/ITorrentFileInfo.cs
+++ b/src/MonoTorrent/MonoTorrent/ITorrentFileInfo.cs
@@ -61,5 +61,11 @@ namespace MonoTorrent
     {
         public static long BytesDownloaded (this ITorrentManagerFile info)
             => (long) (info.BitField.PercentComplete * info.Length / 100.0);
+
+        public static bool Overlaps (this ITorrentManagerFile self, ITorrentManagerFile file)
+            => self.Length > 0 &&
+            file.Length > 0 &&
+            self.StartPieceIndex <= file.EndPieceIndex &&
+            file.StartPieceIndex <= self.EndPieceIndex;
     }
 }

--- a/src/Samples/SampleClient/StressTest.cs
+++ b/src/Samples/SampleClient/StressTest.cs
@@ -26,6 +26,11 @@ namespace ClientSample
             return ReusableTask.CompletedTask;
         }
 
+        public ReusableTask<bool> CreateAsync (ITorrentManagerFile file, FileCreationOptions options)
+        {
+            throw new NotImplementedException ();
+        }
+
         public void Dispose ()
         {
         }
@@ -40,6 +45,11 @@ namespace ClientSample
             return ReusableTask.CompletedTask;
         }
 
+        public ReusableTask<long?> GetLengthAsync (ITorrentManagerFile file)
+        {
+            throw new NotImplementedException ();
+        }
+
         public ReusableTask MoveAsync (ITorrentManagerFile file, string fullPath, bool overwrite)
         {
             return ReusableTask.CompletedTask;
@@ -48,6 +58,11 @@ namespace ClientSample
         public ReusableTask<int> ReadAsync (ITorrentManagerFile file, long offset, Memory<byte> buffer)
         {
             return ReusableTask.FromResult (0);
+        }
+
+        public ReusableTask<bool> SetLengthAsync (ITorrentManagerFile file, long length)
+        {
+            throw new NotImplementedException ();
         }
 
         public ReusableTask SetMaximumOpenFilesAsync (int maximumOpenFiles)

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/DownloadModeTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/DownloadModeTests.cs
@@ -242,6 +242,10 @@ namespace MonoTorrent.Client.Modes
             await TrackerManager.AddTrackerAsync (new Uri ("http://1.1.1.1"));
             var bitfield = new BitField (Manager.Bitfield);
 
+            // Create all the files.
+            foreach (var file in Manager.Files)
+                await Manager.Engine.DiskManager.CreateAsync (file, MonoTorrent.PieceWriter.FileCreationOptions.PreferSparse);
+
             // Leecher at first
             bitfield.SetAll (true).Set (0, false);
             await Manager.LoadFastResumeAsync (new FastResume (Manager.InfoHashes, bitfield, new BitField (Manager.Torrent.PieceCount ())));

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/HashingModeTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/HashingModeTests.cs
@@ -146,7 +146,7 @@ namespace MonoTorrent.Client.Modes
             var pieceHashed = new TaskCompletionSource<byte[]> ();
             var secondPieceHashed = new TaskCompletionSource<byte[]> ();
 
-            PieceWriter.FilesThatExist.AddRange (Manager.Files);
+            await PieceWriter.CreateAsync (Manager.Files);
 
             Manager.Engine.DiskManager.GetHashAsyncOverride = async (torrentdata, pieceIndex, dest) => {
                 pieceTryHash.TrySetResult (null);
@@ -230,7 +230,7 @@ namespace MonoTorrent.Client.Modes
             await Manager.LoadFastResumeAsync (new FastResume (Manager.InfoHashes, bf, unhashed));
 
             foreach (var f in Manager.Files) {
-                PieceWriter.FilesThatExist.Add (f);
+                await PieceWriter.CreateAsync (f, MonoTorrent.PieceWriter.FileCreationOptions.PreferPreallocation);
                 await Manager.SetFilePriorityAsync (f, Priority.DoNotDownload);
                 ((TorrentFileInfo) f).BitField.SetAll (true);
             }
@@ -266,7 +266,7 @@ namespace MonoTorrent.Client.Modes
             await Manager.LoadFastResumeAsync (new FastResume (Manager.InfoHashes, bf, unhashed));
 
             foreach (var f in Manager.Files) {
-                PieceWriter.FilesThatExist.Add (f);
+                await PieceWriter.CreateAsync (f, MonoTorrent.PieceWriter.FileCreationOptions.PreferPreallocation);
                 await Manager.SetFilePriorityAsync (f, Priority.DoNotDownload);
             }
 
@@ -330,7 +330,7 @@ namespace MonoTorrent.Client.Modes
         [Test]
         public async Task StopWhileHashingPaused ()
         {
-            PieceWriter.FilesThatExist.AddRange (Manager.Files);
+            await PieceWriter.CreateAsync (Manager.Files);
 
             int getHashCount = 0;
             DiskManager.GetHashAsyncOverride = (manager, index, dest) => {
@@ -362,7 +362,7 @@ namespace MonoTorrent.Client.Modes
             await Manager.LoadFastResumeAsync (new FastResume (Manager.InfoHashes, bf, unhashed));
 
             foreach (var f in Manager.Files.Skip (1)) {
-                PieceWriter.FilesThatExist.Add (f);
+                await PieceWriter.CreateAsync (f, MonoTorrent.PieceWriter.FileCreationOptions.PreferPreallocation);
                 await Manager.SetFilePriorityAsync (f, Priority.DoNotDownload);
             }
 
@@ -384,14 +384,14 @@ namespace MonoTorrent.Client.Modes
         [Test]
         public async Task ReadZeroFromDisk ()
         {
-            PieceWriter.FilesThatExist.AddRange (new[]{
-                Manager.Files [0],
-                Manager.Files [2],
-            });
+            var emptyFiles = Manager.Files.Where (t => t.Length == 0).ToArray ();
+            var nonEmptyFiles = Manager.Files.Where (t => t.Length != 0).ToArray ();
+            await PieceWriter.CreateAsync (new[] { nonEmptyFiles[0], nonEmptyFiles[2] });
+            await PieceWriter.CreateAsync (emptyFiles);
 
             PieceWriter.DoNotReadFrom.AddRange (new[]{
-                Manager.Files[0],
-                Manager.Files[3],
+                nonEmptyFiles [0],
+                nonEmptyFiles [3],
             });
 
             var bf = new BitField (Manager.Torrent.PieceCount ()).SetAll (true);
@@ -401,6 +401,9 @@ namespace MonoTorrent.Client.Modes
             foreach (var file in Manager.Files)
                 Assert.IsTrue (file.BitField.AllTrue, "#2." + file.Path);
 
+            // Remove zero length files so they no longer exist
+            foreach (var v in emptyFiles)
+                PieceWriter.FilesWithLength.Remove (v);
             var mode = new HashingMode (Manager, DiskManager);
             Manager.Mode = mode;
             await mode.WaitForHashingToComplete ();

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/HashingModeTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/HashingModeTests.cs
@@ -271,6 +271,9 @@ namespace MonoTorrent.Client.Modes
         [Test]
         public async Task DoNotDownload_All ()
         {
+            // No files exist!
+            Assert.AreEqual (0, PieceWriter.FilesWithLength.Count);
+
             var bf = new BitField (Manager.Bitfield).SetAll (true);
             var unhashed = new BitField (bf).SetAll (false);
             await Manager.LoadFastResumeAsync (new FastResume (Manager.InfoHashes, bf, unhashed));
@@ -292,6 +295,8 @@ namespace MonoTorrent.Client.Modes
             // No piece should be marked as available, and no pieces should actually be hashchecked.
             Assert.IsTrue (Manager.Bitfield.AllFalse, "#2");
             Assert.AreEqual (Manager.UnhashedPieces.TrueCount, Manager.UnhashedPieces.Length, "#3");
+
+            // Empty files will always have their bitfield set to true if they exist on disk. None should exist though
             foreach (var f in Manager.Files)
                 Assert.IsTrue (f.BitField.AllFalse, "#4." + f.Path);
         }

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/InitialSeedingModeTest.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/InitialSeedingModeTest.cs
@@ -43,6 +43,8 @@ namespace MonoTorrent.Client.Modes
             get { return Rig.Manager.Mode as InitialSeedingMode; }
         }
 
+        TestWriter PieceWriter { get; set; }
+
         TestRig Rig {
             get; set;
         }
@@ -50,14 +52,19 @@ namespace MonoTorrent.Client.Modes
         [SetUp]
         public async Task Setup ()
         {
+            PieceWriter = new TestWriter ();
             Rig = TestRig.CreateSingleFile (Constants.BlockSize * 20, Constants.BlockSize * 2);
+            await Rig.Engine.DiskManager.SetWriterAsync (PieceWriter);
+
+            // create all the files
+            await PieceWriter.CreateAsync (Rig.Manager.Files);
 
             var bf = new BitField (Rig.Manager.Bitfield).SetAll (true);
             var unhashed = new BitField (bf).SetAll (false);
             await Rig.Manager.LoadFastResumeAsync (new FastResume (Rig.Manager.InfoHashes, bf, unhashed));
 
-
             Rig.Manager.Mode = new InitialSeedingMode (Rig.Manager, Rig.Engine.DiskManager, Rig.Engine.ConnectionManager, Rig.Engine.Settings);
+
         }
 
         [TearDown]

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/NullWriter.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/NullWriter.cs
@@ -17,6 +17,11 @@ namespace MonoTorrent.Client
             return ReusableTask.CompletedTask;
         }
 
+        public ReusableTask<bool> CreateAsync (ITorrentManagerFile file, FileCreationOptions options)
+        {
+            throw new NotImplementedException ();
+        }
+
         public void Dispose ()
         {
         }
@@ -31,6 +36,11 @@ namespace MonoTorrent.Client
             return ReusableTask.CompletedTask;
         }
 
+        public ReusableTask<long?> GetLengthAsync (ITorrentManagerFile file)
+        {
+            throw new NotImplementedException ();
+        }
+
         public ReusableTask MoveAsync (ITorrentManagerFile file, string fullPath, bool overwrite)
         {
             return ReusableTask.CompletedTask;
@@ -41,6 +51,11 @@ namespace MonoTorrent.Client
             return ReusableTask.FromResult (0);
         }
 
+        public ReusableTask SetLengthAsync (ITorrentManagerFile file, long length)
+        {
+            throw new NotImplementedException ();
+        }
+
         public ReusableTask SetMaximumOpenFilesAsync (int maximumOpenFiles)
         {
             return ReusableTask.CompletedTask;
@@ -49,6 +64,11 @@ namespace MonoTorrent.Client
         public ReusableTask WriteAsync (ITorrentManagerFile file, long offset, ReadOnlyMemory<byte> buffer)
         {
             return ReusableTask.CompletedTask;
+        }
+
+        ReusableTask<bool> IPieceWriter.SetLengthAsync (ITorrentManagerFile file, long length)
+        {
+            throw new NotImplementedException ();
         }
     }
 }

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/StartingModeTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/StartingModeTests.cs
@@ -167,7 +167,7 @@ namespace MonoTorrent.Client.Modes
         [Test]
         public async Task FastResume_SomeExist ()
         {
-            PieceWriter.FilesThatExist.AddRange (new[]{
+            await PieceWriter.CreateAsync (new[]{
                 Manager.Files [0],
                 Manager.Files [2],
             });

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/BlockingWriter.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/BlockingWriter.cs
@@ -26,6 +26,11 @@ namespace MonoTorrent.Client
             await tcs.Task;
         }
 
+        public ReusableTask<bool> CreateAsync (ITorrentManagerFile file, FileCreationOptions options)
+        {
+            throw new NotImplementedException ();
+        }
+
         public void Dispose ()
         {
         }
@@ -43,6 +48,12 @@ namespace MonoTorrent.Client
             Flushes.Add ((file, tcs));
             await tcs.Task;
         }
+
+        public ReusableTask<long?> GetLengthAsync (ITorrentManagerFile file)
+        {
+            throw new NotImplementedException ();
+        }
+
         public async ReusableTask MoveAsync (ITorrentManagerFile file, string fullPath, bool overwrite)
         {
             var tcs = new ReusableTaskCompletionSource<object> ();
@@ -55,6 +66,11 @@ namespace MonoTorrent.Client
             var tcs = new ReusableTaskCompletionSource<int> ();
             Reads.Add ((file, offset, buffer, tcs));
             return await tcs.Task;
+        }
+
+        public ReusableTask<bool> SetLengthAsync (ITorrentManagerFile file, long length)
+        {
+            throw new NotImplementedException ();
         }
 
         public ReusableTask SetMaximumOpenFilesAsync (int maximumOpenFiles)

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/ClientEngineTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/ClientEngineTests.cs
@@ -573,6 +573,7 @@ namespace MonoTorrent.Client
 
             await rig.Manager.SetFilePriorityAsync (rig.Manager.Files[0], Priority.Normal);
             Assert.IsTrue (await writer.ExistsAsync (rig.Manager.Files[0]));
+            Assert.IsTrue (rig.Manager.Files[0].BitField.AllTrue);
             Assert.IsFalse (await writer.ExistsAsync (rig.Manager.Files[1]));
 
             await rig.Manager.SetFilePriorityAsync (rig.Manager.Files[1], Priority.Normal);

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/DiskManagerExceptionTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/DiskManagerExceptionTests.cs
@@ -103,6 +103,21 @@ namespace MonoTorrent.Client
             {
                 return ReusableTask.CompletedTask;
             }
+
+            public ReusableTask<bool> CreateAsync (ITorrentManagerFile file, FileCreationOptions options)
+            {
+                throw new NotImplementedException ();
+            }
+
+            public ReusableTask<long?> GetLengthAsync (ITorrentManagerFile file)
+            {
+                throw new NotImplementedException ();
+            }
+
+            public ReusableTask<bool> SetLengthAsync (ITorrentManagerFile file, long length)
+            {
+                throw new NotImplementedException ();
+            }
         }
 
         byte[] buffer;

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/DiskManagerTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/DiskManagerTests.cs
@@ -53,6 +53,11 @@ namespace MonoTorrent.Client
             return ReusableTask.CompletedTask;
         }
 
+        public ReusableTask<bool> CreateAsync (ITorrentManagerFile file, FileCreationOptions options)
+        {
+            throw new NotImplementedException ();
+        }
+
         public void Dispose ()
         {
         }
@@ -67,6 +72,11 @@ namespace MonoTorrent.Client
             return ReusableTask.CompletedTask;
         }
 
+        public ReusableTask<long?> GetLengthAsync (ITorrentManagerFile file)
+        {
+            throw new NotImplementedException ();
+        }
+
         public ReusableTask MoveAsync (ITorrentManagerFile file, string fullPath, bool overwrite)
         {
             return ReusableTask.CompletedTask;
@@ -75,6 +85,11 @@ namespace MonoTorrent.Client
         public virtual ReusableTask<int> ReadAsync (ITorrentManagerFile file, long offset, Memory<byte> buffer)
         {
             return ReusableTask.FromResult (0);
+        }
+
+        public ReusableTask<bool> SetLengthAsync (ITorrentManagerFile file, long length)
+        {
+            throw new NotImplementedException ();
         }
 
         public ReusableTask SetMaximumOpenFilesAsync (int maximumOpenFiles)
@@ -162,6 +177,21 @@ namespace MonoTorrent.Client
             public ReusableTask SetMaximumOpenFilesAsync (int maximumOpenFiles)
             {
                 return ReusableTask.CompletedTask;
+            }
+
+            public ReusableTask<bool> CreateAsync (ITorrentManagerFile file, FileCreationOptions options)
+            {
+                throw new NotImplementedException ();
+            }
+
+            public ReusableTask<long?> GetLengthAsync (ITorrentManagerFile file)
+            {
+                throw new NotImplementedException ();
+            }
+
+            public ReusableTask<bool> SetLengthAsync (ITorrentManagerFile file, long length)
+            {
+                throw new NotImplementedException ();
             }
         }
 

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/DiskManagerTests.v2.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/DiskManagerTests.v2.cs
@@ -53,6 +53,11 @@ namespace MonoTorrent.Client
             public ReusableTask CloseAsync (ITorrentManagerFile file)
                 => ReusableTask.CompletedTask;
 
+            public ReusableTask<bool> CreateAsync (ITorrentManagerFile file, FileCreationOptions options)
+            {
+                throw new NotImplementedException ();
+            }
+
             public void Dispose ()
             {
             }
@@ -63,6 +68,11 @@ namespace MonoTorrent.Client
             public ReusableTask FlushAsync (ITorrentManagerFile file)
                 => ReusableTask.CompletedTask;
 
+            public ReusableTask<long?> GetLengthAsync (ITorrentManagerFile file)
+            {
+                throw new NotImplementedException ();
+            }
+
             public ReusableTask MoveAsync (ITorrentManagerFile file, string fullPath, bool overwrite)
                 => ReusableTask.CompletedTask;
 
@@ -70,6 +80,11 @@ namespace MonoTorrent.Client
             {
                 buffer.Span.Clear ();
                 return ReusableTask.FromResult (buffer.Length);
+            }
+
+            public ReusableTask<bool> SetLengthAsync (ITorrentManagerFile file, long length)
+            {
+                throw new NotImplementedException ();
             }
 
             public ReusableTask SetMaximumOpenFilesAsync (int maximumOpenFiles)

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/FastResumeTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/FastResumeTests.cs
@@ -212,7 +212,8 @@ namespace MonoTorrent.Client
             Directory.CreateDirectory (Path.GetDirectoryName (path));
             File.WriteAllBytes (path, new FastResume (torrent.InfoHashes, new BitField (torrent.PieceCount).SetAll (true), new BitField (torrent.PieceCount)).Encode ());
             var manager = await engine.AddAsync (torrent, "savedir");
-            testWriter.FilesThatExist = new System.Collections.Generic.List<ITorrentManagerFile> (manager.Files);
+            await testWriter.CreateAsync (manager.Files);
+
             Assert.IsTrue (manager.HashChecked);
             manager.Engine.DiskManager.GetHashAsyncOverride = (torrent, pieceIndex, dest) => {
                 first.SetResult (null);

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Streaming/StreamProviderTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Streaming/StreamProviderTests.cs
@@ -71,7 +71,7 @@ namespace MonoTorrent.Streaming
         {
             var manager = await Engine.AddStreamingAsync (Torrent, "test");
             await manager.LoadFastResumeAsync (new FastResume (manager.InfoHashes, new BitField (manager.Torrent.PieceCount ()).SetAll (true), new BitField (manager.Torrent.PieceCount ())));
-            PieceWriter.FilesThatExist.AddRange (manager.Files);
+            await PieceWriter.CreateAsync (manager.Files);
 
             await manager.StartAsync ();
             await manager.WaitForState (TorrentState.Seeding);
@@ -87,7 +87,7 @@ namespace MonoTorrent.Streaming
         {
             var manager = await Engine.AddStreamingAsync (Torrent, "test");
             await manager.LoadFastResumeAsync (new FastResume (manager.InfoHashes, new BitField (manager.Torrent.PieceCount ()).SetAll (true), new BitField (manager.Torrent.PieceCount ())));
-            PieceWriter.FilesThatExist.AddRange (manager.Files);
+            await PieceWriter.CreateAsync (manager.Files);
 
             await manager.StartAsync ();
             await manager.WaitForState (TorrentState.Seeding);
@@ -103,7 +103,7 @@ namespace MonoTorrent.Streaming
         {
             var manager = await Engine.AddStreamingAsync (Torrent, "testDir");
             await manager.LoadFastResumeAsync (new FastResume (manager.InfoHashes, new BitField (manager.Torrent.PieceCount ()).SetAll (true), new BitField (manager.Torrent.PieceCount ())));
-            PieceWriter.FilesThatExist.AddRange (manager.Files);
+            await PieceWriter.CreateAsync (manager.Files);
 
             await manager.StartAsync ();
             await manager.WaitForState (TorrentState.Seeding);
@@ -122,7 +122,7 @@ namespace MonoTorrent.Streaming
         {
             var manager = await Engine.AddStreamingAsync (Torrent, "testDir");
             await manager.LoadFastResumeAsync (new FastResume (manager.InfoHashes, new BitField (manager.Torrent.PieceCount ()).SetAll (true), new BitField (manager.Torrent.PieceCount ())));
-            PieceWriter.FilesThatExist.AddRange (manager.Files);
+            await PieceWriter.CreateAsync (manager.Files);
 
             await manager.StartAsync ();
             await manager.WaitForState (TorrentState.Seeding);
@@ -140,7 +140,7 @@ namespace MonoTorrent.Streaming
         {
             var manager = await Engine.AddStreamingAsync (Torrent, "testDir");
             await manager.LoadFastResumeAsync (new FastResume (manager.InfoHashes, new BitField (manager.Torrent.PieceCount ()).SetAll (true), new BitField (manager.Torrent.PieceCount ())));
-            PieceWriter.FilesThatExist.AddRange (manager.Files);
+            await PieceWriter.CreateAsync (manager.Files);
 
             await manager.StartAsync ();
             await manager.WaitForState (TorrentState.Seeding);
@@ -155,7 +155,7 @@ namespace MonoTorrent.Streaming
         {
             var manager = await Engine.AddStreamingAsync (Torrent, "testDir");
             await manager.LoadFastResumeAsync (new FastResume (manager.InfoHashes, new BitField (manager.Torrent.PieceCount ()).SetAll (true), new BitField (manager.Torrent.PieceCount ())));
-            PieceWriter.FilesThatExist.AddRange (manager.Files);
+            await PieceWriter.CreateAsync (manager.Files);
 
             await manager.StartAsync ();
             await manager.WaitForState (TorrentState.Seeding);
@@ -169,7 +169,7 @@ namespace MonoTorrent.Streaming
         {
             var manager = await Engine.AddStreamingAsync (Torrent, "testDir");
             await manager.LoadFastResumeAsync (new FastResume (manager.InfoHashes, new BitField (manager.Torrent.PieceCount ()).SetAll (true), new BitField (manager.Torrent.PieceCount ())));
-            PieceWriter.FilesThatExist.AddRange (manager.Files);
+            await PieceWriter.CreateAsync (manager.Files);
 
             await manager.StartAsync ();
             await manager.WaitForState (TorrentState.Seeding);
@@ -184,7 +184,7 @@ namespace MonoTorrent.Streaming
         {
             var manager = await Engine.AddStreamingAsync (Torrent, "testDir");
             await manager.LoadFastResumeAsync (new FastResume (manager.InfoHashes, new BitField (manager.Torrent.PieceCount ()).SetAll (true), new BitField (manager.Torrent.PieceCount ())));
-            PieceWriter.FilesThatExist.AddRange (manager.Files);
+            await PieceWriter.CreateAsync (manager.Files);
 
             Assert.ThrowsAsync<InvalidOperationException> (() => manager.StreamProvider.CreateHttpStreamAsync (manager.Files[0]));
         }
@@ -194,7 +194,7 @@ namespace MonoTorrent.Streaming
         {
             var manager = await Engine.AddStreamingAsync (Torrent, "testDir");
             await manager.LoadFastResumeAsync (new FastResume (manager.InfoHashes, new BitField (manager.Torrent.PieceCount ()).SetAll (true), new BitField (manager.Torrent.PieceCount ())));
-            PieceWriter.FilesThatExist.AddRange (manager.Files);
+            await PieceWriter.CreateAsync (manager.Files);
 
             await manager.StartAsync ();
             await manager.WaitForState (TorrentState.Seeding);

--- a/src/Tests/Tests.MonoTorrent.IntegrationTests/IntegrationTests_FakePieceWriter.cs
+++ b/src/Tests/Tests.MonoTorrent.IntegrationTests/IntegrationTests_FakePieceWriter.cs
@@ -106,6 +106,22 @@ namespace Tests.MonoTorrent.IntegrationTests
 
                 return default;
             }
+
+            public ReusableTask<long?> GetLengthAsync (ITorrentManagerFile file)
+            {
+                // pretend the file exists but is empty if leeching
+                return ReusableTask.FromResult<long?> (IsSeeder ? file.Length : 0);
+            }
+
+            public ReusableTask<bool> SetLengthAsync (ITorrentManagerFile file, long length)
+            {
+                throw new NotImplementedException ();
+            }
+
+            public ReusableTask<bool> CreateAsync (ITorrentManagerFile file, FileCreationOptions options)
+            {
+                throw new NotImplementedException ();
+            }
         }
 
         class CustomTorrentFileSource : ITorrentFileSource

--- a/src/Tests/Tests.MonoTorrent.PieceWriter/DiskWriterTests.cs
+++ b/src/Tests/Tests.MonoTorrent.PieceWriter/DiskWriterTests.cs
@@ -123,10 +123,10 @@ namespace MonoTorrent.PieceWriter
             using (var file = new FileStream (TorrentFile.FullPath, FileMode.OpenOrCreate))
                 file.Write (new byte[TorrentFile.Length + 1]);
 
-            // This should implicitly truncate.
+            // File truncating only happens when starting a torrent in order to seed or leech it. It does not happen during hashchecking
             using var writer = new DiskWriter ();
             await writer.WriteAsync (TorrentFile, 0, new byte[12]);
-            Assert.AreEqual (TorrentFile.Length, new FileInfo (TorrentFile.FullPath).Length);
+            Assert.AreEqual (TorrentFile.Length + 1, new FileInfo (TorrentFile.FullPath).Length);
         }
 
         [Test]

--- a/src/Tests/Tests.MonoTorrent.PieceWriter/MemoryCacheTests.cs
+++ b/src/Tests/Tests.MonoTorrent.PieceWriter/MemoryCacheTests.cs
@@ -58,6 +58,11 @@ namespace MonoTorrent.PieceWriter
             return ReusableTask.CompletedTask;
         }
 
+        public ReusableTask<bool> CreateAsync (ITorrentManagerFile file, FileCreationOptions options)
+        {
+            throw new NotImplementedException ();
+        }
+
         public void Dispose ()
         {
         }
@@ -72,6 +77,11 @@ namespace MonoTorrent.PieceWriter
         {
             Flushes.Add (file);
             return ReusableTask.CompletedTask;
+        }
+
+        public ReusableTask<long?> GetLengthAsync (ITorrentManagerFile file)
+        {
+            throw new NotSupportedException ();
         }
 
         public ReusableTask MoveAsync (ITorrentManagerFile file, string fullPath, bool overwrite)
@@ -93,6 +103,11 @@ namespace MonoTorrent.PieceWriter
             }
             Reads.Add ((file, offset, null));
             return ReusableTask.FromResult (0);
+        }
+
+        public ReusableTask<bool> SetLengthAsync (ITorrentManagerFile file, long length)
+        {
+            throw new NotSupportedException ();
         }
 
         public ReusableTask SetMaximumOpenFilesAsync (int maximumOpenFiles)

--- a/src/Tests/Tests.MonoTorrent.PieceWriter/NullWriter.cs
+++ b/src/Tests/Tests.MonoTorrent.PieceWriter/NullWriter.cs
@@ -43,6 +43,11 @@ namespace MonoTorrent.PieceWriter
             return ReusableTask.CompletedTask;
         }
 
+        public ReusableTask<bool> CreateAsync (ITorrentManagerFile file, FileCreationOptions options)
+        {
+            throw new NotImplementedException ();
+        }
+
         public void Dispose ()
         {
         }
@@ -57,6 +62,11 @@ namespace MonoTorrent.PieceWriter
             return ReusableTask.CompletedTask;
         }
 
+        public ReusableTask<long?> GetLengthAsync (ITorrentManagerFile file)
+        {
+            return ReusableTask.FromResult<long?> (null);
+        }
+
         public ReusableTask MoveAsync (ITorrentManagerFile file, string fullPath, bool overwrite)
         {
             return ReusableTask.CompletedTask;
@@ -67,6 +77,11 @@ namespace MonoTorrent.PieceWriter
             return ReusableTask.FromResult (0);
         }
 
+        public ReusableTask SetLengthAsync (ITorrentManagerFile file, long length)
+        {
+            throw new NotImplementedException ();
+        }
+
         public ReusableTask SetMaximumOpenFilesAsync (int maximumOpenFiles)
         {
             return ReusableTask.CompletedTask;
@@ -75,6 +90,11 @@ namespace MonoTorrent.PieceWriter
         public ReusableTask WriteAsync (ITorrentManagerFile file, long offset, ReadOnlyMemory<byte> buffer)
         {
             return ReusableTask.CompletedTask;
+        }
+
+        ReusableTask<bool> IPieceWriter.SetLengthAsync (ITorrentManagerFile file, long length)
+        {
+            throw new NotImplementedException ();
         }
     }
 }


### PR DESCRIPTION
The original implementation had some conveniences which are not great in certain circumstances. The DiskManager implementation would do it's utmost to ensure files were always the correct size/length, and that zero length files always existed on disk.

This is fine *except* if someone wishes to check if a particular file matches a particular hash - in this scenario, while they simply wanted to see if there was a match, the act of running the hashcheck would also truncate the file if it were too large.

Now the engine doesn't do this, and `TorrentManager.HashCheckAsync` neither truncates, nor creates zero length files.

If someone takes the step of actually calling `TorrentManager.StartAsync`, this is a clear sign they *really do* want to download the torrent, and at that point zero length files will be created, and existing files will be truncated if they are too large. This operation occurs only during the 'Starting' phase, prior to enter 'Downloading' or 'Seeding'. This makes things a little easier to reason about :) 

However, to support this in the optimal way additional methods need to be added to some of the interfaces used for IO, such as a get/set length method.