### PR TITLE
Disambiguate between v1 and v2 connections more clearly

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/PieceHashesMode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/PieceHashesMode.cs
@@ -165,6 +165,13 @@ namespace MonoTorrent.Client.Modes
             foreach (var peer in Manager.Peers.ConnectedPeers) {
                 if (IgnoredPeers.Contains (peer))
                     continue;
+
+                // Never request data from peers who do not have a BEP52 connection.
+                if (peer.ExpectedInfoHash != Manager.InfoHashes.V2) {
+                    IgnoredPeers.Add (peer);
+                    continue;
+                }
+
                 foreach (var picker in pickers) {
                     if (!picker.Value.Item2.ValidatedPieces.AllTrue)
                         picker.Value.Item1.AddRequests (picker.Value.Item2.Wrap (peer), picker.Value.Item2.AvailablePieces, Array.Empty<ReadOnlyBitField> ());

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/ConnectionManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/ConnectionManager.cs
@@ -197,8 +197,12 @@ namespace MonoTorrent.Client
             Interlocked.Increment (ref openConnections);
 
             try {
+                // If this is a hybrid torrent and a connection is being made with the v1 infohash, then
+                // set the bit which tells the peer the connection can be upgraded to a bittorrent v2 (BEP52) connection.
+                var canUpgradeToV2 = manager.InfoHashes.IsHybrid && id.ExpectedInfoHash == manager.InfoHashes.V1;
+
                 // Create a handshake message to send to the peer
-                var handshake = new HandshakeMessage (id.ExpectedInfoHash.Truncate (), LocalPeerId, Constants.ProtocolStringV100);
+                var handshake = new HandshakeMessage (id.ExpectedInfoHash.Truncate (), LocalPeerId, Constants.ProtocolStringV100, enableFastPeer: true, enableExtended: true, supportsUpgradeToV2: true);
                 logger.InfoFormatted (id.Connection, "[outgoing] Sending handshake message with peer id '{0}'", LocalPeerId);
 
                 var preferredEncryption = EncryptionTypes.GetPreferredEncryption (id.Peer.AllowedEncryption, Settings.AllowedEncryption);

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -881,7 +881,7 @@ namespace MonoTorrent.Client
             if (peerInfo is null)
                 throw new ArgumentNullException (nameof (peerInfo));
 
-            var peer = new Peer (peerInfo, infoHash) {
+            var peer = new Peer (peerInfo, InfoHashes.Expand (infoHash)) {
                 IsSeeder = peerInfo.MaybeSeeder,
             };
 

--- a/src/Tests/Tests.MonoTorrent.IntegrationTests/IntegrationTests_RealPieceWriter.cs
+++ b/src/Tests/Tests.MonoTorrent.IntegrationTests/IntegrationTests_RealPieceWriter.cs
@@ -147,6 +147,14 @@ namespace MonoTorrent.IntegrationTests
         [Test]
         public async Task DownloadFileInTorrent_V1V2 () => await CreateAndDownloadTorrent (TorrentType.V1V2Hybrid, createEmptyFile: false, explitlyHashCheck: false);
 
+        // 100 byte files will not have a 'layers' key as there's only 1 piece.
+        [Test]
+        public async Task DownloadFileInTorrent_V1V2_MagnetLink_NoLayers () => await CreateAndDownloadTorrent (TorrentType.V1V2Hybrid, createEmptyFile: false, explitlyHashCheck: false, magnetLinkLeecher: true, fileSize: 100);
+
+        // 5MB files will have a 'layers' key as there will be many pieces.
+        [Test]
+        public async Task DownloadFileInTorrent_V1V2_MagnetLinkWithLayers () => await CreateAndDownloadTorrent (TorrentType.V1V2Hybrid, createEmptyFile: false, explitlyHashCheck: false, magnetLinkLeecher: true, fileSize: 5 * 1024 * 1024);
+
         [Test]
         public async Task DownloadEmptyFileInTorrent_V1 () => await CreateAndDownloadTorrent (TorrentType.V1Only, createEmptyFile: true, explitlyHashCheck: false);
 


### PR DESCRIPTION
As per BEP52 - if a connection is initiated with the V1 infohash and the relevant reserved bit is set, respond with the V2 infohash to upgrade the connection to 'V2' mode. This makes it unambiguous as to whether or not a given peer supports BEP52.

More importantly, the 'ExpectedInfoHash' property is now the clear indicator as to whether a given peer supports BEP52 or not, as it will always be set to the V2 infohash *if* the peer supports V2 torrents.

This means peers supporting v1 only can be filtered out when requesting piecelayers from other V2 peers.