### PR TITLE
Expose IPeerConnectionListeners publicly

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Client/ClientEngine.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/ClientEngine.cs
@@ -236,7 +236,7 @@ namespace MonoTorrent.Client
         /// A readonly list of the listeners which the engine is using to receive incoming connections from other peers.
         /// This are created by passing <see cref="EngineSettings.ListenEndPoints"/> to the <see cref="Factories.CreatePeerConnectionListener(IPEndPoint)"/> factory method.
         /// </summary>
-        public IList<IPeerConnectionListener> PeerListeners { get; set; } = Array.Empty<IPeerConnectionListener> ();
+        public IList<IPeerConnectionListener> PeerListeners { get; private set; } = Array.Empty<IPeerConnectionListener> ();
 
         internal ILocalPeerDiscovery LocalPeerDiscovery { get; private set; }
 

--- a/src/MonoTorrent.Client/MonoTorrent.Client/ClientEngine.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/ClientEngine.cs
@@ -231,7 +231,12 @@ namespace MonoTorrent.Client
 
         internal Factories Factories { get; }
 
-        internal IList<IPeerConnectionListener> PeerListeners { get; set; } = Array.Empty<IPeerConnectionListener> ();
+
+        /// <summary>
+        /// A readonly list of the listeners which the engine is using to receive incoming connections from other peers.
+        /// This are created by passing <see cref="EngineSettings.ListenEndPoints"/> to the <see cref="Factories.CreatePeerConnectionListener(IPEndPoint)"/> factory method.
+        /// </summary>
+        public IList<IPeerConnectionListener> PeerListeners { get; set; } = Array.Empty<IPeerConnectionListener> ();
 
         internal ILocalPeerDiscovery LocalPeerDiscovery { get; private set; }
 

--- a/src/MonoTorrent/MonoTorrent.Connections.Peer/IPeerConnectionListener.cs
+++ b/src/MonoTorrent/MonoTorrent.Connections.Peer/IPeerConnectionListener.cs
@@ -35,14 +35,14 @@ namespace MonoTorrent.Connections.Peer
     public interface IPeerConnectionListener : IListener
     {
         /// <summary>
-        /// The EndPoint to which the Listener is bound.
+        /// The EndPoint to which the Listener is bound. This is null when the listener is not in the <see cref="ListenerStatus.Listening"/> state.
         /// </summary>
         IPEndPoint? LocalEndPoint { get; }
 
         /// <summary>
         /// The EndPoint to which the Listener will attempt to be bound. If the preferred endpoint has it's port set to 0, then
         /// the actual port the listener is bound to will be set in the <see cref="LocalEndPoint"/> property after <see cref="IListener.Start"/>
-        /// has been invoked.
+        /// has been invoked and the listener enters the <see cref="ListenerStatus.Listening"/> state.
         /// </summary>
         IPEndPoint PreferredLocalEndPoint { get; }
 


### PR DESCRIPTION
This makes it easier for everyone to determine which specific local ports are bound when '0' is used as the preferred port.