### PR TITLE
Remove the internal feature flags to disable BitTorrent V2 support

### DIFF
--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/TorrentTest.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/TorrentTest.cs
@@ -472,13 +472,7 @@ namespace MonoTorrent.Common
         [Test]
         public void V1InfoHashOnly ()
         {
-            (bool before1, bool before2) = (Torrent.SupportsV1V2Torrents, Torrent.SupportsV2Torrents);
-            (Torrent.SupportsV1V2Torrents, Torrent.SupportsV2Torrents) = (true, true);
-            try {
-                Assert.IsNull (Torrent.Load (torrentInfo).InfoHashes.V2);
-            } finally {
-                (Torrent.SupportsV1V2Torrents, Torrent.SupportsV2Torrents) = (before1, before2);
-            }
+            Assert.IsNull (Torrent.Load (torrentInfo).InfoHashes.V2);
         }
 
         [Test]

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/TorrentV2Test.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/TorrentV2Test.cs
@@ -54,22 +54,8 @@ namespace MonoTorrent.Common
         [OneTimeSetUp]
         public void FixtureSetup ()
         {
-            Torrent.SupportsV2Torrents = true;
             HybridTorrent = Torrent.Load (HybridTorrentPath);
             V2OnlyTorrent = Torrent.Load (V2OnlyTorrentPath);
-            Torrent.SupportsV2Torrents = false;
-        }
-
-        [SetUp]
-        public void Setup ()
-        {
-            Torrent.SupportsV2Torrents = true;
-        }
-
-        [TearDown]
-        public void Teardown ()
-        {
-            Torrent.SupportsV2Torrents = false;
         }
 
         [Test]
@@ -98,24 +84,6 @@ namespace MonoTorrent.Common
 
             var hash = Enumerable.Repeat ((byte) 'a', 32).ToArray ().AsMemory ();
             Assert.IsTrue (hash.Span.SequenceEqual (file.PiecesRoot.Span));
-        }
-
-        [Test]
-        public void LoadingMetadataVersion2FailsBEP52Unsupported ()
-        {
-            Torrent.SupportsV2Torrents = false;
-
-            var dict = (BEncodedDictionary) BEncodedValue.Decode (Encoding.UTF8.GetBytes ("d4:infod9:file treed4:dir1d4:dir2d9:fileA.txtd0:d6:lengthi1024e11:pieces root32:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeeeee12:meta versioni2e12:piece lengthi16382eee"));
-            Assert.Throws<TorrentException> (() => Torrent.Load (dict));
-        }
-
-        [Test]
-        public void LoadingFileTreesFailsWhenBEP52Unsupported ()
-        {
-            Torrent.SupportsV2Torrents = false;
-
-            var dict = (BEncodedDictionary) BEncodedValue.Decode (Encoding.UTF8.GetBytes ("d4:infod9:file treed4:dir1d4:dir2d9:fileA.txtd0:d6:lengthi1024e11:pieces root32:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaeeeee12:piece lengthi16382eee"));
-            Assert.Throws<TorrentException> (() => Torrent.Load (dict));
         }
 
         [Test]


### PR DESCRIPTION
These were useful during initial implementation, but it's ok to remove them now. They'll always be on.