### PR TITLE
Add logging for incoming connections

### DIFF
--- a/src/Logger.cs
+++ b/src/Logger.cs
@@ -136,6 +136,12 @@ namespace MonoTorrent.Logging
                 Writer.Error (string.Format ("{0}{1}{2}", message, Environment.NewLine, ex));
         }
 
+        internal void Exception (IPeerConnection connection, Exception ex, string message)
+        {
+            if (Writer != null)
+                Writer.Error ($"{connection.Uri}: {message}{Environment.NewLine}{ex}");
+        }
+
         internal void ExceptionFormated (Exception ex, string formatString, object p1)
         {
             if (Writer != null)


### PR DESCRIPTION
I believe one of the integration tests is racing in CI as there's no explicit 'wait until ready' when starting the 'Leecher' download. As such, the seeder is nearly definitely initiating connections before the leecher is finished starting.