### PR TITLE
Treat peers as 'connecting' until the handshake completes

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/ListenManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/ListenManager.cs
@@ -100,14 +100,14 @@ namespace MonoTorrent.Client
                 if (!e.Connection.IsIncoming) {
                     var manager = Engine.Torrents.First (t => t.InfoHashes.Contains (e.InfoHash!));
                     var peer = new Peer (peerInfo);
-                    Engine.ConnectionManager.ProcessNewOutgoingConnection (manager, peer, e.Connection);
+                    await Engine.ConnectionManager.ProcessNewOutgoingConnection (manager, peer, e.Connection);
                     return;
                 }
 
                 logger.Info (e.Connection, "ConnectionReceived");
 
                 var supportedEncryptions = Engine.Settings.AllowedEncryption;
-                EncryptorFactory.EncryptorResult result = await EncryptorFactory.CheckIncomingConnectionAsync (e.Connection, supportedEncryptions, SKeys, Engine.Factories);
+                EncryptorFactory.EncryptorResult result = await EncryptorFactory.CheckIncomingConnectionAsync (e.Connection, supportedEncryptions, SKeys, Engine.Factories, Engine.Settings.ConnectionTimeout);
                 if (!await HandleHandshake (peerInfo, e.Connection, result.Handshake!, result.Decryptor, result.Encryptor))
                     e.Connection.Dispose ();
             } catch (Exception ex) {

--- a/src/MonoTorrent.Client/MonoTorrent.Connections.Peer.Encryption/EncryptorFactory.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Connections.Peer.Encryption/EncryptorFactory.cs
@@ -55,14 +55,12 @@ namespace MonoTorrent.Connections.Peer.Encryption
             }
         }
 
-        static TimeSpan Timeout => Debugger.IsAttached ? TimeSpan.FromHours (1) : TimeSpan.FromSeconds (10);
-
-        internal static async ReusableTask<EncryptorResult> CheckIncomingConnectionAsync (IPeerConnection connection, IList<EncryptionType> allowedEncryption, InfoHash[] sKeys, Factories factories)
+        internal static async ReusableTask<EncryptorResult> CheckIncomingConnectionAsync (IPeerConnection connection, IList<EncryptionType> allowedEncryption, InfoHash[] sKeys, Factories factories, TimeSpan timeout)
         {
             if (!connection.IsIncoming)
                 throw new Exception ("oops");
 
-            using var cts = new CancellationTokenSource (Timeout);
+            using var cts = new CancellationTokenSource (timeout);
             using CancellationTokenRegistration registration = cts.Token.Register (connection.Dispose);
             return await DoCheckIncomingConnectionAsync (connection, allowedEncryption, sKeys, factories).ConfigureAwait (false);
         }
@@ -114,12 +112,12 @@ namespace MonoTorrent.Connections.Peer.Encryption
             throw new EncryptionException ("Invalid handshake received and no decryption works");
         }
 
-        internal static async ReusableTask<EncryptorResult> CheckOutgoingConnectionAsync (IPeerConnection connection, IList<EncryptionType> allowedEncryption, InfoHash infoHash, HandshakeMessage handshake, Factories factories)
+        internal static async ReusableTask<EncryptorResult> CheckOutgoingConnectionAsync (IPeerConnection connection, IList<EncryptionType> allowedEncryption, InfoHash infoHash, HandshakeMessage handshake, Factories factories, TimeSpan timeout)
         {
             if (connection.IsIncoming)
                 throw new Exception ("oops");
 
-            using var cts = new CancellationTokenSource (Timeout);
+            using var cts = new CancellationTokenSource (timeout);
             using CancellationTokenRegistration registration = cts.Token.Register (connection.Dispose);
             return await DoCheckOutgoingConnectionAsync (connection, allowedEncryption, infoHash, handshake, factories).ConfigureAwait (false);
         }

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/MetadataModeTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/MetadataModeTests.cs
@@ -71,7 +71,7 @@ namespace MonoTorrent.Client.Modes
             var connection = pair.Incoming;
             PeerId id = new PeerId (new Peer (new PeerInfo (connection.Uri)), connection, new BitField (rig.Torrent.PieceCount), rig.Manager.InfoHashes.V1OrV2);
 
-            var result = await EncryptorFactory.CheckIncomingConnectionAsync (id.Connection, id.Peer.AllowedEncryption, new[] { rig.Manager.InfoHashes.V1OrV2 }, Factories.Default);
+            var result = await EncryptorFactory.CheckIncomingConnectionAsync (id.Connection, id.Peer.AllowedEncryption, new[] { rig.Manager.InfoHashes.V1OrV2 }, Factories.Default, TaskExtensions.Timeout);
             decryptor = id.Decryptor = result.Decryptor;
             encryptor = id.Encryptor = result.Encryptor;
         }

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/ConnectionManagerTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/ConnectionManagerTests.cs
@@ -1,7 +1,17 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
 using System.Threading.Tasks;
 
+using MonoTorrent.Client.Modes;
+using MonoTorrent.Connections;
+using MonoTorrent.Connections.Peer;
+using MonoTorrent.Messages.Peer;
+
 using NUnit.Framework;
+
+using ReusableTasks;
 
 namespace MonoTorrent.Client
 {
@@ -32,6 +42,119 @@ namespace MonoTorrent.Client
             Assert.AreEqual (torrents[1], manager.Torrents[0]);
             Assert.AreEqual (torrents[2], manager.Torrents[1]);
             Assert.AreEqual (torrents[0], manager.Torrents[2]);
+        }
+
+        class FakeConnection : IPeerConnection
+        {
+            public ReadOnlyMemory<byte> AddressBytes { get; }
+            public bool CanReconnect { get; }
+            public bool Disposed { get; private set; }
+            public IPEndPoint EndPoint { get; }
+            public bool IsIncoming { get; }
+            public Uri Uri { get; }
+
+            public FakeConnection (Uri uri)
+                => Uri = uri;
+
+            public ReusableTaskCompletionSource<bool> ConnectAsyncInvokedTask = new ReusableTaskCompletionSource<bool> ();
+            public ReusableTaskCompletionSource<bool> ConnectAsyncResultTask = new ReusableTaskCompletionSource<bool> ();
+            public async ReusableTask ConnectAsync ()
+            {
+                ConnectAsyncInvokedTask.SetResult (true);
+                await ConnectAsyncResultTask.Task;
+            }
+
+            public TaskCompletionSource<bool> DisposeAsyncInvokedTask = new TaskCompletionSource<bool> ();
+            public void Dispose ()
+            {
+                TestContext.Out.WriteLine (Environment.StackTrace);
+                Disposed = true;
+                ConnectAsyncResultTask.SetException (new SocketException ((int) SocketError.ConnectionAborted));
+                DisposeAsyncInvokedTask.SetResult (true);
+            }
+
+            public ReusableTaskCompletionSource<Memory<byte>> ReceiveAsyncInvokedTask = new ReusableTaskCompletionSource<Memory<byte>> ();
+            public ReusableTaskCompletionSource<int> ReceiveAsyncResultTask = new ReusableTaskCompletionSource<int> ();
+            public async ReusableTask<int> ReceiveAsync (Memory<byte> buffer)
+            {
+                ReceiveAsyncInvokedTask.SetResult (buffer);
+                return await ReceiveAsyncResultTask.Task;
+            }
+
+            public ReusableTaskCompletionSource<Memory<byte>> SendAsyncInvokedTask = new ReusableTaskCompletionSource<Memory<byte>> ();
+            public ReusableTaskCompletionSource<int> SendAsyncResultTask = new ReusableTaskCompletionSource<int> ();
+            public async ReusableTask<int> SendAsync (Memory<byte> buffer)
+            {
+                SendAsyncInvokedTask.SetResult (buffer);
+                return await SendAsyncResultTask.Task;
+            }
+        }
+
+        [Test]
+        public async Task CancelPending_WaitingForConnect ()
+        {
+            var fake = new FakeConnection (new Uri ("ipv4://1.2.3.4:56789"));
+            var engine = EngineHelpers.Create (
+                EngineHelpers.CreateSettings (),
+                EngineHelpers.Factories.WithPeerConnectionCreator ("ipv4", t => fake)
+            );
+
+            var connectionManager = new ConnectionManager ("test", engine.Settings, engine.Factories, engine.DiskManager);
+
+            var manager = await engine.AddAsync (new MagnetLink (new InfoHash (Enumerable.Repeat ((byte) 0, 20).ToArray ())), "tmp");
+            manager.Mode = new MetadataMode (manager, engine.DiskManager, connectionManager, engine.Settings, "");
+            manager.Peers.AvailablePeers.Add (PeerId.CreateNull (1, manager.InfoHashes.V1OrV2).Peer);
+            connectionManager.Add (manager);
+
+            await ClientEngine.MainLoop;
+
+            // Initiate a connection
+            connectionManager.TryConnect ();
+            await fake.ConnectAsyncInvokedTask.Task.WithTimeout ();
+
+            // Abort it while we're waiting for the connection to succeed.
+            connectionManager.CancelPendingConnects (manager);
+
+            // Make sure the connection was disposed.
+            await fake.DisposeAsyncInvokedTask.Task.WithTimeout ();
+            Assert.IsTrue (fake.Disposed);
+        }
+
+        [Test]
+        public async Task CancelPending_SendingHandshake ()
+        {
+            var fake = new FakeConnection (new Uri ("ipv4://1.2.3.4:56789"));
+            var builder = new EngineSettingsBuilder (EngineHelpers.CreateSettings ());
+            builder.ConnectionTimeout = TimeSpan.FromHours (1);
+            var engine = EngineHelpers.Create (
+                builder.ToSettings (),
+                EngineHelpers.Factories.WithPeerConnectionCreator ("ipv4",t => {
+                    return fake;
+                })
+            );
+
+            var connectionManager = new ConnectionManager ("test", engine.Settings, engine.Factories, engine.DiskManager);
+
+            var manager = await engine.AddAsync (new MagnetLink (new InfoHash (Enumerable.Repeat ((byte) 0, 20).ToArray ())), "tmp");
+            manager.Mode = new MetadataMode (manager, engine.DiskManager, connectionManager, engine.Settings, "");
+            manager.Peers.AvailablePeers.Add (new Peer (new PeerInfo (fake.Uri), new[] { EncryptionType.PlainText }));
+            connectionManager.Add (manager);
+
+            await ClientEngine.MainLoop;
+
+            // Initiate a connection and allow it to succeed
+            connectionManager.TryConnect ();
+            await fake.ConnectAsyncInvokedTask.Task.WithTimeout ();
+            fake.ConnectAsyncResultTask.SetResult (true);
+
+            // Handshake should be sent.
+            var data = await fake.SendAsyncInvokedTask.Task.WithTimeout ();
+            var message = new HandshakeMessage (data.Span);
+            Assert.AreEqual (message.ProtocolString, Constants.ProtocolStringV100);
+
+            connectionManager.CancelPendingConnects (manager);
+            await fake.DisposeAsyncInvokedTask.Task.WithTimeout ();
+            Assert.IsTrue (fake.Disposed);
         }
     }
 }

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/EncryptorFactoryTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/EncryptorFactoryTests.cs
@@ -166,8 +166,8 @@ namespace MonoTorrent.Client.Encryption
             var handshakeIn = new HandshakeMessage (InfoHash, IncomingId, Constants.ProtocolStringV100);
             var handshakeOut = new HandshakeMessage (InfoHash, OutgoingId, Constants.ProtocolStringV100);
 
-            var incomingTask = EncryptorFactory.CheckIncomingConnectionAsync (Incoming, incomingEncryption, SKeys, Factories.Default);
-            var outgoingTask = EncryptorFactory.CheckOutgoingConnectionAsync (Outgoing, outgoingEncryption, InfoHash, appendInitialPayload ? handshakeOut : null, Factories.Default);
+            var incomingTask = EncryptorFactory.CheckIncomingConnectionAsync (Incoming, incomingEncryption, SKeys, Factories.Default, TaskExtensions.Timeout);
+            var outgoingTask = EncryptorFactory.CheckOutgoingConnectionAsync (Outgoing, outgoingEncryption, InfoHash, appendInitialPayload ? handshakeOut : null, Factories.Default, TaskExtensions.Timeout);
 
             // If the handshake was not part of the initial payload, send it now.
             var outgoingCrypto = await outgoingTask;


### PR DESCRIPTION
We allow up to 'Timeout' seconds to establish a connection. We now also allow an additional 'Timeout' seconds for the handshake to complete before the connection is discarded.

A recent change made it so that peers who are in the handshaking phase are no longer counted as 'connected', so the timeout which disconnects peers who don't send messages within a reasonable amount of time doesn't apply, and prior to this commit the connection timeout only applied to the actual Socket.Connect.