### PR TITLE
Restructure how peer connection retries are executed

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/DownloadMode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/DownloadMode.cs
@@ -65,7 +65,7 @@ namespace MonoTorrent.Client.Modes
         public override bool ShouldConnect (Peer peer)
         {
             return !(peer.IsSeeder && Manager.HasMetadata && Manager.Complete)
-                && peer.LastConnectionAttempt.Elapsed >= Settings.ConnectionRetryDelay (peer.FailedConnectionAttempts);
+                && base.ShouldConnect (peer);
         }
 
         public override void Tick (int counter)

--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/Mode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/Mode.cs
@@ -217,7 +217,7 @@ namespace MonoTorrent.Client.Modes
 
         public virtual bool ShouldConnect (Peer peer)
         {
-            return true;
+            return peer.LastConnectionAttempt.Elapsed >= Settings.GetConnectionRetryDelay (peer.FailedConnectionAttempts);
         }
 
         protected virtual void HandleGenericExtensionMessage (PeerId id, ExtensionMessage extensionMessage)

--- a/src/MonoTorrent.Client/MonoTorrent.Client/ConnectionFailureReason.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/ConnectionFailureReason.cs
@@ -40,6 +40,11 @@ namespace MonoTorrent.Client
         Unreachable,
 
         /// <summary>
+        /// No compatible IPeerConnection could be instantiated by the <see cref="Factories.CreatePeerConnection(System.Uri)"/> method.
+        /// </summary>
+        UnknownUriSchema,
+
+        /// <summary>
         /// After accepting the connection, a compatible connection encryption method could not
         /// be selected. Alternatively the remote peer could have reached it's open connection
         /// limit and simply closed the connection, or it could mean the peer did not support

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/ListenManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/ListenManager.cs
@@ -100,7 +100,10 @@ namespace MonoTorrent.Client
                 if (!e.Connection.IsIncoming) {
                     var manager = Engine.Torrents.First (t => t.InfoHashes.Contains (e.InfoHash!));
                     var peer = new Peer (peerInfo);
-                    await Engine.ConnectionManager.ProcessNewOutgoingConnection (manager, peer, e.Connection);
+                    // FIXME: THis is a hack to inject connections into the engine. Kill the hack, and then we don't have to hardcode that this
+                    // always uses tier[0].
+                    // This is only used for tests, so it's fine.
+                    await Engine.ConnectionManager.ProcessNewOutgoingConnection (manager, peer, e.Connection, Engine.Settings.OutgoingConnectionEncryptionTiers[0]);
                     return;
                 }
 

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/PeerExchangeManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/PeerExchangeManager.cs
@@ -135,7 +135,10 @@ namespace MonoTorrent.Client
                 if (!peer.Peer.TryWriteCompactPeer (added.Span.Slice (i * stride, stride), out int written) || written != stride)
                     throw new NotSupportedException ();
 
-                if (EncryptionTypes.SupportsRC4 (peer.Peer.AllowedEncryption)) {
+                // FIXME: Decide whether to tell *other* peers if we believe *this* peer prefers encryption or not. I'm not sure
+                // how this particular decision can be made. We can't ask peers whether or not they prefer encryption, or just happened
+                // to use it because it's what the local monotorrent was configured to prefer/require.
+                if (peer.EncryptionType == EncryptionType.RC4Full || peer.EncryptionType == EncryptionType.RC4Header) {
                     addedDotF.Span[i] = 0x01;
                 } else {
                     addedDotF.Span[i] = 0x00;

--- a/src/MonoTorrent.Client/MonoTorrent.Client/PeerId.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/PeerId.cs
@@ -154,8 +154,6 @@ namespace MonoTorrent.Client
 
         public EncryptionType EncryptionType => Encryptor.EncryptionType;
 
-        public IList<EncryptionType> SupportedEncryptionTypes => Peer.AllowedEncryption;
-
         public bool IsChoking { get; internal set; }
         public bool IsConnected => !Disposed;
         public bool IsInterested { get; internal set; }

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Peers/Peer.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Peers/Peer.cs
@@ -44,11 +44,6 @@ namespace MonoTorrent.Client
         internal int CleanedUpCount { get; set; }
 
         /// <summary>
-        /// The list of encryption methods which can be used to connect to this peer.
-        /// </summary>
-        internal IList<EncryptionType> AllowedEncryption { get; set; }
-
-        /// <summary>
         /// The number of times we failed to establish an outgoing connection to this peer.
         /// </summary>
         internal int FailedConnectionAttempts { get; set; }
@@ -72,7 +67,7 @@ namespace MonoTorrent.Client
         /// </summary>
         internal bool MaybeStale { get; set; }
 
-        public PeerInfo Info { get; private set; }
+        internal PeerInfo Info { get; private set; }
 
         /// <summary>
         /// The number of times, in a row, that this peer has sent us the blocks for a piece and that
@@ -92,15 +87,8 @@ namespace MonoTorrent.Client
         internal ValueStopwatch LastConnectionAttempt;
 
         public Peer (PeerInfo peerInfo)
-            : this (peerInfo, EncryptionTypes.All)
-        {
-
-        }
-
-        public Peer (PeerInfo peerInfo, IList<EncryptionType> allowedEncryption)
         {
             Info = peerInfo ?? throw new ArgumentNullException (nameof (peerInfo));
-            AllowedEncryption = allowedEncryption ?? throw new ArgumentNullException (nameof (allowedEncryption));
         }
 
         public override bool Equals (object? obj)

--- a/src/Samples/SampleClient/StandardDownloader.cs
+++ b/src/Samples/SampleClient/StandardDownloader.cs
@@ -149,8 +149,7 @@ namespace ClientSample
                                                                                     p.Monitor.DownloadRate / 1024.0,
                                                                                     p.AmRequestingPiecesCount,
                                                                                     p.Monitor.UploadRate / 1024.0,
-                                                                                    p.EncryptionType,
-                                                                                    string.Join ("|", p.SupportedEncryptionTypes.Select (t => t.ToString ()).ToArray ()));
+                                                                                    p.EncryptionType);
                     }
                     AppendFormat (sb, "");
                     AppendFormat (sb, "Incoming:");
@@ -159,8 +158,7 @@ namespace ClientSample
                                                                                     p.Monitor.DownloadRate / 1024.0,
                                                                                     p.AmRequestingPiecesCount,
                                                                                     p.Monitor.UploadRate / 1024.0,
-                                                                                    p.EncryptionType,
-                                                                                    string.Join ("|", p.SupportedEncryptionTypes.Select (t => t.ToString ()).ToArray ()));
+                                                                                    p.EncryptionType);
                     }
 
                     AppendFormat (sb, "", null);

--- a/src/Samples/SampleClient/VLCStream.cs
+++ b/src/Samples/SampleClient/VLCStream.cs
@@ -132,8 +132,7 @@ namespace ClientSample
                                                                                             p.Monitor.DownloadRate / 1024.0,
                                                                                             p.AmRequestingPiecesCount,
                                                                                             p.Monitor.UploadRate / 1024.0,
-                                                                                            p.EncryptionType,
-                                                                                            string.Join ("|", p.SupportedEncryptionTypes.Select (t => t.ToString ()).ToArray ()));
+                                                                                            p.EncryptionType);
                             }
                             AppendFormat (sb, "");
                             AppendFormat (sb, "Incoming:");
@@ -142,8 +141,7 @@ namespace ClientSample
                                                                                             p.Monitor.DownloadRate / 1024.0,
                                                                                             p.AmRequestingPiecesCount,
                                                                                             p.Monitor.UploadRate / 1024.0,
-                                                                                            p.EncryptionType,
-                                                                                            string.Join ("|", p.SupportedEncryptionTypes.Select (t => t.ToString ()).ToArray ()));
+                                                                                            p.EncryptionType);
                             }
 
                             AppendFormat (sb, "", null);

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/MetadataModeTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/MetadataModeTests.cs
@@ -75,7 +75,7 @@ namespace MonoTorrent.Client.Modes
             var connection = pair.Incoming;
             PeerId id = new PeerId (new Peer (new PeerInfo (connection.Uri)), connection, new BitField (rig.Torrent.PieceCount), rig.Manager.InfoHashes.V1OrV2);
 
-            var result = await EncryptorFactory.CheckIncomingConnectionAsync (id.Connection, id.Peer.AllowedEncryption, new[] { rig.Manager.InfoHashes.V1OrV2 }, Factories.Default, TaskExtensions.Timeout);
+            var result = await EncryptorFactory.CheckIncomingConnectionAsync (id.Connection, rig.Engine.Settings.AllowedEncryption, new[] { rig.Manager.InfoHashes.V1OrV2 }, Factories.Default, TaskExtensions.Timeout);
             decryptor = id.Decryptor = result.Decryptor;
             encryptor = id.Encryptor = result.Encryptor;
         }


### PR DESCRIPTION
The library will now try every supported encryption method each time it attempts to establish a connection, and it'll try to establish a connection a fixed number of times before bailing out. Each (overall) retry will be spaced out in time in case the receiving client is temporarily busy or inaccessible.