### PR TITLE
Check and ban peer when accepting incoming connection

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/ConnectionManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/ConnectionManager.cs
@@ -443,6 +443,11 @@ namespace MonoTorrent.Client
                     CleanupSocket (manager, id);
                     return false;
                 }
+                if (ShouldBanPeer (id.Peer.Info)) {
+                    logger.Info (id.Connection, "Peer was banned");
+                    CleanupSocket (manager, id);
+                    return false;
+                }
 
                 // Add the PeerId to the lists *before* doing anything asynchronous. This ensures that
                 // all PeerIds are tracked in 'ConnectedPeers' as soon as they're created.

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -870,6 +870,23 @@ namespace MonoTorrent.Client
             }
         }
 
+        public async Task DisconnectPeerAsync (PeerId id)
+        {
+            await ClientEngine.MainLoop;
+            DisconnectPeer (id);
+        }
+
+        internal void DisconnectPeer (PeerId id)
+        {
+            if (id == null)
+                throw new ArgumentNullException (nameof (id));
+
+            if (Peers.ConnectedPeers.Contains (id)) {
+                Engine!.ConnectionManager.CleanupSocket (this, id);
+                Peers.ConnectedPeers.Remove (id);
+            }
+        }
+
         #endregion
 
 


### PR DESCRIPTION
### Description

The current implementation only checks if a peer should be banned during `TryConnect`. This PR adds a check using `ShouldBanPeer()` within the `IncomingConnectionAcceptedAsync()` method to ensure that peers are also evaluated for banning when an incoming connection is accepted.

### Changes

- Added `ShouldBanPeer()` check in `IncomingConnectionAcceptedAsync()`.

### Motivation

Enhancing the robustness of the peer banning mechanism by ensuring that peers are evaluated for banning not only during connection attempts but also when incoming connections are accepted.