### PR TITLE
Check and ban peer when accepting incoming connection

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Client/ConnectionFailureReason.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/ConnectionFailureReason.cs
@@ -68,6 +68,12 @@ namespace MonoTorrent.Client
         TooManyOpenConnections,
 
         /// <summary>
+        /// This peer has been banned. This can happen if the peer repeatedly sends data which fails a hashcheck, or it can happen if
+        /// the user of the library has used the <see cref="ConnectionManager.BanPeer"/> event to indicate the peer should be banned.
+        /// </summary>
+        Banned,
+
+        /// <summary>
         /// There is no clear reason why the connection attempt failed.
         /// </summary>
         Unknown,

--- a/src/MonoTorrent.Client/MonoTorrent.Client/EventArgs/AttemptConnectionEventArgs.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/EventArgs/AttemptConnectionEventArgs.cs
@@ -33,13 +33,22 @@ namespace MonoTorrent.Client
 {
     public class AttemptConnectionEventArgs : EventArgs
     {
+        /// <summary>
+        /// Set the boolean to true if the peer should be banned and the connection closed immediately.
+        /// Default is <see langword="false"/>, which allows the connection to remain open.
+        /// </summary>
         public bool BanPeer { get; set; }
 
         public PeerInfo Peer { get; }
 
+        public AttemptConnectionStage Stage { get; }
+
         public AttemptConnectionEventArgs (PeerInfo peer)
+            : this (peer, AttemptConnectionStage.BeforeConnectionEstablished)
         {
-            Peer = peer;
         }
+
+        public AttemptConnectionEventArgs (PeerInfo peer, AttemptConnectionStage stage)
+            => (Peer, Stage) = (peer, stage);
     }
 }

--- a/src/MonoTorrent.Client/MonoTorrent.Client/EventArgs/AttemptConnectionStage.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/EventArgs/AttemptConnectionStage.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MonoTorrent.Client
+{
+    /// <summary>
+    /// Peers can be banned at two points, when the connection has been opened, or after the handshakes have been transferred.
+    /// </summary>
+    public enum AttemptConnectionStage
+    {
+        /// <summary>
+        /// This is invoked before an outgoing connection attempt is made so peers can be discarded at the earliest point in time.
+        /// For incoming connections, this is invoked before any data is sent or received through the connection.
+        /// At this stage the only information available is the peers <see cref="PeerInfo.ConnectionUri"/>, which contains the
+        /// IP address and port of the remote peer.
+        /// </summary>
+        BeforeConnectionEstablished,
+
+        /// <summary>
+        /// At this stage both <see cref="PeerInfo.ConnectionUri"/> and <see cref="PeerInfo.PeerId"/> are known as the BitTorrent
+        /// handshakes have been exchanged.
+        /// </summary>
+        HandshakeComplete,
+    }
+}

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/ConnectionManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/ConnectionManager.cs
@@ -444,6 +444,11 @@ namespace MonoTorrent.Client
                     CleanupSocket (manager, id);
                     return false;
                 }
+                if (ShouldBanPeer (id.Peer.Info)) {
+                    logger.Info (id.Connection, "Peer was banned");
+                    CleanupSocket (manager, id);
+                    return false;
+                }
 
                 // Add the PeerId to the lists *before* doing anything asynchronous. This ensures that
                 // all PeerIds are tracked in 'ConnectedPeers' as soon as they're created.

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/ListenManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/ListenManager.cs
@@ -93,7 +93,7 @@ namespace MonoTorrent.Client
             await ClientEngine.MainLoop;
             var peerInfo = new PeerInfo (e.Connection.Uri);
             try {
-                if (Engine.ConnectionManager.ShouldBanPeer (peerInfo)) {
+                if (Engine.ConnectionManager.ShouldBanPeer (peerInfo, AttemptConnectionStage.BeforeConnectionEstablished)) {
                     e.Connection.Dispose ();
                     return;
                 }
@@ -163,13 +163,12 @@ namespace MonoTorrent.Client
 
             var id = new PeerId (peer, connection, new BitField (man.Bitfield.Length).SetAll (false), infoHash) {
                 Decryptor = decryptor,
-                Encryptor = encryptor
+                Encryptor = encryptor,
+                ClientApp = new Software (message.PeerId),
             };
 
             man.Mode.HandleMessage (id, message, default);
             logger.Info (id.Connection, "Handshake successful handled");
-
-            id.ClientApp = new Software (message.PeerId);
 
             return await Engine.ConnectionManager.IncomingConnectionAcceptedAsync (man, id);
         }

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/PeerManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/PeerManager.cs
@@ -38,7 +38,6 @@ namespace MonoTorrent.Client
 
         internal List<Peer> ActivePeers;
         internal List<Peer> AvailablePeers;
-        internal List<Peer> BannedPeers;
 
         /// <summary>
         /// The number of peers which are available to be connected to.
@@ -69,7 +68,6 @@ namespace MonoTorrent.Client
 
             ActivePeers = new List<Peer> ();
             AvailablePeers = new List<Peer> ();
-            BannedPeers = new List<Peer> ();
         }
 
         internal void ClearAll ()
@@ -79,14 +77,12 @@ namespace MonoTorrent.Client
 
             ActivePeers.Clear ();
             AvailablePeers.Clear ();
-            BannedPeers.Clear ();
         }
 
         internal bool Contains (Peer peer)
         {
             return ActivePeers.Contains (peer)
-                || AvailablePeers.Contains (peer)
-                || BannedPeers.Contains (peer);
+                || AvailablePeers.Contains (peer);
         }
 
         internal void UpdatePeerCounts ()


### PR DESCRIPTION
### Description

The current implementation only checks if a peer should be banned during `TryConnect`. This PR adds a check using `ShouldBanPeer()` within the `IncomingConnectionAcceptedAsync()` method to ensure that peers are also evaluated for banning when an incoming connection is accepted.

### Changes

- Added `ShouldBanPeer()` check in `IncomingConnectionAcceptedAsync()`.

### Motivation

Enhancing the robustness of the peer banning mechanism by ensuring that peers are evaluated for banning not only during connection attempts but also when incoming connections are accepted.