### PR TITLE
Handle PeerExchangeManager on the right thread

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/Mode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/Mode.cs
@@ -568,6 +568,10 @@ namespace MonoTorrent.Client.Modes
                 AppendFastPieces (id, bundle);
 
                 id.MessageQueue.Enqueue (bundle, releaser);
+
+                foreach (var peer in Manager.Peers.ConnectedPeers)
+                    if (peer != id && peer.PeerExchangeManager != null)
+                        peer.PeerExchangeManager.OnAdd (id);
             } else {
                 ConnectionManager.CleanupSocket (Manager, id);
             }
@@ -575,6 +579,10 @@ namespace MonoTorrent.Client.Modes
 
         public virtual void HandlePeerDisconnected (PeerId id)
         {
+            foreach (var peer in Manager.Peers.ConnectedPeers)
+                if (peer != id && peer.PeerExchangeManager != null)
+                    peer.PeerExchangeManager.OnDrop (id);
+
             Manager.RaisePeerDisconnected (id);
         }
 

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/IPeerExchangeSource.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/IPeerExchangeSource.cs
@@ -8,9 +8,6 @@ namespace MonoTorrent.Client
 {
     interface IPeerExchangeSource
     {
-        event EventHandler<PeerConnectedEventArgs> PeerConnected;
-        event EventHandler<PeerDisconnectedEventArgs> PeerDisconnected;
-
         TorrentSettings Settings { get; }
     }
 }

--- a/src/MonoTorrent.Client/MonoTorrent.Client/PeerId.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/PeerId.cs
@@ -240,7 +240,6 @@ namespace MonoTorrent.Client
             Disposed = true;
             Connection.SafeDispose ();
             MessageQueue.Dispose ();
-            PeerExchangeManager?.Dispose ();
         }
 
         public override string ToString ()

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/PeerExchangeManagerTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/PeerExchangeManagerTests.cs
@@ -15,27 +15,25 @@ namespace MonoTorrent.Client
         class PeerExchangeSource : IPeerExchangeSource
         {
             public TorrentSettings Settings { get; } = new TorrentSettings ();
-
-#pragma warning disable CS0067
-            public event EventHandler<PeerConnectedEventArgs> PeerConnected;
-            public event EventHandler<PeerDisconnectedEventArgs> PeerDisconnected;
-#pragma warning restore CS0067
         }
 
         byte counter = 0;
         PeerId CreatePeer () => PeerId.CreateNull (10, new InfoHash (Enumerable.Repeat<byte> (counter++, 20).ToArray ()));
 
         [Test]
-        public void TestPeerExchangeManager ()
+        public async Task TestPeerExchangeManager ()
         {
             var peer = CreatePeer ();
             var pex = new PeerExchangeManager (new PeerExchangeSource (), peer);
-            pex.OnAdd (null, new PeerConnectedEventArgs (null, CreatePeer ()));
-            pex.OnAdd (null, new PeerConnectedEventArgs (null, CreatePeer ()));
-            pex.OnAdd (null, new PeerConnectedEventArgs (null, CreatePeer ()));
-            pex.OnAdd (null, new PeerConnectedEventArgs (null, CreatePeer ()));
-            pex.OnDrop (null, new PeerDisconnectedEventArgs (null, CreatePeer ()));
-            pex.OnDrop (null, new PeerDisconnectedEventArgs (null, CreatePeer ()));
+
+            await ClientEngine.MainLoop;
+
+            pex.OnAdd (CreatePeer ());
+            pex.OnAdd (CreatePeer ());
+            pex.OnAdd (CreatePeer ());
+            pex.OnAdd (CreatePeer ());
+            pex.OnDrop (CreatePeer ());
+            pex.OnDrop (CreatePeer ());
 
             pex.OnTick ();
 


### PR DESCRIPTION
Rather than listening to the events, which are asynchronous, just call the PeerExchangeManager methods directly when a peer connects or disconnects. This ensures the methods are called on the main thread.

Probably fixes https://github.com/alanmcgovern/monotorrent/issues/695, where null reference exceptions are thrown when encoding peers in a peer exchange message.

One codepath/thread probably added/removed peers from the list and another thread did the same. This left things out of sync.