### PR TITLE
Better handling of incoming and outgoing connections

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/Mode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/Mode.cs
@@ -216,7 +216,8 @@ namespace MonoTorrent.Client.Modes
 
         public virtual bool ShouldConnect (Peer peer)
         {
-            return peer.LastConnectionAttempt.Elapsed >= Settings.GetConnectionRetryDelay (peer.FailedConnectionAttempts);
+            return peer.WaitUntilNextConnectionAttempt.Elapsed >= Settings.GetConnectionRetryDelay (peer.FailedConnectionAttempts)
+                && peer.WaitUntilNextConnectionAttempt.Elapsed >= Settings.GetConnectionRetryDelay (peer.CleanedUpCount);
         }
 
         protected virtual void HandleGenericExtensionMessage (PeerId id, ExtensionMessage extensionMessage)

--- a/src/MonoTorrent.Client/MonoTorrent.Client/ConnectionFailureReason.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/ConnectionFailureReason.cs
@@ -45,6 +45,12 @@ namespace MonoTorrent.Client
         UnknownUriSchema,
 
         /// <summary>
+        /// This peer has been banned. This can happen if the peer repeatedly sends data which fails a hashcheck, or it can happen if
+        /// the user of the library has used the <see cref="ConnectionManager.BanPeer"/> event to indicate the peer should be banned.
+        /// </summary>
+        ConnectedToSelf,
+
+        /// <summary>
         /// After accepting the connection, a compatible connection encryption method could not
         /// be selected. Alternatively the remote peer could have reached it's open connection
         /// limit and simply closed the connection, or it could mean the peer did not support

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/ConnectionManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/ConnectionManager.cs
@@ -145,7 +145,7 @@ namespace MonoTorrent.Client
             }
 
             // Always restart the the timer after the connection attempt completes
-            peer.LastConnectionAttempt.Restart ();
+            peer.WaitUntilNextConnectionAttempt.Restart ();
 
             // If the connection attempt failed, decide what to do next. Drop the peer or retry it later.
             if (failureReason.HasValue) {
@@ -441,6 +441,7 @@ namespace MonoTorrent.Client
             if (manager.Peers.ConnectedPeers.Remove (id))
                 Interlocked.Decrement (ref openConnections);
             id.Peer.CleanedUpCount++;
+            id.Peer.WaitUntilNextConnectionAttempt.Restart ();
 
             CleanupSocket (manager, id.Peer, id.Connection);
 
@@ -455,6 +456,7 @@ namespace MonoTorrent.Client
         internal void CleanupSocket (TorrentManager manager, Peer peer, IPeerConnection connection)
         {
             try {
+                logger.Info (connection, "Closing connection");
                 // We can reuse this peer if the connection says so and it's not marked as inactive
                 bool canReuse = (connection?.CanReconnect ?? false)
                     && !manager.InactivePeerManager.InactivePeerList.Contains (peer.Info.ConnectionUri)

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/ListenManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/ListenManager.cs
@@ -127,11 +127,6 @@ namespace MonoTorrent.Client
                 return false;
             }
 
-            if (Engine.PeerId.Equals (message.PeerId)) {
-                logger.Info (connection, "Unintentionally connected to self. Dropping connection...");
-                return false;
-            }
-
             // If we're forcing encrypted connections and this is in plain-text, close it!
             if (encryptor is PlainTextEncryption && !Engine.Settings.AllowedEncryption.Contains (EncryptionType.PlainText)) {
                 logger.Info (connection, "Connection is unencrypted and plain text connections are disabled via the engine Settings. Dropping connection...");

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/ListenManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/ListenManager.cs
@@ -153,21 +153,12 @@ namespace MonoTorrent.Client
                 return false;
             }
 
-            // If this is a hybrid torrent, and the other peer announced with the v1 hash *and* set the bit which indicates
-            // they can upgrade to a V2 connection, respond with the V2 hash to upgrade the connection to V2 mode.
-            var infoHash = message.SupportsUpgradeToV2 && man.InfoHashes.IsHybrid ? man.InfoHashes.V2! : man.InfoHashes.Expand (message.InfoHash);
             var peer = new Peer (peerInfo);
             peer.UpdatePeerId (message.PeerId);
 
-            logger.InfoFormatted (connection, "[incoming] Received handshake with peer_id '{0}'", message.PeerId);
+            logger.InfoFormatted (connection, "Received handshake with peer_id '{0}'", message.PeerId);
 
-            var id = new PeerId (peer, connection, new BitField (man.Bitfield.Length).SetAll (false), infoHash) {
-                Decryptor = decryptor,
-                Encryptor = encryptor,
-                ClientApp = new Software (message.PeerId),
-            };
-
-            man.Mode.HandleMessage (id, message, default);
+            var id = ConnectionManager.CreatePeerIdFromHandshake (message, peer, connection, man, encryptor: encryptor, decryptor: decryptor);
             logger.Info (id.Connection, "Handshake successful handled");
 
             return await Engine.ConnectionManager.IncomingConnectionAcceptedAsync (man, id);

--- a/src/MonoTorrent.Client/MonoTorrent.Client/PeerId.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/PeerId.cs
@@ -110,7 +110,14 @@ namespace MonoTorrent.Client
         /// <returns></returns>
         internal static PeerId CreateNull (int bitfieldLength, bool seeder, bool isChoking, bool amInterested, InfoHash expectedInfoHash)
         {
-            var peer = new PeerId (new Peer (new PeerInfo (new Uri ("ipv4://128.127.126.125:12345"), "null peer's id")), new NullPeerConnection () , new BitField (bitfieldLength).SetAll (seeder), expectedInfoHash) {
+            var peer = new PeerId (
+                new Peer (new PeerInfo (new Uri ("ipv4://128.127.126.125:12345"), "null peer's id")),
+                new NullPeerConnection (),
+                new BitField (bitfieldLength).SetAll (seeder),
+                expectedInfoHash,
+                PlainTextEncryption.Instance,
+                PlainTextEncryption.Instance,
+                new Software (BEncodedString.Empty)) {
                 IsChoking = isChoking,
                 AmChoking = true,
                 AmInterested = amInterested,
@@ -147,8 +154,8 @@ namespace MonoTorrent.Client
         public bool AmInterested { get; internal set; }
         public int AmRequestingPiecesCount { get; internal set; }
         public ReadOnlyBitField BitField => MutableBitField;
-        internal BitField MutableBitField { get; private set; }
-        public Software ClientApp { get; internal set; }
+        internal BitField MutableBitField { get; }
+        public Software ClientApp { get; }
 
         public Direction ConnectionDirection => Connection.IsIncoming ? Direction.Incoming : Direction.Outgoing;
 
@@ -175,20 +182,20 @@ namespace MonoTorrent.Client
         /// The remote peer can request these and we'll fulfill the request if we're choking them
         /// </summary>
         internal ReadOnlyMemory<int> AmAllowedFastPieces { get; set; }
-        internal IEncryption Decryptor { get; set; }
+        internal IEncryption Decryptor { get; }
         internal bool Disposed { get; private set; }
-        internal IEncryption Encryptor { get; set; }
+        internal IEncryption Encryptor { get; }
         internal ExtensionSupports ExtensionSupports { get; set; }
         /// <summary>
         /// This is the set of pieces we can request while choked.
         /// </summary>
-        internal List<int> IsAllowedFastPieces { get; set; }
+        internal List<int> IsAllowedFastPieces { get; }
         internal ValueStopwatch LastMessageReceived;
         internal ValueStopwatch LastMessageSent;
         internal ValueStopwatch WhenConnected;
         internal int MaxPendingRequests { get; set; }
         internal int MaxSupportedPendingRequests { get; set; }
-        internal MessageQueue MessageQueue { get; set; }
+        internal MessageQueue MessageQueue { get; }
         internal Peer Peer { get; }
         internal PeerExchangeManager? PeerExchangeManager { get; set; }
         internal ushort Port { get; set; }
@@ -198,10 +205,15 @@ namespace MonoTorrent.Client
 
         #region Constructors
 
-        internal PeerId (Peer peer, IPeerConnection connection, BitField bitfield, InfoHash expectedInfoHash)
+        internal PeerId (Peer peer, IPeerConnection connection, BitField bitfield, InfoHash expectedInfoHash, IEncryption encryptor, IEncryption decryptor, Software clientApp)
         {
-            Peer = peer;
+            Peer = peer ?? throw new ArgumentNullException (nameof (peer));
+            Connection = connection ?? throw new ArgumentNullException (nameof (connection));
+            MutableBitField = bitfield ?? throw new ArgumentNullException (nameof (bitfield));
             ExpectedInfoHash = expectedInfoHash ?? throw new ArgumentNullException (nameof (expectedInfoHash));
+            Encryptor = encryptor ?? throw new ArgumentNullException (nameof (encryptor));
+            Decryptor = decryptor ?? throw new ArgumentNullException (nameof (decryptor));
+            ClientApp = clientApp;
 
             AmChoking = true;
             IsChoking = true;
@@ -220,12 +232,6 @@ namespace MonoTorrent.Client
             Monitor = new ConnectionMonitor ();
 
             InitializeTyrant ();
-
-            Connection = connection ?? throw new ArgumentNullException (nameof (connection));
-            Peer = peer ?? throw new ArgumentNullException (nameof (peer));
-            MutableBitField = bitfield;
-            Decryptor = PlainTextEncryption.Instance;
-            Encryptor = PlainTextEncryption.Instance;
         }
 
         #endregion

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Peers/Peer.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Peers/Peer.cs
@@ -84,7 +84,7 @@ namespace MonoTorrent.Client
         /// <summary>
         /// The time since the last outgoing connection was attempted
         /// </summary>
-        internal ValueStopwatch LastConnectionAttempt;
+        internal ValueStopwatch WaitUntilNextConnectionAttempt;
 
         public Peer (PeerInfo peerInfo)
         {

--- a/src/MonoTorrent.Client/MonoTorrent/PeerID.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/PeerID.cs
@@ -110,6 +110,8 @@ namespace MonoTorrent
     /// </summary>
     public struct Software
     {
+        internal static Software Synthetic => new Software (new BEncodedString ("---- synthetic -----"));
+
         static readonly Regex bow = new Regex ("-BOWA");
         static readonly Regex brahms = new Regex ("M/d-/d-/d--");
         static readonly Regex bitlord = new Regex ("exbc..LORD");

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/HashingModeTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/HashingModeTests.cs
@@ -33,6 +33,7 @@ using System.Linq;
 using System.Threading.Tasks;
 
 using MonoTorrent.Connections;
+using MonoTorrent.Connections.Peer.Encryption;
 using MonoTorrent.Trackers;
 
 using NUnit.Framework;
@@ -75,7 +76,7 @@ namespace MonoTorrent.Client.Modes
             DiskManager = Manager.Engine.DiskManager;
             ConnectionManager = Manager.Engine.ConnectionManager;
 
-            Peer = new PeerId (new Peer (new PeerInfo (new Uri ("ipv4://123.123.123.123:12345"))), conn.Outgoing, new BitField (Manager.Bitfield.Length).SetAll (true), Manager.InfoHashes.V1OrV2) {
+            Peer = new PeerId (new Peer (new PeerInfo (new Uri ("ipv4://123.123.123.123:12345"))), conn.Outgoing, new BitField (Manager.Bitfield.Length).SetAll (true), Manager.InfoHashes.V1OrV2, PlainTextEncryption.Instance, PlainTextEncryption.Instance, Software.Synthetic) {
                 IsChoking = false,
                 AmInterested = true,
             };

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/MetadataModeTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/MetadataModeTests.cs
@@ -73,11 +73,12 @@ namespace MonoTorrent.Client.Modes
             rig.AddConnection (pair.Outgoing);
 
             var connection = pair.Incoming;
-            PeerId id = new PeerId (new Peer (new PeerInfo (connection.Uri)), connection, new BitField (rig.Torrent.PieceCount), rig.Manager.InfoHashes.V1OrV2);
 
-            var result = await EncryptorFactory.CheckIncomingConnectionAsync (id.Connection, rig.Engine.Settings.AllowedEncryption, new[] { rig.Manager.InfoHashes.V1OrV2 }, Factories.Default, TaskExtensions.Timeout);
-            decryptor = id.Decryptor = result.Decryptor;
-            encryptor = id.Encryptor = result.Encryptor;
+            var result = await EncryptorFactory.CheckIncomingConnectionAsync (connection, rig.Engine.Settings.AllowedEncryption, new[] { rig.Manager.InfoHashes.V1OrV2 }, Factories.Default, TaskExtensions.Timeout);
+
+            PeerId id = new PeerId (new Peer (new PeerInfo (connection.Uri)), connection, new BitField (rig.Torrent.PieceCount), rig.Manager.InfoHashes.V1OrV2, encryptor: result.Encryptor, decryptor: result.Decryptor, Software.Synthetic);
+            decryptor = id.Decryptor;
+            encryptor = id.Encryptor;
         }
 
         [TearDown]

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/StoppedModeTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/StoppedModeTests.cs
@@ -30,6 +30,7 @@
 using System;
 
 using MonoTorrent.Connections;
+using MonoTorrent.Connections.Peer.Encryption;
 using MonoTorrent.Trackers;
 
 using NUnit.Framework;
@@ -65,7 +66,7 @@ namespace MonoTorrent.Client.Modes
             };
             Manager = TestRig.CreateMultiFileManager (fileSizes, Constants.BlockSize * 2);
             Manager.SetTrackerManager (TrackerManager);
-            Peer = new PeerId (new Peer (new PeerInfo (new Uri ("ipv4://123.123.123.123:12345"))), conn.Outgoing, new BitField (Manager.Torrent.PieceCount ()), Manager.InfoHashes.V1OrV2);
+            Peer = new PeerId (new Peer (new PeerInfo (new Uri ("ipv4://123.123.123.123:12345"))), conn.Outgoing, new BitField (Manager.Torrent.PieceCount ()), Manager.InfoHashes.V1OrV2, PlainTextEncryption.Instance, PlainTextEncryption.Instance, Software.Synthetic);
         }
 
         [TearDown]

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/StoppingModeTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client.Modes/StoppingModeTests.cs
@@ -32,6 +32,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using MonoTorrent.Connections;
+using MonoTorrent.Connections.Peer.Encryption;
 using MonoTorrent.Trackers;
 
 using NUnit.Framework;
@@ -66,7 +67,7 @@ namespace MonoTorrent.Client.Modes
             };
             Manager = TestRig.CreateMultiFileManager (fileSizes, Constants.BlockSize * 2);
             Manager.SetTrackerManager (TrackerManager);
-            Peer = new PeerId (new Peer (new PeerInfo (new Uri ("ipv4://123.123.123.123:5555"))), conn.Outgoing, new BitField (Manager.Torrent.PieceCount ()), Manager.InfoHashes.V1OrV2);
+            Peer = new PeerId (new Peer (new PeerInfo (new Uri ("ipv4://123.123.123.123:5555"))), conn.Outgoing, new BitField (Manager.Torrent.PieceCount ()), Manager.InfoHashes.V1OrV2, PlainTextEncryption.Instance, PlainTextEncryption.Instance, Software.Synthetic);
         }
 
         [TearDown]

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/ConnectionManagerTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/ConnectionManagerTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
+using System.Threading;
 using System.Threading.Tasks;
 
 using MonoTorrent.Client.Modes;
@@ -292,5 +293,77 @@ namespace MonoTorrent.Client
             var peer = addToSeeder ? seederManager.Peers.AvailablePeers[0] : leecherManager.Peers.AvailablePeers[0];
             Assert.AreEqual (1, peer.FailedConnectionAttempts);
         }
+
+        [Test]
+        public async Task RetryConnection_AfterTimeout ()
+        {
+            // The first retry should happen immediately, a second retry should take 'forever'.
+            var seeder = EngineHelpers.Create (new EngineSettingsBuilder (EngineHelpers.CreateSettings ()) {
+                AllowLocalPeerDiscovery = false,
+                ConnectionRetryDelays = new List<TimeSpan> { TimeSpan.FromSeconds (1000), TimeSpan.FromSeconds (3000) },
+                AllowedEncryption = new List<EncryptionType> { EncryptionType.RC4Header, EncryptionType.PlainText, EncryptionType.RC4Full },
+                ListenEndPoints = new Dictionary<string, IPEndPoint> { { "ipv4", new IPEndPoint (IPAddress.Loopback, 0) } },
+            }.ToSettings ());
+
+            var leecher = EngineHelpers.Create (new EngineSettingsBuilder (EngineHelpers.CreateSettings ()) {
+                AllowLocalPeerDiscovery = false,
+                AllowedEncryption = new System.Collections.Generic.List<EncryptionType> { EncryptionType.RC4Full },
+                ListenEndPoints = new Dictionary<string, IPEndPoint> { { "ipv4", new IPEndPoint (IPAddress.Loopback, 0) } },
+            }.ToSettings ());
+
+            var magnetLink = new MagnetLink (new InfoHash (Enumerable.Repeat ((byte) 0, 20).ToArray ()));
+            var seederManager = await seeder.AddAsync (magnetLink, "tmp_seeder");
+            var leecherManager = await leecher.AddAsync (magnetLink, "tmp_seeder");
+
+            var ready = Task.WhenAll (seederManager.WaitForState (TorrentState.Metadata), leecherManager.WaitForState (TorrentState.Metadata));
+            await seederManager.StartAsync ();
+            await leecherManager.StartAsync ();
+            await ready;
+
+            var seederDisconnected = new ReusableTaskCompletionSource<PeerId> ();
+            seederManager.PeerDisconnected += (o, e) => seederDisconnected.SetResult (e.Peer);
+
+            var leecherDisconnected = new ReusableTaskCompletionSource<PeerId> ();
+            leecherManager.PeerDisconnected += (o, e) => leecherDisconnected.SetResult (e.Peer);
+
+            var seederConnected = new ReusableTaskCompletionSource<PeerId> ();
+            seederManager.PeerConnected += (o, e) => seederConnected.SetResult (e.Peer);
+
+            var leecherConnected = new ReusableTaskCompletionSource<PeerId> ();
+            leecherManager.PeerConnected += (o, e) => leecherConnected.SetResult (e.Peer);
+
+            int failedCount = 0;
+            seederManager.ConnectionAttemptFailed += (o, e) => failedCount++;
+            leecherManager.ConnectionAttemptFailed += (o, e) => failedCount++;
+
+            await seederManager.AddPeerAsync (new PeerInfo (new Uri ($"ipv4://127.0.0.1:{leecher.PeerListeners[0].LocalEndPoint.Port}")));
+
+            var seederPeer = await seederConnected.Task.WithTimeout ();
+            var leecherPeer = await leecherConnected.Task.WithTimeout ();
+            Assert.AreEqual (0, seederPeer.Peer.CleanedUpCount);
+
+            // Close the connections
+            seederPeer.Connection.Dispose ();
+            leecherPeer.Connection.Dispose ();
+
+            // Send a keepalive message so the engine definitively sees that the socket has been closed.
+            seederPeer.LastMessageSent = ValueStopwatch.WithTime (TimeSpan.FromSeconds (100));
+            leecherPeer.LastMessageSent = ValueStopwatch.WithTime (TimeSpan.FromSeconds (100));
+
+            Assert.IsTrue (seederPeer == await seederDisconnected.Task.WithTimeout ());
+            Assert.IsTrue (leecherPeer == await leecherDisconnected.Task.WithTimeout ());
+
+            seederManager.Peers.AvailablePeers[0].WaitUntilNextConnectionAttempt = ValueStopwatch.WithTime (TimeSpan.FromSeconds(2000));
+
+            // Wait for the retry!
+            seederPeer = await seederConnected.Task.WithTimeout ();
+            leecherPeer = await leecherConnected.Task.WithTimeout ();
+
+            Assert.AreEqual (1, seederPeer.Peer.CleanedUpCount);
+
+            await seeder.StopAsync ();
+            await leecher.StopAsync ();
+        }
+
     }
 }

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/InitialSeedUnchokerTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/InitialSeedUnchokerTests.cs
@@ -32,6 +32,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
+using MonoTorrent.Connections.Peer.Encryption;
 using MonoTorrent.Messages.Peer;
 
 using NUnit.Framework;
@@ -259,10 +260,10 @@ namespace MonoTorrent.Client
                 new Peer (new PeerInfo (new Uri ("ipv4://127.0.0.5:5355"), new string ('c', 20))),
                 new Peer (new PeerInfo (new Uri ("ipv4://127.0.0.5:5356"), new string ('d', 20)))
             };
-            PeerId a = new PeerId (peers[0], NullConnection.Incoming, new BitField (rig.Manager.Torrent.PieceCount ()), rig.Manager.InfoHashes.V1OrV2);
-            PeerId b = new PeerId (peers[1], NullConnection.Incoming, new BitField (rig.Manager.Torrent.PieceCount ()), rig.Manager.InfoHashes.V1OrV2);
-            PeerId c = new PeerId (peers[2], NullConnection.Incoming, new BitField (rig.Manager.Torrent.PieceCount ()), rig.Manager.InfoHashes.V1OrV2);
-            PeerId d = new PeerId (peers[3], NullConnection.Incoming, new BitField (rig.Manager.Torrent.PieceCount ()), rig.Manager.InfoHashes.V1OrV2);
+            PeerId a = new PeerId (peers[0], NullConnection.Incoming, new BitField (rig.Manager.Torrent.PieceCount ()), rig.Manager.InfoHashes.V1OrV2, PlainTextEncryption.Instance, PlainTextEncryption.Instance, Software.Synthetic);
+            PeerId b = new PeerId (peers[1], NullConnection.Incoming, new BitField (rig.Manager.Torrent.PieceCount ()), rig.Manager.InfoHashes.V1OrV2, PlainTextEncryption.Instance, PlainTextEncryption.Instance, Software.Synthetic);
+            PeerId c = new PeerId (peers[2], NullConnection.Incoming, new BitField (rig.Manager.Torrent.PieceCount ()), rig.Manager.InfoHashes.V1OrV2, PlainTextEncryption.Instance, PlainTextEncryption.Instance, Software.Synthetic);
+            PeerId d = new PeerId (peers[3], NullConnection.Incoming, new BitField (rig.Manager.Torrent.PieceCount ()), rig.Manager.InfoHashes.V1OrV2, PlainTextEncryption.Instance, PlainTextEncryption.Instance, Software.Synthetic);
 
             unchoker.PeerDisconnected (a);
             Assert.AreEqual (1, unchoker.PeerCount, "#1");

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/PeerExchangeManagerTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/PeerExchangeManagerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 using MonoTorrent.BEncoding;
 using MonoTorrent.Messages.Peer.Libtorrent;

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/TestRig.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/TestRig.cs
@@ -41,6 +41,7 @@ using MonoTorrent.BEncoding;
 using MonoTorrent.Connections;
 using MonoTorrent.Connections.Dht;
 using MonoTorrent.Connections.Peer;
+using MonoTorrent.Connections.Peer.Encryption;
 using MonoTorrent.Connections.Tracker;
 using MonoTorrent.PieceWriter;
 using MonoTorrent.Trackers;
@@ -413,7 +414,7 @@ namespace MonoTorrent.Client
             for (int i = 0; i < 20; i++)
                 sb.Append ((char) Random.Next ('a', 'z'));
             Peer peer = new Peer (new PeerInfo (new Uri ($"ipv4://127.0.0.1:{(port++)}"), sb.ToString ()));
-            PeerId id = new PeerId (peer, NullConnection.Incoming, new BitField (Manager.Torrent.PieceCount ()).SetAll (false), new InfoHash (new byte[20]));
+            PeerId id = new PeerId (peer, NullConnection.Incoming, new BitField (Manager.Torrent.PieceCount ()).SetAll (false), new InfoHash (new byte[20]), PlainTextEncryption.Instance, PlainTextEncryption.Instance, Software.Synthetic);
             id.SupportsFastPeer = supportsFastPeer;
             id.MessageQueue.SetReady ();
             if (processingQueue)

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/TestWebSeed.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/TestWebSeed.cs
@@ -38,6 +38,7 @@ using System.Threading.Tasks;
 using MonoTorrent.BEncoding;
 using MonoTorrent.Client.Modes;
 using MonoTorrent.Connections.Peer;
+using MonoTorrent.Connections.Peer.Encryption;
 using MonoTorrent.Messages;
 using MonoTorrent.Messages.Peer;
 using MonoTorrent.PiecePicking;
@@ -88,7 +89,7 @@ namespace MonoTorrent.Client
             connection = new HttpPeerConnection (rig.Manager, rig.Engine.Settings.WebSeedConnectionTimeout, rig.Engine.Factories, new Uri (ListenerURL));
             rig.Manager.UnhashedPieces.SetAll (false);
 
-            id = new PeerId (new Peer (new PeerInfo (connection.Uri, "this is my id")), connection, new BitField (rig.Manager.Torrent.PieceCount ()).SetAll (true), rig.Manager.InfoHashes.V1OrV2);
+            id = new PeerId (new Peer (new PeerInfo (connection.Uri, "this is my id")), connection, new BitField (rig.Manager.Torrent.PieceCount ()).SetAll (true), rig.Manager.InfoHashes.V1OrV2, PlainTextEncryption.Instance, PlainTextEncryption.Instance, Software.Synthetic);
             id.IsChoking = false;
             id.AmInterested = true;
             id.MaxPendingRequests = numberOfPieces;
@@ -394,7 +395,7 @@ namespace MonoTorrent.Client
             connection = new HttpPeerConnection (rig.Manager, rig.Engine.Settings.WebSeedConnectionTimeout, rig.Engine.Factories, url);
             rig.Manager.UnhashedPieces.SetAll (false);
 
-            id = new PeerId (new Peer (new PeerInfo (connection.Uri, "this is my id")), id.Connection, new BitField (rig.Manager.Torrent.PieceCount ()).SetAll (true), rig.Manager.InfoHashes.V1OrV2);
+            id = new PeerId (new Peer (new PeerInfo (connection.Uri, "this is my id")), id.Connection, new BitField (rig.Manager.Torrent.PieceCount ()).SetAll (true), rig.Manager.InfoHashes.V1OrV2, PlainTextEncryption.Instance, PlainTextEncryption.Instance, Software.Synthetic);
             id.IsChoking = false;
             id.AmInterested = true;
             id.MaxPendingRequests = numberOfPieces;

--- a/src/Tests/Tests.MonoTorrent.Dht/MonoTorrent.Dht/TaskTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Dht/MonoTorrent.Dht/TaskTests.cs
@@ -62,6 +62,7 @@ namespace MonoTorrent.Dht
         [Repeat (10)]
         public async Task InitialiseFailure ()
         {
+            // FIXME: this flakily fails sometimes... why? DNS timeouts?
             // Block until we've checked the status moved to Initializing
             var errorSource = new TaskCompletionSource<object> ();
             listener.MessageSent += (o, e) => errorSource.Task.GetAwaiter ().GetResult ();


### PR DESCRIPTION
PeerId objects are now guaranteed to run their disposal logic exactly once, which ensures retries are attempted at the right time.

Additionally, PeerId objects are only created when the session is fully initialised, making it harder to add them to internal lists before everything is ready. This also makes cleanup easier if the connection attempt fails as the only thing which needs to be done is to dispose the `IPeerConnection` object :) 