### PR TITLE
exception in SimpleTorrentManager.GetPeers

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.TrackerServer/SimpleTorrentManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.TrackerServer/SimpleTorrentManager.cs
@@ -169,8 +169,12 @@ namespace MonoTorrent.TrackerServer
             int start = Random.Next (0, peers.Count);
 
             lock (PeersList) {
-                if (PeersList.Count != peers.Values.Count)
-                    PeersList = new List<Peer> (peers.Values);
+                // Update PeersList only if the count differs or if the address family has changed
+                if (PeersList.Count != peers.Values.Count || 
+                    (PeersList.Count > 0 && PeersList[0].ClientAddress.AddressFamily != addressFamily))
+                {
+                    PeersList = new List<Peer>(peers.Values);
+                }
             }
 
             while (total > 0) {


### PR DESCRIPTION
Fixes #715: Buffer overflow when announcing IPv4 address immediately after IPv6

This PR addresses an issue where announcing an IPv4 address immediately after an IPv6 address for the same torrent could cause an unhandled exception. The problem occurs because:

The `PeersList` is not updated when its length remains the same, even if the address family changes.
This leads to a mismatch between the address family of the peers in `PeersList` and the newly announced address family.
Consequently, when trying to copy IPv6 peer data (18 bytes) into a buffer allocated for IPv4 peers (6 bytes), a System.ArgumentException occurs during Buffer.BlockCopy.

The fix involves updating the condition for refreshing the `PeersList`. Now, it checks both the count and the address family of the peers, ensuring that the list is always consistent with the current announcement type.