### PR TITLE
Fix: `MagnetLink.ConvertToString` should include Exact Length if known

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent/MagnetLink.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/MagnetLink.cs
@@ -213,6 +213,11 @@ namespace MonoTorrent
                 sb.Append (Name.UrlEncodeQueryUTF8 ());
             }
 
+            if (Size.HasValue) {
+                sb.Append ("&xl=");
+                sb.Append (Size.Value);
+            }
+
             foreach (string tracker in AnnounceUrls) {
                 sb.Append ("&tr=");
                 sb.Append (tracker.UrlEncodeQueryUTF8 ());


### PR DESCRIPTION
This PR addresses a key issue in the string conversion code for the `MagnetLink` class where the Exact Length `xl=` attribute would not be printed, even if the current instance provided such a value. The new code makes sure to print this parameter alongside the rest. 