### PR TITLE
Fix: allow WebSeed to be added from magnet link

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/Mode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/Mode.cs
@@ -700,7 +700,7 @@ namespace MonoTorrent.Client.Modes
         void DownloadLogic (int counter)
         {
             if (ClientEngine.SupportsWebSeed && (DateTime.Now - Manager.StartTime) > Settings.WebSeedDelay && (Manager.Monitor.DownloadRate < Settings.WebSeedSpeedTrigger || Settings.WebSeedSpeedTrigger == 0)) {
-                foreach (Uri uri in Manager.Torrent!.HttpSeeds) {
+                foreach (Uri uri in Manager.MagnetLink.Webseeds.Select(x => new Uri(x))) {
                     var peer = new Peer (new PeerInfo (uri, CreatePeerId ()));
                     if (Manager.Peers.Contains (peer) || Manager.Peers.ConnectedPeers.Any (p => p.Uri == uri))
                         continue;

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -448,7 +448,7 @@ namespace MonoTorrent.Client
         {
             Engine = engine;
             Files = Array.Empty<ITorrentManagerFile> ();
-            MagnetLink = magnetLink ?? new MagnetLink (torrent!.InfoHashes, torrent.Name, torrent.AnnounceUrls.SelectMany (t => t).ToArray (), null, torrent.Size);
+            MagnetLink = magnetLink ?? new MagnetLink (torrent!.InfoHashes, torrent.Name, torrent.AnnounceUrls.SelectMany (t => t).ToArray (), torrent.HttpSeeds.Select(x => x.OriginalString), torrent.Size);
             PieceHashes = new PieceHashes (null, null);
             Settings = settings;
             Torrent = torrent;


### PR DESCRIPTION
Currently, MonoTorrent only pulls potential WebSeed addresses from the `Torrent` instance passed to a given `TorrentManager`. However, there is a need for enabling WebSeed from a `MagnetLink` instance as well. This PR addresses this need by using the established internal APIs.