### PR TITLE
remove redundant context switches

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/DiskManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/DiskManager.cs
@@ -314,15 +314,11 @@ namespace MonoTorrent.Client
 
         internal async Task<bool> CheckFileExistsAsync (ITorrentManagerFile file)
         {
-            await IOLoop;
-
             return await Cache.Writer.ExistsAsync (file).ConfigureAwait (false);
         }
 
         internal async Task<bool> CheckAnyFilesExistAsync (ITorrentManagerInfo manager)
         {
-            await IOLoop;
-
             for (int i = 0; i < manager.Files.Count; i++)
                 if (await Cache.Writer.ExistsAsync (manager.Files[i]).ConfigureAwait (false))
                     return true;
@@ -729,13 +725,11 @@ namespace MonoTorrent.Client
 
         internal async ReusableTask<long?> GetLengthAsync (ITorrentManagerFile file)
         {
-            await IOLoop;
             return await Cache.Writer.GetLengthAsync (file);
         }
 
         internal async ReusableTask<bool> SetLengthAsync (ITorrentManagerFile file, long length)
         {
-            await IOLoop;
             return await Cache.Writer.SetLengthAsync (file, length);
         }
     }


### PR DESCRIPTION
it is redundant to switch synchronization context to just switch again
<img width="1137" height="127" alt="image" src="https://github.com/user-attachments/assets/4302060f-7153-4392-ab01-f388bf3287e6" />
performance test scenario: call GetLength with different thread and call count
<img width="1255" height="989" alt="image" src="https://github.com/user-attachments/assets/79d9e799-c951-4820-9817-4761e152eaf6" />
