### PR TITLE
optimize strings memory allocations and utilization

### DIFF
--- a/src/MonoTorrent.BEncoding/MonoTorrent.BEncoding.csproj
+++ b/src/MonoTorrent.BEncoding/MonoTorrent.BEncoding.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.0;netstandard2.1;netstandard2.0;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net5.0;netcoreapp3.0;netstandard2.1;netstandard2.0;net472</TargetFrameworks>
     <AllowUnsafeBlocks Condition="$(TargetFramework) == 'netstandard2.0' Or $(TargetFramework) == 'net472'">true</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/src/MonoTorrent.Client/MonoTorrent.Client.csproj
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.0;netstandard2.1;netstandard2.0;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net5.0;netcoreapp3.0;netstandard2.1;netstandard2.0;net472</TargetFrameworks>
 
     <BeforePack>$(BeforePack);SetPackProperties</BeforePack>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>

--- a/src/MonoTorrent.Client/MonoTorrent.Client/ClientEngine.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/ClientEngine.cs
@@ -500,7 +500,7 @@ namespace MonoTorrent.Client
                         File.Delete (path);
             }
             if (mode.HasFlag (RemoveMode.DownloadedDataOnly)) {
-                foreach (var path in manager.Files.Select (f => f.FullPath))
+                foreach (var path in manager.Files.Select (f => f.FullPath.ToString ()))
                     if (File.Exists (path))
                         File.Delete (path);
                 // FIXME: Clear the empty directories.

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/DiskManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/DiskManager.cs
@@ -479,11 +479,15 @@ namespace MonoTorrent.Client
             }
         }
 
-        internal Task MoveFileAsync (ITorrentManagerFile file, (string newPath, string downloadComplete, string downloadIncomplete) paths)
-            => MoveFileAsync ((TorrentFileInfo) file, paths);
+        internal Task MoveFileAsync (ITorrentManagerFile file, (SpanStringList newPath, SpanStringList downloadComplete, SpanStringList downloadIncomplete) paths)
+        {
+            return MoveFileAsync ((TorrentFileInfo) file, paths);
+        }
 
-        internal Task MoveFileAsync (TorrentFileInfo file, (string newPath, string downloadComplete, string downloadIncomplete) paths)
-            => MoveFileAsync (file, paths, false);
+        internal Task MoveFileAsync (TorrentFileInfo file, (SpanStringList newPath, SpanStringList downloadComplete, SpanStringList downloadIncomplete) paths)
+        {
+            return MoveFileAsync (file, paths, false);
+        }
 
         internal async Task MoveFilesAsync (IList<ITorrentManagerFile> files, string newRoot, bool overwrite)
         {
@@ -493,7 +497,7 @@ namespace MonoTorrent.Client
             }
         }
 
-        async Task MoveFileAsync (TorrentFileInfo file, (string newPath, string downloadCompletePath, string downloadIncompletePath) paths, bool overwrite)
+        async Task MoveFileAsync (TorrentFileInfo file, (SpanStringList newPath, SpanStringList downloadCompletePath, SpanStringList downloadIncompletePath) paths, bool overwrite)
         {
             await IOLoop;
 

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -34,7 +34,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using MonoTorrent.BEncoding;
 using MonoTorrent.Client.Modes;
 using MonoTorrent.Client.RateLimiters;
 using MonoTorrent.Messages.Peer;
@@ -631,7 +630,7 @@ namespace MonoTorrent.Client
             CheckMetadata ();
 
             try {
-                var paths = TorrentFileInfo.GetNewPaths (Path.GetFullPath (path), Engine!.Settings.UsePartialFiles, file.Path == file.DownloadCompleteFullPath);
+                (SpanStringList path, SpanStringList completePath, SpanStringList incompletePath) paths = TorrentFileInfo.GetNewPaths (Path.GetFullPath (path), Engine!.Settings.UsePartialFiles, file.Path == file.DownloadCompleteFullPath);
                 await Engine!.DiskManager.MoveFileAsync (file, paths);
             } catch (Exception ex) {
                 TrySetError (Reason.WriteFailure, ex);
@@ -694,23 +693,22 @@ namespace MonoTorrent.Client
             // All files marked as 'Normal' priority by default so 'PartialProgressSelector'
             // should be set to 'true' for each piece as all files are being downloaded.
             Files = Torrent.Files.Select (file => {
-
                 // Generate the paths when 'UsePartialFiles' is enabled.
-                var paths = TorrentFileInfo.GetNewPaths (Path.Combine (ContainingDirectory, TorrentFileInfo.PathAndFileNameEscape (file.Path)), usePartialFiles: true, isComplete: true);
-                var downloadCompleteFullPath = paths.completePath;
-                var downloadIncompleteFullPath = paths.incompletePath;
+                var paths = TorrentFileInfo.GetNewPaths (ContainingDirectory, file.Path, true, true);
+                string downloadCompleteFullPath = paths.completePath;
+                string downloadIncompleteFullPath = paths.incompletePath;
 
                 // FIXME: Is this the best place to futz with actually moving files?
                 if (!Engine!.Settings.UsePartialFiles) {
                     if (File.Exists (downloadIncompleteFullPath) && !File.Exists (downloadCompleteFullPath))
                         File.Move (downloadIncompleteFullPath, downloadCompleteFullPath);
 
-                    downloadIncompleteFullPath = downloadCompleteFullPath;
+                    paths.incompletePath = paths.completePath;
                 }
 
-                var currentPath = File.Exists (downloadCompleteFullPath) ? downloadCompleteFullPath : downloadIncompleteFullPath;
+                SpanStringList currentPath = File.Exists (downloadCompleteFullPath) ? paths.completePath : paths.incompletePath;
                 var torrentFileInfo = new TorrentFileInfo (file, currentPath);
-                torrentFileInfo.UpdatePaths ((currentPath, downloadCompleteFullPath, downloadIncompleteFullPath));
+                torrentFileInfo.UpdatePaths ((currentPath, paths.completePath, paths.incompletePath));
                 return torrentFileInfo;
             }).Cast<ITorrentManagerFile> ().ToList ().AsReadOnly ();
 
@@ -1028,7 +1026,7 @@ namespace MonoTorrent.Client
             for (int i = fileStartIndex; i < fileStartIndex + count; i++) {
                 var current = files[i].FullPath;
                 var completePath = files[i].DownloadCompleteFullPath;
-                var incompletePath = files[i].DownloadCompleteFullPath + (usePartialFiles ? TorrentFileInfo.IncompleteFileSuffix : "");
+                var incompletePath= usePartialFiles? files[i].DownloadCompleteFullPath.Append (TorrentFileInfo.IncompleteFileSuffix): files[i].DownloadCompleteFullPath;
 
                 if (files[i].BitField.AllTrue && files[i].FullPath != completePath) {
                     tasks ??= new List<Task> ();

--- a/src/MonoTorrent.Client/MonoTorrent/TorrentCreator.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/TorrentCreator.cs
@@ -456,13 +456,13 @@ namespace MonoTorrent
 
                 if (currentFile.EndPieceIndex == piece) {
                     while (currentFile != null && currentFile.EndPieceIndex == piece) {
-                        OnHashed (new TorrentCreatorEventArgs (currentFile.FullPath, currentFile.Length, currentFile.Length, torrentInfo.PieceIndexToByteOffset(piece) + sizeOfCurrentPiece, torrentInfo.Size));
+                            OnHashed (currentFile.FullPath, currentFile.Length, currentFile.Length, torrentInfo.PieceIndexToByteOffset (piece) + sizeOfCurrentPiece, torrentInfo.Size);
 
                         files = files.Slice (1);
                         currentFile = files.Length == 0 ? null : files.Span[0];
                     }
                 } else {
-                    OnHashed (new TorrentCreatorEventArgs (currentFile.FullPath, torrentInfo.PieceIndexToByteOffset (piece) - currentFile.OffsetInTorrent + sizeOfCurrentPiece, currentFile.Length, torrentInfo.PieceIndexToByteOffset (piece) + sizeOfCurrentPiece, torrentInfo.Size));
+                        OnHashed (currentFile.FullPath, torrentInfo.PieceIndexToByteOffset (piece) - currentFile.OffsetInTorrent + sizeOfCurrentPiece, currentFile.Length, torrentInfo.PieceIndexToByteOffset (piece) + sizeOfCurrentPiece, torrentInfo.Size);
                 }
 
                 // Asynchronously begin reading the *next* piece and computing the hash for that piece.
@@ -492,8 +492,8 @@ namespace MonoTorrent
             return (sha1Hashes, merkleLayers, fileSHA1Hashes, fileMD5Hashes);
         }
 
-        protected virtual void OnHashed (TorrentCreatorEventArgs args)
-            => Hashed?.InvokeAsync (this, args);
+        protected virtual void OnHashed (SpanStringList file, long fileHashed, long fileTotal, long overallHashed, long overallTotal)
+            => Hashed?.InvokeAsync (this, new TorrentCreatorEventArgs (file, fileHashed, fileTotal, overallHashed, overallTotal));
 
         async ReusableTask AppendPerFileHashes (ITorrentManagerInfo manager, IncrementalHash? fileMD5, Dictionary<ITorrentManagerFile, ReadOnlyMemory<byte>> fileMD5Hashes, IncrementalHash? fileSHA1, Dictionary<ITorrentManagerFile, ReadOnlyMemory<byte>> fileSHA1Hashes, long offset, Memory<byte> buffer)
         {

--- a/src/MonoTorrent.Connections/MonoTorrent.Connections.csproj
+++ b/src/MonoTorrent.Connections/MonoTorrent.Connections.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.0;netstandard2.1;netstandard2.0;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net5.0;netcoreapp3.0;netstandard2.1;netstandard2.0;net472</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/MonoTorrent.Dht/MonoTorrent.Dht.csproj
+++ b/src/MonoTorrent.Dht/MonoTorrent.Dht.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.0;netstandard2.1;netstandard2.0;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net5.0;netcoreapp3.0;netstandard2.1;netstandard2.0;net472</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/MonoTorrent.Factories/MonoTorrent.Factories.csproj
+++ b/src/MonoTorrent.Factories/MonoTorrent.Factories.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.0;netstandard2.1;netstandard2.0;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net5.0;netcoreapp3.0;netstandard2.1;netstandard2.0;net472</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MonoTorrent.Messages/MonoTorrent.Messages.csproj
+++ b/src/MonoTorrent.Messages/MonoTorrent.Messages.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.0;netstandard2.1;netstandard2.0;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net5.0;netcoreapp3.0;netstandard2.1;netstandard2.0;net472</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/MonoTorrent.PiecePicking/MonoTorrent.PiecePicking.csproj
+++ b/src/MonoTorrent.PiecePicking/MonoTorrent.PiecePicking.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.0;netstandard2.1;netstandard2.0;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net5.0;netcoreapp3.0;netstandard2.1;netstandard2.0;net472</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/MonoTorrent.PieceWriter/MonoTorrent.PieceWriter.csproj
+++ b/src/MonoTorrent.PieceWriter/MonoTorrent.PieceWriter.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.0;netstandard2.1;netstandard2.0;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net5.0;netcoreapp3.0;netstandard2.1;netstandard2.0;net472</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/MonoTorrent.PortForwarding/MonoTorrent.PortForwarding.csproj
+++ b/src/MonoTorrent.PortForwarding/MonoTorrent.PortForwarding.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.0;netstandard2.1;netstandard2.0;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net5.0;netcoreapp3.0;netstandard2.1;netstandard2.0;net472</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/MonoTorrent.Trackers/MonoTorrent.Trackers.csproj
+++ b/src/MonoTorrent.Trackers/MonoTorrent.Trackers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.0;netstandard2.1;netstandard2.0;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net5.0;netcoreapp3.0;netstandard2.1;netstandard2.0;net472</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/MonoTorrent/MonoTorrent.csproj
+++ b/src/MonoTorrent/MonoTorrent.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.0;netstandard2.1;netstandard2.0;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net5.0;netcoreapp3.0;netstandard2.1;netstandard2.0;net472</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -12,6 +12,7 @@
     <UseSimpleSpinLock>true</UseSimpleSpinLock>
     <UseTorrentFileExtensions>true</UseTorrentFileExtensions>
     <UseValueStopWatch>true</UseValueStopWatch>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MonoTorrent/MonoTorrent/ITorrentFileInfo.cs
+++ b/src/MonoTorrent/MonoTorrent/ITorrentFileInfo.cs
@@ -39,17 +39,17 @@ namespace MonoTorrent
         /// <summary>
         /// If the file is currently being downloaded, this will be the same as <see cref="DownloadIncompleteFullPath"/>. Otherwise it will be <see cref="DownloadCompleteFullPath"/>
         /// </summary>
-        string FullPath { get; }
+        SpanStringList FullPath { get; }
 
         /// <summary>
         /// The file will exist at this path after it has been fully downloaded.
         /// </summary>
-        string DownloadCompleteFullPath { get; }
+        SpanStringList DownloadCompleteFullPath { get; }
 
         /// <summary>
         /// The file will exist at this path when it is partially downloaded. This value may be the same as <see cref="DownloadCompleteFullPath"/>.
         /// </summary>
-        string DownloadIncompleteFullPath { get; }
+        SpanStringList DownloadIncompleteFullPath { get; }
 
         /// <summary>
         /// The priority of the file when downloading.

--- a/src/MonoTorrent/MonoTorrent/SpanStringList.cs
+++ b/src/MonoTorrent/MonoTorrent/SpanStringList.cs
@@ -4,8 +4,17 @@ using MonoTorrent.BEncoding;
 
 namespace MonoTorrent
 {
+    /// <summary>
+    /// Represents a list of string segments that can be efficiently concatenated and compared.
+    /// </summary>
     public sealed class SpanStringList : IEquatable<SpanStringList>, IEquatable<string>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SpanStringList"/> class with a single segment.
+        /// </summary>
+        /// <param name="value">The underlying string.</param>
+        /// <param name="start">The starting index of the segment.</param>
+        /// <param name="length">The length of the segment.</param>
         public SpanStringList (string value, int start, int length) : this (value, start, length, null)
         {
             Value = value;
@@ -13,6 +22,13 @@ namespace MonoTorrent
             Length = length;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SpanStringList"/> class as a continuation of another list.
+        /// </summary>
+        /// <param name="value">The underlying string for the new segment.</param>
+        /// <param name="start">The starting index of the new segment.</param>
+        /// <param name="length">The length of the new segment.</param>
+        /// <param name="prev">The previous list of segments.</param>
         public SpanStringList (string value, int start, int length, SpanStringList? prev)
         {
             Value = value;
@@ -21,6 +37,10 @@ namespace MonoTorrent
             Prev = prev;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SpanStringList"/> class from a whole string.
+        /// </summary>
+        /// <param name="value">The string value.</param>
         public SpanStringList (string value) : this (value, 0, value.Length, null)
         {
         }
@@ -33,16 +53,32 @@ namespace MonoTorrent
 
         SpanStringList? Prev { get; }
 
+        /// <summary>
+        /// Appends a new string segment to the end of the list.
+        /// </summary>
+        /// <param name="value">The string value to append.</param>
+        /// <returns>A new <see cref="SpanStringList"/> containing the appended segment.</returns>
         public SpanStringList Append (string value)
         {
             return Append (value, 0, value.Length);
         }
 
+        /// <summary>
+        /// Appends a new string segment to the end of the list.
+        /// </summary>
+        /// <param name="value">The underlying string for the new segment.</param>
+        /// <param name="start">The starting index of the segment.</param>
+        /// <param name="length">The length of the segment.</param>
+        /// <returns>A new <see cref="SpanStringList"/> containing the appended segment.</returns>
         public SpanStringList Append (string value, int start, int length)
         {
             return new SpanStringList (value, start, length, this);
         }
 
+        /// <summary>
+        /// Converts the list of segments into a single string.
+        /// </summary>
+        /// <returns>A string representation of the combined segments.</returns>
         public override string ToString ()
         {
             SpanStringList? current;
@@ -70,6 +106,11 @@ namespace MonoTorrent
             return result;
         }
 
+        /// <summary>
+        /// Fills the provided span with the character data from the segment list.
+        /// </summary>
+        /// <param name="span">The target span to fill.</param>
+        /// <param name="spanList">The list of segments to copy from.</param>
         static void FillSpan (Span<char> span, SpanStringList spanList)
         {
             var offset = span.Length;
@@ -83,26 +124,40 @@ namespace MonoTorrent
             } while (current is not null);
         }
 
+        /// <summary>
+        /// Implicitly converts a string to a <see cref="SpanStringList"/>.
+        /// </summary>
+        /// <param name="value">The string value.</param>
         public static implicit operator SpanStringList (string value)
         {
             return new SpanStringList (value);
         }
 
+        /// <summary>
+        /// Implicitly converts a <see cref="SpanStringList"/> to a string.
+        /// </summary>
+        /// <param name="value">The list of segments.</param>
         public static implicit operator string (SpanStringList value)
         {
             return value.ToString ();
         }
 
+        /// <summary>
+        /// Explicitly converts a <see cref="SpanStringList"/> to a <see cref="BEncodedString"/>.
+        /// </summary>
+        /// <param name="value">The list of segments.</param>
         public static explicit operator BEncodedString (SpanStringList value)
         {
             return value.ToString ();
         }
 
+        /// <inheritdoc />
         public override bool Equals (object? obj)
         {
             return ReferenceEquals (this, obj) || obj is SpanStringList other && Equals (other);
         }
 
+        /// <inheritdoc />
         public override int GetHashCode ()
         {
             var result = 397;
@@ -119,16 +174,34 @@ namespace MonoTorrent
             return result;
         }
 
+        /// <summary>
+        /// Determines whether two specified <see cref="SpanStringList"/> instances are equal.
+        /// </summary>
+        /// <param name="left">The first list to compare.</param>
+        /// <param name="right">The second list to compare.</param>
+        /// <returns>true if the lists are equal; otherwise, false.</returns>
         public static bool operator == (SpanStringList? left, SpanStringList? right)
         {
             return Equals (left, right);
         }
 
+        /// <summary>
+        /// Determines whether two specified <see cref="SpanStringList"/> instances are not equal.
+        /// </summary>
+        /// <param name="left">The first list to compare.</param>
+        /// <param name="right">The second list to compare.</param>
+        /// <returns>true if the lists are not equal; otherwise, false.</returns>
         public static bool operator != (SpanStringList? left, SpanStringList? right)
         {
             return !Equals (left, right);
         }
 
+        /// <summary>
+        /// Determines whether a <see cref="SpanStringList"/> instance and a string are equal.
+        /// </summary>
+        /// <param name="left">The list to compare.</param>
+        /// <param name="right">The string to compare.</param>
+        /// <returns>true if they are equal; otherwise, false.</returns>
         public static bool operator == (SpanStringList? left, string? right)
         {
             if (left is null && right is null) return true;
@@ -136,6 +209,12 @@ namespace MonoTorrent
             return left!.Equals (right);
         }
 
+        /// <summary>
+        /// Determines whether a <see cref="SpanStringList"/> instance and a string are not equal.
+        /// </summary>
+        /// <param name="left">The list to compare.</param>
+        /// <param name="right">The string to compare.</param>
+        /// <returns>true if they are not equal; otherwise, false.</returns>
         public static bool operator != (SpanStringList? left, string? right)
         {
             if (left is null && right is null)
@@ -145,6 +224,12 @@ namespace MonoTorrent
             return !left!.Equals (right);
         }
 
+        /// <summary>
+        /// Determines whether a string and a <see cref="SpanStringList"/> instance are equal.
+        /// </summary>
+        /// <param name="left">The string to compare.</param>
+        /// <param name="right">The list to compare.</param>
+        /// <returns>true if they are equal; otherwise, false.</returns>
         public static bool operator == (string? left, SpanStringList? right)
         {
             if (right is null && left is null)
@@ -154,6 +239,12 @@ namespace MonoTorrent
             return right!.Equals (left);
         }
 
+        /// <summary>
+        /// Determines whether a string and a <see cref="SpanStringList"/> instance are not equal.
+        /// </summary>
+        /// <param name="left">The string to compare.</param>
+        /// <param name="right">The list to compare.</param>
+        /// <returns>true if they are not equal; otherwise, false.</returns>
         public static bool operator != (string? left, SpanStringList? right)
         {
             if (right is null && left is null)
@@ -163,6 +254,11 @@ namespace MonoTorrent
             return !right!.Equals (left);
         }
 
+        /// <summary>
+        /// Determines whether the current <see cref="SpanStringList"/> is equal to a specified string.
+        /// </summary>
+        /// <param name="other">The string to compare with the current list.</param>
+        /// <returns>true if the list is equal to the string; otherwise, false.</returns>
         public bool Equals (string? other)
         {
             if (other is null)
@@ -191,6 +287,11 @@ namespace MonoTorrent
             return true;
         }
 
+        /// <summary>
+        /// Determines whether the current <see cref="SpanStringList"/> is equal to another <see cref="SpanStringList"/>.
+        /// </summary>
+        /// <param name="other">The list to compare with the current list.</param>
+        /// <returns>true if the lists are equal; otherwise, false.</returns>
         public bool Equals (SpanStringList? other)
         {
             if (other is null)

--- a/src/MonoTorrent/MonoTorrent/SpanStringList.cs
+++ b/src/MonoTorrent/MonoTorrent/SpanStringList.cs
@@ -1,0 +1,244 @@
+﻿using System;
+
+using MonoTorrent.BEncoding;
+
+namespace MonoTorrent
+{
+    public sealed class SpanStringList : IEquatable<SpanStringList>, IEquatable<string>
+    {
+        public SpanStringList (string value, int start, int length) : this (value, start, length, null)
+        {
+            Value = value;
+            Start = start;
+            Length = length;
+        }
+
+        public SpanStringList (string value, int start, int length, SpanStringList? prev)
+        {
+            Value = value;
+            Start = start;
+            Length = length;
+            Prev = prev;
+        }
+
+        public SpanStringList (string value) : this (value, 0, value.Length, null)
+        {
+        }
+
+        string Value { get; }
+
+        int Start { get; }
+
+        int Length { get; }
+
+        SpanStringList? Prev { get; }
+
+        public SpanStringList Append (string value)
+        {
+            return Append (value, 0, value.Length);
+        }
+
+        public SpanStringList Append (string value, int start, int length)
+        {
+            return new SpanStringList (value, start, length, this);
+        }
+
+        public override string ToString ()
+        {
+            SpanStringList? current;
+            if (Prev is null) {
+                current = this;
+                if (current.Start == 0 && current.Length == current.Value.Length)
+                    return current.Value;
+                return current.Value.AsSpan ().Slice (current.Start, current.Length).ToString ();
+            }
+
+            var length = 0;
+            current = this;
+            do {
+                length += current.Length;
+                current = current.Prev;
+            } while (current is not null);
+#if NET5_0_OR_GREATER
+            var result = string.Create (length, this, FillSpan);
+#else
+            var chars = new char[length];
+            var span = chars.AsSpan ();
+            FillSpan (span, this);
+            var result = new string (chars);
+#endif
+            return result;
+        }
+
+        static void FillSpan (Span<char> span, SpanStringList spanList)
+        {
+            var offset = span.Length;
+            var current = spanList;
+            do {
+                var toCopy = current.Value.AsSpan ().Slice (current.Start, current.Length);
+                var copyTo = span.Slice (offset - toCopy.Length, toCopy.Length);
+                toCopy.CopyTo (copyTo);
+                offset -= toCopy.Length;
+                current = current.Prev;
+            } while (current is not null);
+        }
+
+        public static implicit operator SpanStringList (string value)
+        {
+            return new SpanStringList (value);
+        }
+
+        public static implicit operator string (SpanStringList value)
+        {
+            return value.ToString ();
+        }
+
+        public static explicit operator BEncodedString (SpanStringList value)
+        {
+            return value.ToString ();
+        }
+
+        public override bool Equals (object? obj)
+        {
+            return ReferenceEquals (this, obj) || obj is SpanStringList other && Equals (other);
+        }
+
+        public override int GetHashCode ()
+        {
+            var result = 397;
+            var item = this;
+            do {
+                var span = item.Value.AsSpan (item.Start, item.Length);
+                for (int i = span.Length - 1; i >= 0; i--) {
+                    result ^= (span[i].GetHashCode () * 397);
+                }
+
+                item = item.Prev;
+            } while (item is not null);
+
+            return result;
+        }
+
+        public static bool operator == (SpanStringList? left, SpanStringList? right)
+        {
+            return Equals (left, right);
+        }
+
+        public static bool operator != (SpanStringList? left, SpanStringList? right)
+        {
+            return !Equals (left, right);
+        }
+
+        public static bool operator == (SpanStringList? left, string? right)
+        {
+            if (left is null && right is null) return true;
+            if (left is null && right is not null) return false;
+            return left!.Equals (right);
+        }
+
+        public static bool operator != (SpanStringList? left, string? right)
+        {
+            if (left is null && right is null)
+                return false;
+            if (left is null && right is not null)
+                return true;
+            return !left!.Equals (right);
+        }
+
+        public static bool operator == (string? left, SpanStringList? right)
+        {
+            if (right is null && left is null)
+                return true;
+            if (right is null && left is not null)
+                return false;
+            return right!.Equals (left);
+        }
+
+        public static bool operator != (string? left, SpanStringList? right)
+        {
+            if (right is null && left is null)
+                return false;
+            if (right is null && left is not null)
+                return true;
+            return !right!.Equals (left);
+        }
+
+        public bool Equals (string? other)
+        {
+            if (other is null)
+                return false;
+            if (Prev is null) {
+                if (Start == 0 && Length == Value.Length)
+                    return other == Value;
+                return Value.AsSpan ().Slice (Start, Length).Equals (other, StringComparison.Ordinal);
+            }
+
+            var offset = 0;
+            var item = this;
+            do {
+                if (item.Length > other.Length - offset)
+                    return false;
+                var otherSpan = other.AsSpan ().Slice (other.Length - offset - item.Length, item.Length);
+                var thisSpan = item.Value.AsSpan (item.Start, item.Length);
+                if (!thisSpan.Equals (otherSpan, StringComparison.Ordinal))
+                    return false;
+                offset += item.Length;
+                item = item.Prev;
+            } while (item is not null);
+
+            if (offset != other.Length)
+                return false;
+            return true;
+        }
+
+        public bool Equals (SpanStringList? other)
+        {
+            if (other is null)
+                return false;
+            if (Prev is null && other.Prev is null) {
+                if (Start == 0 && Length == Value.Length && other.Start == 0 && other.Length == other.Value.Length)
+                    return other.Value == Value;
+                return Value.AsSpan ().Slice (Start, Length).Equals (other.Value.AsSpan ().Slice (other.Start, other.Length), StringComparison.Ordinal);
+            }
+
+            var thisOffset = 0;
+            var otherOffset = 0;
+            var thisItem = this;
+            var otherItem = other;
+            do {
+                if (thisItem is null || otherItem is null)
+                    return false;
+                var thisLength = thisItem.Length - thisOffset;
+                var otherLength = otherItem.Length - otherOffset;
+                if (thisLength < otherLength) {
+                    var thisSpan = thisItem.Value.AsSpan ().Slice (thisItem.Start, thisItem.Length).Slice (0, thisLength);
+                    var otherSpan = otherItem.Value.AsSpan ().Slice (otherItem.Start, otherItem.Length).Slice (otherLength - thisLength, thisLength);
+                    if (!thisSpan.Equals (otherSpan, StringComparison.Ordinal))
+                        return false;
+                    otherOffset += thisLength;
+                    thisItem = thisItem.Prev;
+                    thisOffset = 0;
+                } else if (thisLength > otherLength) {
+                    var otherSpan = otherItem.Value.AsSpan ().Slice (otherItem.Start, otherItem.Length).Slice (0, otherLength);
+                    var thisSpan = thisItem.Value.AsSpan ().Slice (thisItem.Start, thisItem.Length).Slice (thisLength - otherLength, otherLength);
+                    if (!otherSpan.Equals (thisSpan, StringComparison.Ordinal))
+                        return false;
+                    thisOffset += otherLength;
+                    otherItem = otherItem.Prev;
+                    otherOffset = 0;
+                } else {
+                    var otherSpan = otherItem.Value.AsSpan ().Slice (otherItem.Start, otherLength);
+                    var thisSpan = thisItem.Value.AsSpan ().Slice (thisItem.Start, thisLength);
+                    if (!otherSpan.Equals (thisSpan, StringComparison.Ordinal))
+                        return false;
+                    thisOffset = 0;
+                    otherOffset = 0;
+                    thisItem = thisItem.Prev;
+                    otherItem = otherItem.Prev;
+                }
+            } while (thisItem is not null || otherItem is not null);
+
+            return true;
+        }
+    }
+}

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/TorrentCreatorTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/TorrentCreatorTests.cs
@@ -25,8 +25,9 @@ namespace MonoTorrent.Common
 
             }
 
-            protected override void OnHashed (TorrentCreatorEventArgs e)
+            protected override void OnHashed (SpanStringList file, long fileHashed, long fileTotal, long overallHashed, long overallTotal)
             {
+                var e = new TorrentCreatorEventArgs (file, fileHashed, fileTotal, overallHashed, overallTotal);
                 if (!HashedEventArgs.TryGetValue (e.CurrentFile, out List<TorrentCreatorEventArgs> value))
                     HashedEventArgs[e.CurrentFile] = value = new List<TorrentCreatorEventArgs> ();
                 value.Add (e);

--- a/src/Tests/Tests.MonoTorrent/SpanStringListTests.cs
+++ b/src/Tests/Tests.MonoTorrent/SpanStringListTests.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using MonoTorrent;
+
+using NUnit.Framework;
+
+namespace Tests.MonoTorrent
+{
+    [TestFixture]
+    class SpanStringListTests
+    {
+        [Test]
+        [TestCaseSource(nameof(EqualsSource))]
+        public void Equals (object a, object b)
+        {
+            Assert.That (a, Is.EqualTo (b));
+            if (a is string a1 && b is SpanStringList b1) {
+                Assert.True (a1 == b1);
+                Assert.False (a1 != b1);
+            }
+            if (a is SpanStringList a2 && b is string b2) {
+                Assert.True (a2 == b2);
+                Assert.False (a2 != b2);
+            }
+
+            if (a is SpanStringList a3 && b is SpanStringList b3) {
+                Assert.That (a3.GetHashCode (), Is.EqualTo (b3.GetHashCode ()));
+                Assert.True (a3 == b3);
+                Assert.False (a3 != b3);
+            }
+        }
+
+        public static IEnumerable EqualsSource ()
+        {
+            yield return new object[] { new SpanStringList ("123456"), "123456" };
+            yield return new object[] { new SpanStringList ("123456"), new SpanStringList("123").Append ("456") };
+            yield return new object[] { "123456", new SpanStringList("123").Append ("456") };
+            yield return new object[] { new SpanStringList ("1234"), new SpanStringList("1").Append ("2").Append ("3").Append ("4") };
+            yield return new object[] { "1234", new SpanStringList("1").Append ("2").Append ("3").Append ("4") };
+            yield return new object[] { new SpanStringList ("123").Append ("456").Append ("789").Append ("0"), new SpanStringList("12").Append ("34").Append ("56").Append ("78").Append ("90") };
+        }
+
+        [Test]
+        [TestCaseSource(nameof(NotEqualsSource))]
+        public void NotEquals (object a, object b)
+        {
+            Assert.That (a, Is.Not.EqualTo (b));
+            if (a is string a1 && b is SpanStringList b1) {
+                Assert.False (a1 == b1);
+                Assert.True (a1 != b1);
+            }
+            if (a is SpanStringList a2 && b is string b2) {
+                Assert.False (a2 == b2);
+                Assert.True (a2 != b2);
+            }
+
+            if (a is SpanStringList a3 && b is SpanStringList b3) {
+                Assert.False (a3 == b3);
+                Assert.True (a3 != b3);
+            }
+        }
+
+        public static IEnumerable NotEqualsSource ()
+        {
+            yield return new object[] { new SpanStringList ("12345"), "12456" };
+            yield return new object[] { new SpanStringList ("123456"), new SpanStringList("123").Append ("46") };
+            yield return new object[] { "z", new SpanStringList("123").Append ("456") };
+            yield return new object[] { new SpanStringList ("1234"), new SpanStringList("1").Append ("2").Append ("4") };
+            yield return new object[] { "123", new SpanStringList("1").Append ("2").Append ("3").Append ("4") };
+            yield return new object[] { new SpanStringList ("123").Append ("456").Append ("79").Append ("0"), new SpanStringList("12").Append ("34").Append ("6").Append ("78").Append ("90") };
+        }
+    }
+}

--- a/src/UdpClientExtensions.cs
+++ b/src/UdpClientExtensions.cs
@@ -36,7 +36,7 @@ using System.Threading.Tasks;
 
 namespace MonoTorrent
 {
-#if NET472 || NET5_0 || NET6_0 || NETCOREAPP3_0 || NETSTANDARD2_0 || NETSTANDARD2_1
+#if NET472 || NET5_0 || NET6_0 || NET8_0 || NETCOREAPP3_0 || NETSTANDARD2_0 || NETSTANDARD2_1
     static class UdpClientExtensions
     {
         public static Task<int> SendAsync (this UdpClient client, ReadOnlyMemory<byte> datagram, int bytes, IPEndPoint? endPoint)


### PR DESCRIPTION
For each file, the path relative to the SavePath, the full path to the file, and the full path to the incomplete file (FullPath + ".mt") are stored in memory. Zero memory allocation is great, but without fanaticism. Sometimes, instead of constantly traveling through pre-allocated objects during second-level garbage collection, it is better to create them if necessary and collect them at the zero level. Paths are needed only on fairly rare operations of opening a file and moving a file, and are not needed immediately after that.

In order to avoid significant refactoring of the code and tests (after all, this is an optimization task, not refactoring), instead of preallocating strings, an immutable list of parts of strings (Span) is preallocated.

There are other references to the original strings, so they remained in memory before that.

Also implemented equality operators for comparing lists and strings without strings allocations.

<img width="2558" height="560" alt="image" src="https://github.com/user-attachments/assets/a109a9c8-5bcf-4a1c-94bf-8e907db874c0" />

<img width="2559" height="657" alt="image" src="https://github.com/user-attachments/assets/e6d71a53-2f6f-4180-8de0-cb2493b0a8c5" />

Also optimized path escaping method and string can be allocated without performance degradation as many times as it almost never will be (if assuming that garbage collection has not accelerated).

Test data:
Valid - valid path (246be4fb-f7c0-43d2-88d0-df6947d51d92\\1afb977d-3c2b-431e-b81f-b7b15b8d3f72\\80c0cc63-1614-4e79-ba68-7bd53381cc44\\575827f1-a5f6-4353-b85c-09c9d8d29ff9\\836d2896-0ff8-4838-8d0a-2d868e76a7f7.mp4)
Invalid - path with 1 invalid symbol (246be4fb-f7c0-43d2-88d0-df6947d51d92\\1afb977d-3c2b-431e-b81f-b7b15b8d3f72\\80c0cc63-1614-4e79-ba68-7bd53381cc44\\575827f1-a5f6-4353-b85c-09c9d8d29ff9\\836d2896-0ff8-4838-8d0a-2d868e76a7f7?.mp4)
Invalid2 - path with 5 invalid symbols
<img width="1154" height="703" alt="image" src="https://github.com/user-attachments/assets/e4cfc672-6db0-408a-b173-73ea3a4f492f" />

