### PR TITLE
Fix AllFilesCorrectLength bug - torrents not marked complete after 100% downloaded

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Client.Modes/DownloadMode.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client.Modes/DownloadMode.cs
@@ -90,6 +90,10 @@ namespace MonoTorrent.Client.Modes
         internal async Task UpdateSeedingDownloadingState ()
         {
             //If download is fully complete, set state to 'Seeding' and send an announce to the tracker.
+            if (Manager.Bitfield.AllTrue) {
+                await Manager.RefreshAllFilesCorrectLengthAsync ();
+            }
+
             if (Manager.Complete && state == TorrentState.Downloading) {
                 state = TorrentState.Seeding;
                 await Task.WhenAll (


### PR DESCRIPTION
When a torrent completes downloading (Bitfield.AllTrue), RefreshAllFilesCorrectLengthAsync was not being called, so AllFilesCorrectLength remained false from startup/hash check. This caused torrents to reach 100% but never be marked as Complete.

This fix adds the RefreshAllFilesCorrectLengthAsync call in DownloadMode.UpdateSeedingDownloadingState when Bitfield.AllTrue, ensuring file lengths are verified before checking Complete status.