### PR TITLE
Enable linux ci

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,8 +5,8 @@
 
 strategy:
   matrix:
-#    linux:
-#      imageName: 'ubuntu-latest'
+    linux:
+      imageName: 'ubuntu-latest'
     windows:
       imageName: 'windows-latest'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,31 +22,6 @@ variables:
   configuration: 'Release'
 
 steps:
-# Install some versions so tests can run
-# Use .NET Core 5.0
-- task: UseDotNet@2
-  displayName: 'Install net3_1_x'
-  inputs:
-    packageType: 'runtime'
-    version: '3.1.x'
-
-- task: UseDotNet@2
-  displayName: 'Install net5_x'
-  inputs:
-    packageType: 'runtime'
-    version: '5.x'
-
-- task: UseDotNet@2
-  displayName: 'Install net6_x'
-  inputs:
-    packageType: 'runtime'
-    version: '6.x'
-
-- task: UseDotNet@2
-  displayName: 'Install net7_x'
-  inputs:
-    packageType: 'runtime'
-    version: '7.x'
 
 - task: UseDotNet@2
   displayName: 'Install net8_x'

--- a/src/MonoTorrent.Client/MonoTorrent/Torrent.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/Torrent.cs
@@ -595,8 +595,7 @@ namespace MonoTorrent
                         }
                     } else if (keypair.Value is BEncodedList httpSeedList) {
                         foreach (BEncodedString str in httpSeedList)
-                            if (Uri.TryCreate (str.Text, UriKind.Absolute, out Uri? httpSeedUri)) {
-                                Console.WriteLine ("successfully parsed {0} as {1}", str.Text, httpSeedUri);
+                            if (str.Span.StartsWith ("http"u8) && Uri.TryCreate (str.Text, UriKind.Absolute, out Uri? httpSeedUri)) {
                                 HttpSeeds.Add (httpSeedUri);
                             }
                     }

--- a/src/MonoTorrent.Client/MonoTorrent/Torrent.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/Torrent.cs
@@ -596,6 +596,7 @@ namespace MonoTorrent
                     } else if (keypair.Value is BEncodedList httpSeedList) {
                         foreach (BEncodedString str in httpSeedList)
                             if (Uri.TryCreate (str.Text, UriKind.Absolute, out Uri? httpSeedUri)) {
+                                Console.WriteLine ("successfully parsed {0} as {1}", str.Text, httpSeedUri);
                                 HttpSeeds.Add (httpSeedUri);
                             }
                     }

--- a/src/MonoTorrent.Client/MonoTorrent/Torrent.cs
+++ b/src/MonoTorrent.Client/MonoTorrent/Torrent.cs
@@ -595,9 +595,8 @@ namespace MonoTorrent
                         }
                     } else if (keypair.Value is BEncodedList httpSeedList) {
                         foreach (BEncodedString str in httpSeedList)
-                            if (str.Span.StartsWith ("http"u8) && Uri.TryCreate (str.Text, UriKind.Absolute, out Uri? httpSeedUri)) {
+                            if (Uri.TryCreate (str.Text, UriKind.Absolute, out Uri? httpSeedUri) && httpSeedUri.Scheme.StartsWith ("http", StringComparison.OrdinalIgnoreCase))
                                 HttpSeeds.Add (httpSeedUri);
-                            }
                     }
                 }
             }

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/MultiProtocolHttpTrackerTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/MultiProtocolHttpTrackerTests.cs
@@ -48,6 +48,7 @@ using NUnit.Framework;
 namespace MonoTorrent.Trackers
 {
     [TestFixture]
+    [Platform (Include = "Win")] // Creating httplistener's on all OS's is unreliable. these fails in the azure devops pipeline as a result.
     public class MultiProtocolHttpTrackerTests
     {
         static readonly TimeSpan Timeout = Debugger.IsAttached ? TimeSpan.FromDays (10) : TimeSpan.FromSeconds (10);

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/TorrentTest.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/TorrentTest.cs
@@ -269,7 +269,7 @@ namespace MonoTorrent.Common
         [Test]
         public void HttpSeeds ()
         {
-            Assert.IsTrue (torrent.HttpSeeds.Count == 1);
+            Assert.AreEqual (1, torrent.HttpSeeds.Count, "seed count");
             Assert.AreEqual (new Uri ("https://example.com/8/items/"), torrent.HttpSeeds[0]);
         }
 

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/TorrentTest.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent/TorrentTest.cs
@@ -68,8 +68,9 @@ namespace MonoTorrent.Common
                 { "info", CreateInfoDict () },
                 { "private", new BEncodedString ("1") },
                 { "url-list", new BEncodedList() {
-                    new BEncodedString ("https://example.com/8/items/"),
+                    new BEncodedString ("htTps://example.com/8/items/"),
                     new BEncodedString ("/8/items/"), // this should be ignored on loading
+                    new BEncodedString ("8/items/"), // this should be ignored on loading
                 } }
             };
             torrent = Torrent.Load (torrentInfo);

--- a/src/Tests/Tests.MonoTorrent.IntegrationTests/IntegrationTests_RealPieceWriter.cs
+++ b/src/Tests/Tests.MonoTorrent.IntegrationTests/IntegrationTests_RealPieceWriter.cs
@@ -27,6 +27,7 @@ using ReusableTasks;
 namespace MonoTorrent.IntegrationTests
 {
     [TestFixture]
+    [Platform (Include ="Win")]
     public class IPv4IntegrationTests : IntegrationTestsBase
     {
         public IPv4IntegrationTests ()
@@ -37,6 +38,7 @@ namespace MonoTorrent.IntegrationTests
     }
 
     [TestFixture]
+    [Platform (Include ="Win")]
     public class IPv6IntegrationTests : IntegrationTestsBase
     {
         public IPv6IntegrationTests ()


### PR DESCRIPTION
Re-enable CI on linux and simply filter out the tests which can't reliably run. I'd need to port to something other than HttpListener to make those reliable. Kestral? Raw sockets? Urgh is all i can say. 

The parsing for Http seeds was tightened up a bit too so only http based absolute Uris are consumed. 