### PR TITLE
Use both destination endpoint and DHT message ID to identify responses

### DIFF
--- a/src/MonoTorrent.Dht/MonoTorrent.Dht.Messages/DhtMessageFactory.cs
+++ b/src/MonoTorrent.Dht/MonoTorrent.Dht.Messages/DhtMessageFactory.cs
@@ -30,6 +30,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Net;
 
 using MonoTorrent.BEncoding;
 
@@ -42,7 +43,7 @@ namespace MonoTorrent.Dht.Messages
         static readonly BEncodedString TransactionIdKey = new BEncodedString ("t");
         static readonly Dictionary<BEncodedString, Func<BEncodedDictionary, DhtMessage>> queryDecoders = new Dictionary<BEncodedString, Func<BEncodedDictionary, DhtMessage>> ();
 
-        readonly Dictionary<BEncodedValue, QueryMessage> messages = new Dictionary<BEncodedValue, QueryMessage> ();
+        readonly Dictionary<(BEncodedValue, IPEndPoint), QueryMessage> messages = new Dictionary<(BEncodedValue, IPEndPoint), QueryMessage> ();
 
 
         public int RegisteredMessages => messages.Count;
@@ -55,35 +56,49 @@ namespace MonoTorrent.Dht.Messages
             queryDecoders.Add (new BEncodedString ("ping"), d => new Ping (d));
         }
 
-        internal bool IsRegistered (BEncodedValue transactionId)
+        internal bool IsRegistered (BEncodedValue transactionId, IPEndPoint destination)
         {
-            return messages.ContainsKey (transactionId);
+            return messages.ContainsKey ((transactionId, destination));
         }
 
-        public void RegisterSend (QueryMessage message)
+        public void RegisterSend (QueryMessage message, IPEndPoint destination)
         {
-            messages.Add (message.TransactionId ?? throw new ArgumentException ("The message must have a transaction id set"), message);
+            if (message is null)
+                throw new ArgumentNullException (nameof (message));
+            if (message.TransactionId is null)
+                throw new ArgumentException ("The message must have a transaction id set");
+            if (destination is null)
+                throw new ArgumentNullException (nameof (destination));
+
+            messages.Add (((BEncodedValue) message.TransactionId, destination), message);
         }
 
-        public bool UnregisterSend (QueryMessage message)
+        public bool UnregisterSend (QueryMessage message, IPEndPoint destination)
         {
-            return messages.Remove (message.TransactionId ?? throw new ArgumentException("The message must have a transaction id set"));
+            if (message is null)
+                throw new ArgumentNullException (nameof (message));
+            if (message.TransactionId is null)
+                throw new ArgumentException ("The message must have a transaction id set");
+            if (destination is null)
+                throw new ArgumentNullException (nameof (destination));
+
+            return messages.Remove ((message.TransactionId, destination));
         }
 
-        public DhtMessage DecodeMessage (BEncodedDictionary dictionary)
+        public DhtMessage DecodeMessage (BEncodedDictionary dictionary, IPEndPoint source)
         {
-            if (!TryDecodeMessage (dictionary, out DhtMessage? message, out string? error))
+            if (!TryDecodeMessage (dictionary, source, out DhtMessage? message, out string? error))
                 throw new MessageException (ErrorCode.GenericError, error!);
 
             return message;
         }
 
-        public bool TryDecodeMessage (BEncodedDictionary dictionary, [NotNullWhen (true)] out DhtMessage? message)
+        public bool TryDecodeMessage (BEncodedDictionary dictionary, IPEndPoint source, [NotNullWhen (true)] out DhtMessage? message)
         {
-            return TryDecodeMessage (dictionary, out message, out string? error);
+            return TryDecodeMessage (dictionary, source, out message, out string? error);
         }
 
-        public bool TryDecodeMessage (BEncodedDictionary dictionary, [NotNullWhen(true)] out DhtMessage? message, out string? error)
+        public bool TryDecodeMessage (BEncodedDictionary dictionary, IPEndPoint? source, [NotNullWhen(true)] out DhtMessage? message, out string? error)
         {
             message = null;
             error = null;
@@ -98,9 +113,11 @@ namespace MonoTorrent.Dht.Messages
                 message = queryDecoders[(BEncodedString) dictionary[QueryNameKey]] (dictionary);
             } else if (messageType.Equals (ErrorMessage.ErrorType)) {
                 message = new ErrorMessage (dictionary);
-                messages.Remove (message.TransactionId!);
+                messages.Remove ((message.TransactionId!, source!));
             } else {
-                var key = (BEncodedString) dictionary[TransactionIdKey];
+                if (source is null)
+                    throw new InvalidOperationException ("Attempted to decode a response but no source IP was supplied");
+                var key = ((BEncodedValue) dictionary[TransactionIdKey], source!);
                 if (messages.TryGetValue (key, out QueryMessage? query)) {
                     messages.Remove (key);
                     try {

--- a/src/MonoTorrent.Dht/MonoTorrent.Dht/MessageLoop.cs
+++ b/src/MonoTorrent.Dht/MonoTorrent.Dht/MessageLoop.cs
@@ -160,7 +160,7 @@ namespace MonoTorrent.Dht
             // FIXME: This should throw an exception if the message doesn't exist, we need to handle this
             // and return an error message (if that's what the spec allows)
             try {
-                if (DhtMessageFactory.TryDecodeMessage ((BEncodedDictionary) BEncodedValue.Decode (buffer.Span), out DhtMessage? message)) {
+                if (DhtMessageFactory.TryDecodeMessage ((BEncodedDictionary) BEncodedValue.Decode (buffer.Span), endpoint, out DhtMessage? message)) {
                     Monitor.ReceiveMonitor.AddDelta (buffer.Length);
                     ReceiveQueue.Enqueue (new KeyValuePair<IPEndPoint, DhtMessage> (endpoint, message!));
                 }
@@ -252,7 +252,7 @@ namespace MonoTorrent.Dht
         {
             DhtEngine.MainLoop.CheckThread ();
 
-            DhtMessageFactory.UnregisterSend ((QueryMessage) v.Message);
+            DhtMessageFactory.UnregisterSend ((QueryMessage) v.Message, v.Destination);
             WaitingResponse.Remove (v.Message.TransactionId!);
 
             v.CompletionSource?.TrySetResult (new SendQueryEventArgs (v.Node!, v.Destination, (QueryMessage) v.Message));
@@ -346,12 +346,12 @@ namespace MonoTorrent.Dht
                     throw new ArgumentException ("Message must have a transaction id");
                 do {
                     message.TransactionId = TransactionId.NextId ();
-                } while (DhtMessageFactory.IsRegistered (message.TransactionId));
+                } while (DhtMessageFactory.IsRegistered (message.TransactionId, endpoint));
             }
 
             // We need to be able to cancel a query message if we time out waiting for a response
             if (message is QueryMessage)
-                DhtMessageFactory.RegisterSend ((QueryMessage) message);
+                DhtMessageFactory.RegisterSend ((QueryMessage) message, endpoint);
 
             SendQueue.Enqueue (new SendDetails (node, endpoint, message, tcs));
         }

--- a/src/MonoTorrent.Dht/MonoTorrent.Dht/TransactionId.cs
+++ b/src/MonoTorrent.Dht/MonoTorrent.Dht/TransactionId.cs
@@ -26,6 +26,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
+using System;
 using System.Threading;
 
 using MonoTorrent.BEncoding;

--- a/src/Tests/Tests.MonoTorrent.Dht/MonoTorrent.Dht/MessageHandlingTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Dht/MonoTorrent.Dht/MessageHandlingTests.cs
@@ -50,10 +50,10 @@ namespace MonoTorrent.Dht
             };
 
             listener.MessageSent += (data, endpoint) => {
-                engine.MessageLoop.DhtMessageFactory.TryDecodeMessage (BEncodedValue.Decode<BEncodedDictionary> (data.Span), out DhtMessage message);
+                engine.MessageLoop.DhtMessageFactory.TryDecodeMessage (BEncodedValue.Decode<BEncodedDictionary> (data.Span), node.EndPoint, out DhtMessage message);
 
                 // This TransactionId should be registered and it should be pending a response.
-                if (!DhtMessageFactory.IsRegistered (ping.TransactionId) || engine.MessageLoop.PendingQueries != 1)
+                if (!DhtMessageFactory.IsRegistered (ping.TransactionId, node.EndPoint) || engine.MessageLoop.PendingQueries != 1)
                     pingSuccessful.TrySetResult (false);
 
                 if (message.TransactionId.Equals (ping.TransactionId)) {
@@ -69,7 +69,7 @@ namespace MonoTorrent.Dht
             Assert.IsTrue (task.AsTask ().Wait (100000), "#1");
             Assert.IsTrue (pingSuccessful.Task.Wait (1000), "#2");
             Assert.IsTrue (pingSuccessful.Task.Result, "#3");
-            Assert.IsFalse (DhtMessageFactory.IsRegistered (ping.TransactionId), "#4");
+            Assert.IsFalse (DhtMessageFactory.IsRegistered (ping.TransactionId, node.EndPoint), "#4");
             Assert.AreEqual (0, engine.MessageLoop.PendingQueries, "#5");
             Assert.AreEqual (1, failedCount, "#6");
         }
@@ -88,7 +88,7 @@ namespace MonoTorrent.Dht
 
             var tcs = new TaskCompletionSource<object> ();
             listener.MessageSent += (data, endpoint) => {
-                engine.MessageLoop.DhtMessageFactory.TryDecodeMessage (BEncodedValue.Decode<BEncodedDictionary> (data.Span), out DhtMessage message);
+                engine.MessageLoop.DhtMessageFactory.TryDecodeMessage (BEncodedValue.Decode<BEncodedDictionary> (data.Span), node.EndPoint, out DhtMessage message);
 
                 if (message is Ping && endpoint.Equals (node.EndPoint)) {
                     var response = new PingResponse (node.Id, message.TransactionId);
@@ -124,7 +124,7 @@ namespace MonoTorrent.Dht
             };
 
             listener.MessageSent += (data, endpoint) => {
-                engine.MessageLoop.DhtMessageFactory.TryDecodeMessage (BEncodedValue.Decode<BEncodedDictionary> (data.Span), out DhtMessage message);
+                engine.MessageLoop.DhtMessageFactory.TryDecodeMessage (BEncodedValue.Decode<BEncodedDictionary> (data.Span), node.EndPoint, out DhtMessage message);
 
                 if (message.TransactionId.Equals (ping.TransactionId)) {
                     var response = new PingResponse (node.Id, transactionId);

--- a/src/Tests/Tests.MonoTorrent.Dht/MonoTorrent.Dht/MessageTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Dht/MonoTorrent.Dht/MessageTests.cs
@@ -28,6 +28,8 @@
 
 
 using System;
+using System.IO;
+using System.Net;
 using System.Text;
 
 using MonoTorrent.BEncoding;
@@ -166,13 +168,25 @@ namespace MonoTorrent.Dht
         {
             // Register the query as being sent so we can decode the response
             AnnouncePeerDecode ();
-            DhtMessageFactory.RegisterSend (message);
+            DhtMessageFactory.RegisterSend (message, new IPEndPoint (IPAddress.Any, 1));
             string text = "d1:rd2:id20:mnopqrstuvwxyz123456e1:t2:aa1:y1:re";
 
-            AnnouncePeerResponse m = (AnnouncePeerResponse) Decode (text);
+            AnnouncePeerResponse m = (AnnouncePeerResponse) Decode (text, new IPEndPoint (IPAddress.Any, 1));
             Assert.AreEqual (infohash, m.Id, "#1");
 
             Compare (m, text);
+        }
+
+        [Test]
+        public void AnnouncePeerResponse_Unregistered ()
+        {
+            // The message was reigstered to a different ip  / port
+            AnnouncePeerDecode ();
+            DhtMessageFactory.RegisterSend (message, new IPEndPoint (IPAddress.Loopback, 1));
+            string text = "d1:rd2:id20:mnopqrstuvwxyz123456e1:t2:aa1:y1:re";
+
+            Assert.Throws<MessageException> (() => Decode (text, new IPEndPoint (IPAddress.Broadcast, 1)));
+            Assert.Throws<MessageException> (() => Decode (text, new IPEndPoint (IPAddress.Loopback, 2)));
         }
 
         [Test]
@@ -190,9 +204,9 @@ namespace MonoTorrent.Dht
         public void FindNodeResponseDecode ()
         {
             FindNodeEncode ();
-            DhtMessageFactory.RegisterSend (message);
+            DhtMessageFactory.RegisterSend (message, new IPEndPoint (IPAddress.Any, 5));
             string text = "d1:rd2:id20:abcdefghij01234567895:nodes9:def456...e1:t2:aa1:y1:re";
-            FindNodeResponse m = (FindNodeResponse) Decode (text);
+            FindNodeResponse m = (FindNodeResponse) Decode (text, new IPEndPoint (IPAddress.Any, 5));
 
             Assert.AreEqual (id, m.Id, "#1");
             Assert.AreEqual ((BEncodedString) "def456...", m.Nodes, "#2");
@@ -218,10 +232,10 @@ namespace MonoTorrent.Dht
         public void GetPeersResponseDecode ()
         {
             GetPeersEncode ();
-            DhtMessageFactory.RegisterSend (message);
+            DhtMessageFactory.RegisterSend (message, new IPEndPoint (IPAddress.Any, 5));
 
             string text = "d1:rd2:id20:abcdefghij01234567895:token8:aoeusnth6:valuesl6:axje.u6:idhtnmee1:t2:aa1:y1:re";
-            GetPeersResponse m = (GetPeersResponse) Decode (text);
+            GetPeersResponse m = (GetPeersResponse) Decode (text, new IPEndPoint (IPAddress.Any, 5));
 
             Assert.AreEqual (token, m.Token, "#1");
             Assert.AreEqual (id, m.Id, "#2");
@@ -249,10 +263,10 @@ namespace MonoTorrent.Dht
         public void PingResponseDecode ()
         {
             PingEncode ();
-            DhtMessageFactory.RegisterSend (message);
+            DhtMessageFactory.RegisterSend (message, new IPEndPoint (IPAddress.Any, 5));
 
             string text = "d1:rd2:id20:mnopqrstuvwxyz123456e1:t2:aa1:y1:re";
-            PingResponse m = (PingResponse) Decode (text);
+            PingResponse m = (PingResponse) Decode (text, new IPEndPoint (IPAddress.Any, 5));
 
             Assert.AreEqual (infohash, m.Id);
 
@@ -269,9 +283,12 @@ namespace MonoTorrent.Dht
         }
 
         private DhtMessage Decode (string p)
+            => Decode (p, null);
+
+        private DhtMessage Decode (string p, IPEndPoint endPoint)
         {
             byte[] buffer = Encoding.UTF8.GetBytes (p);
-            return DhtMessageFactory.DecodeMessage (BEncodedValue.Decode<BEncodedDictionary> (buffer));
+            return DhtMessageFactory.DecodeMessage (BEncodedValue.Decode<BEncodedDictionary> (buffer), endPoint);
         }
     }
 }

--- a/src/Tests/Tests.MonoTorrent.Dht/MonoTorrent.Dht/TaskTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Dht/MonoTorrent.Dht/TaskTests.cs
@@ -97,7 +97,7 @@ namespace MonoTorrent.Dht
                 TransactionId = transactionId
             };
             listener.MessageSent += (data, endpoint) => {
-                engine.MessageLoop.DhtMessageFactory.TryDecodeMessage (BEncodedValue.Decode<BEncodedDictionary> (data.Span), out DhtMessage message);
+                engine.MessageLoop.DhtMessageFactory.TryDecodeMessage (BEncodedValue.Decode<BEncodedDictionary> (data.Span), node.EndPoint, out DhtMessage message);
                 if (message is Ping && message.TransactionId.Equals (ping.TransactionId)) {
                     counter++;
                     PingResponse response = new PingResponse (node.Id, transactionId);
@@ -129,7 +129,7 @@ namespace MonoTorrent.Dht
             b.Nodes[5].Seen (TimeSpan.FromDays (3));
 
             listener.MessageSent += (data, endpoint) => {
-                engine.MessageLoop.DhtMessageFactory.TryDecodeMessage (BEncodedValue.Decode<BEncodedDictionary> (data.Span), out DhtMessage message);
+                engine.MessageLoop.DhtMessageFactory.TryDecodeMessage (BEncodedValue.Decode<BEncodedDictionary> (data.Span), endpoint, out DhtMessage message);
 
                 b.Nodes.Sort ((l, r) => l.LastSeen.CompareTo (r.LastSeen));
                 if ((endpoint.Port == 3 && nodeCount == 0) ||
@@ -138,7 +138,7 @@ namespace MonoTorrent.Dht
                     Node n = b.Nodes.Find (no => no.EndPoint.Port == endpoint.Port);
                     n.Seen ();
                     PingResponse response = new PingResponse (n.Id, message.TransactionId);
-                    listener.RaiseMessageReceived (response, node.EndPoint);
+                    listener.RaiseMessageReceived (response, n.EndPoint);
                     nodeCount++;
                 }
 
@@ -156,7 +156,7 @@ namespace MonoTorrent.Dht
                 nodes.Add (new Node (NodeId.Create (), new IPEndPoint (IPAddress.Any, i)));
 
             listener.MessageSent += (data, endpoint) => {
-                engine.MessageLoop.DhtMessageFactory.TryDecodeMessage (BEncodedValue.Decode<BEncodedDictionary> (data.Span), out DhtMessage message);
+                engine.MessageLoop.DhtMessageFactory.TryDecodeMessage (BEncodedValue.Decode<BEncodedDictionary> (data.Span), node.EndPoint, out DhtMessage message);
 
                 Node current = nodes.Find (n => n.EndPoint.Port.Equals (endpoint.Port));
                 if (current == null)


### PR DESCRIPTION
This should be better than simply increasing the transaction id size from 2 bytes to 4 bytes.

In the prior setup there is a chance that if there are hundreds of active torrents, each of which are announcing to the DHT engine, then all 65k unique transaction IDs could be consumed. Even if that didn't occur, the CPU cost of looking for an unused ID would be high. By further filtering by destination IP there's a stronger upper bound on the total number of scans needed to find an unused transaction ID.