### PR TITLE
Dht optimisations

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Client/ClientEngine.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/ClientEngine.cs
@@ -219,9 +219,9 @@ namespace MonoTorrent.Client
 
         public ConnectionManager ConnectionManager { get; }
 
-        public IDht Dht { get; private set; }
+        public IDht Dht => DhtEngine;
 
-        internal IDhtEngine DhtEngine { get; private set; }
+        internal DhtEngineWrapper DhtEngine { get; private set; }
 
         IDhtListener DhtListener { get; set; }
 
@@ -336,11 +336,10 @@ namespace MonoTorrent.Client
             listenManager.SetListeners (PeerListeners);
 
             DhtListener = (settings.DhtEndPoint == null ? null : Factories.CreateDhtListener (settings.DhtEndPoint)) ?? new NullDhtListener ();
-            DhtEngine = (settings.DhtEndPoint == null ? null : Factories.CreateDht ()) ?? new NullDhtEngine ();
-            Dht = new DhtEngineWrapper (DhtEngine);
+            var engine = (settings.DhtEndPoint == null ? null : Factories.CreateDht ()) ?? new NullDhtEngine ();
+            DhtEngine = new DhtEngineWrapper (engine);
             DhtEngine.SetListenerAsync (DhtListener).GetAwaiter ().GetResult ();
 
-            DhtEngine.StateChanged += DhtEngineStateChanged;
             DhtEngine.PeersFound += DhtEnginePeersFound;
             LocalPeerDiscovery = new NullLocalPeerDiscovery ();
 
@@ -658,7 +657,7 @@ namespace MonoTorrent.Client
             manager.UploadLimiters.Add (uploadLimiters);
             if (DhtEngine != null && manager.Torrent?.Nodes != null && DhtEngine.State != DhtState.Ready) {
                 try {
-                    DhtEngine.Add (manager.Torrent.Nodes.OfType<BEncodedString> ().Select (t => t.AsMemory ()));
+                    DhtEngine.AddAsync (manager.Torrent.Nodes.OfType<BEncodedString> ().Select (t => t.AsMemory ()));
                 } catch {
                     // FIXME: Should log this somewhere, though it's not critical
                 }
@@ -668,15 +667,13 @@ namespace MonoTorrent.Client
         async Task RegisterDht (IDhtEngine engine)
         {
             if (DhtEngine != null) {
-                DhtEngine.StateChanged -= DhtEngineStateChanged;
                 DhtEngine.PeersFound -= DhtEnginePeersFound;
                 await DhtEngine.StopAsync ();
                 DhtEngine.Dispose ();
             }
-            DhtEngine = engine ?? new NullDhtEngine ();
-            Dht = new DhtEngineWrapper (DhtEngine);
 
-            DhtEngine.StateChanged += DhtEngineStateChanged;
+            DhtEngine = new DhtEngineWrapper (engine ?? new NullDhtEngine ());
+
             DhtEngine.PeersFound += DhtEnginePeersFound;
             if (IsRunning)
                 await DhtEngine.StartAsync (await MaybeLoadDhtNodes ());
@@ -717,28 +714,6 @@ namespace MonoTorrent.Client
                 // This is only used for unit testing to validate that even if the DHT engine
                 // finds peers for a private torrent, we will not add them to the manager.
                 manager.RaisePeersFound (new DhtPeersAdded (manager, 0, 0));
-            }
-        }
-
-        async void DhtEngineStateChanged (object? o, EventArgs e)
-        {
-            if (DhtEngine.State != DhtState.Ready)
-                return;
-
-            await MainLoop;
-            foreach (TorrentManager manager in allTorrents) {
-                if (!manager.CanUseDht)
-                    continue;
-
-                // IPV6: Also report to an ipv6 DHT node
-                if (manager.InfoHashes.V1 != null) {
-                    DhtEngine.Announce (manager.InfoHashes.V1, GetOverrideOrActualListenPort ("ipv4") ?? -1);
-                    DhtEngine.GetPeers (manager.InfoHashes.V1);
-                }
-                if (manager.InfoHashes.V2 != null) {
-                    DhtEngine.Announce (manager.InfoHashes.V2.Truncate (), GetOverrideOrActualListenPort ("ipv4") ?? -1);
-                    DhtEngine.GetPeers (manager.InfoHashes.V2.Truncate ());
-                }
             }
         }
 

--- a/src/MonoTorrent.Client/MonoTorrent.Client/IDhtAnnounceScheduler.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/IDhtAnnounceScheduler.cs
@@ -1,0 +1,41 @@
+//
+// IDhtAnnounceScheduler.cs
+//
+// Authors:
+//   Alan McGovern alan.mcgovern@gmail.com
+//
+// Copyright (C) 2026 Alan McGovern
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MonoTorrent.Client
+{
+    interface IDhtAnnounceScheduler
+    {
+        bool TryEnqueueAnnounce (InfoHashes infoHash, int port, CancellationToken token);
+        bool TryEnqueueGetPeers (InfoHashes infoHash, CancellationToken token);
+    }
+}

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/TorrentManager.cs
@@ -801,13 +801,13 @@ namespace MonoTorrent.Client
         {
             await ClientEngine.MainLoop;
 
-            if (CanUseDht && Engine != null && (!LastDhtAnnounceTimer.IsRunning || LastDhtAnnounceTimer.Elapsed > Engine.DhtEngine.MinimumAnnounceInterval)) {
-                LastDhtAnnounce = DateTime.UtcNow;
-                LastDhtAnnounceTimer.Restart ();
-                if (InfoHashes.V2 != null)
-                    Engine.DhtEngine.GetPeers (InfoHashes.V2.Truncate ());
-                if (InfoHashes.V1 != null)
-                    Engine.DhtEngine.GetPeers (InfoHashes.V1);
+            if (CanUseDht && Engine != null && Engine.Dht.State == Dht.DhtState.Ready && (!LastDhtAnnounceTimer.IsRunning || LastDhtAnnounceTimer.Elapsed > Engine.DhtEngine.MinimumAnnounceInterval)) {
+                // There's a concurrency limit on querying DHT so only mark the torrent as 'announcing' to DHT
+                // if we get a slot. Otherwise it'll be attempted again during the next iteration.
+                if (Engine.DhtEngine.TryEnqueueGetPeers (InfoHashes, Mode.Token)) {
+                    LastDhtAnnounce = DateTime.UtcNow;
+                    LastDhtAnnounceTimer.Restart ();
+                }
             }
         }
 

--- a/src/MonoTorrent.Client/MonoTorrent.Dht/DhtEngineWrapper.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Dht/DhtEngineWrapper.cs
@@ -27,15 +27,29 @@
 //
 
 using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading;
+using System.Threading.Tasks;
 
+using MonoTorrent.Connections.Dht;
 using MonoTorrent.Dht;
+using MonoTorrent.Logging;
+
+using ReusableTasks;
 
 namespace MonoTorrent.Client
 {
-    class DhtEngineWrapper : IDht
+    class DhtEngineWrapper : IDht, IDhtAnnounceScheduler
     {
+        static readonly Logger Log = Logger.Create (nameof (DhtEngineWrapper));
+
+        readonly SemaphoreSlim AnnounceConcurrency = new SemaphoreSlim (20, 20);
+        readonly SemaphoreSlim GetPeersConcurrency = new SemaphoreSlim (20, 20);
+
         IDhtEngine Engine { get; }
 
+        public EventHandler<PeersFoundEventArgs>? PeersFound;
         public event EventHandler? StateChanged;
 
         public ITransferMonitor Monitor => Engine.Monitor;
@@ -47,7 +61,89 @@ namespace MonoTorrent.Client
         public DhtEngineWrapper (IDhtEngine engine)
         {
             Engine = engine;
-            Engine.StateChanged += (o, e) => StateChanged?.Invoke (this, EventArgs.Empty);
+            Engine.StateChanged += (o, e) => StateChanged?.Invoke (this, e);
+            engine.PeersFound += (o, e) => PeersFound?.Invoke (this, e);
         }
+
+        public bool TryEnqueueAnnounce (InfoHashes infoHashes, int port, CancellationToken token)
+        {
+            if (infoHashes is null)
+                throw new ArgumentNullException (nameof (infoHashes));
+            if (State != DhtState.Ready)
+                throw new InvalidOperationException ("You cannot 'Announce' while the dht table is initialising");
+
+            if (!AnnounceConcurrency.Wait (0))
+                return false;
+
+            static async void Announce (IDhtEngine engine, SemaphoreSlim semaphore, InfoHashes infoHashes, int port, CancellationToken token)
+            {
+                try {
+                    // Announce to both infohashes if they exist.
+                    var v1 = engine.AnnounceAsync (infoHashes.V1OrV2.Truncate (), port);
+                    try {
+                        if (infoHashes.IsHybrid)
+                            await engine.AnnounceAsync (infoHashes.V2.Truncate (), port);
+                    } finally {
+                        await v1;
+                    }
+                } catch (Exception ex) {
+                    if (ex.GetBaseException () is not OperationCanceledException op || op.CancellationToken != token) {
+                        Log.Exception (ex, "Unexpected failure announcing an infohash to the DhtEngine");
+                    }
+                } finally {
+                    semaphore.Release ();
+                }
+            }
+
+            Announce (Engine, AnnounceConcurrency, infoHashes, port, token);
+            return true;
+        }
+
+        public bool TryEnqueueGetPeers (InfoHashes infoHashes, CancellationToken token)
+        {
+            if (infoHashes == null)
+                throw new ArgumentNullException (nameof (infoHashes));
+            if (State != DhtState.Ready)
+                throw new InvalidOperationException ("You cannot 'GetPeers' while the dht table is initialising");
+
+            if (!GetPeersConcurrency.Wait (0))
+                return false;
+
+            static async void GetPeers (IDhtEngine engine, SemaphoreSlim semaphore, InfoHashes infoHashes)
+            {
+                try {
+                    // Run 'GetPeers' on both infohashes if they exist
+                    var t1 = engine.GetPeersAsync (infoHashes.V1OrV2.Truncate ());
+                    try {
+                        if (infoHashes.IsHybrid)
+                            await engine.GetPeersAsync (infoHashes.V2.Truncate ());
+                    } finally {
+                        await t1;
+                    }
+                } finally {
+                    semaphore.Release ();
+                }
+            }
+            GetPeers (Engine, GetPeersConcurrency, infoHashes);
+            return true;
+        }
+
+        internal ReusableTask SetListenerAsync (IDhtListener dhtListener)
+            => Engine.SetListenerAsync (dhtListener);
+
+        internal void Dispose ()
+            => Engine.Dispose ();
+
+        internal ReusableTask StopAsync ()
+            => Engine.StopAsync ();
+
+        internal ReusableTask StartAsync (ReadOnlyMemory<byte> readOnlyMemory)
+            => Engine.StartAsync ();
+
+        internal ReusableTask AddAsync (IEnumerable<ReadOnlyMemory<byte>> enumerable)
+            => Engine.AddAsync (enumerable);
+
+        internal ReusableTask<ReadOnlyMemory<byte>> SaveNodesAsync ()
+            => Engine.SaveNodesAsync ();
     }
 }

--- a/src/MonoTorrent.Client/MonoTorrent.Dht/NullDhtEngine.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Dht/NullDhtEngine.cs
@@ -34,6 +34,8 @@ using System.Threading.Tasks;
 using MonoTorrent.Connections.Dht;
 using MonoTorrent.Dht;
 
+using ReusableTasks;
+
 namespace MonoTorrent.Client
 {
     class NullTransferMonitor : ITransferMonitor
@@ -66,14 +68,14 @@ namespace MonoTorrent.Client
 
         public DhtState State => DhtState.NotReady;
 
-        public void Add (IEnumerable<ReadOnlyMemory<byte>> nodes)
+        public ReusableTask AddAsync (IEnumerable<ReadOnlyMemory<byte>> nodes)
         {
-
+            return default;
         }
 
-        public void Announce (InfoHash infoHash, int port)
+        public ReusableTask AnnounceAsync (InfoHash infoHash, int port)
         {
-
+            return default;
         }
 
         public void Dispose ()
@@ -81,34 +83,34 @@ namespace MonoTorrent.Client
 
         }
 
-        public void GetPeers (InfoHash infoHash)
+        public ReusableTask GetPeersAsync (InfoHash infoHash)
         {
-
+            return default;
         }
 
-        public Task<ReadOnlyMemory<byte>> SaveNodesAsync ()
+        public ReusableTask<ReadOnlyMemory<byte>> SaveNodesAsync ()
         {
-            return Task.FromResult (ReadOnlyMemory<byte>.Empty);
+            return default;
         }
 
-        public Task SetListenerAsync (IDhtListener listener)
+        public ReusableTask SetListenerAsync (IDhtListener listener)
         {
-            return Task.CompletedTask;
+            return default;
         }
 
-        public Task StartAsync ()
+        public ReusableTask StartAsync ()
         {
-            return Task.CompletedTask;
+            return default;
         }
 
-        public Task StartAsync (ReadOnlyMemory<byte> initialNodes)
+        public ReusableTask StartAsync (ReadOnlyMemory<byte> initialNodes)
         {
-            return Task.CompletedTask;
+            return default;
         }
 
-        public Task StopAsync ()
+        public ReusableTask StopAsync ()
         {
-            return Task.CompletedTask;
+            return default;
         }
     }
 }

--- a/src/MonoTorrent.Dht/MonoTorrent.Dht/DhtEngine.cs
+++ b/src/MonoTorrent.Dht/MonoTorrent.Dht/DhtEngine.cs
@@ -124,7 +124,7 @@ namespace MonoTorrent.Dht
             });
         }
 
-        public async void Add (IEnumerable<ReadOnlyMemory<byte>> nodes)
+        public async ReusableTask AddAsync (IEnumerable<ReadOnlyMemory<byte>> nodes)
         {
             if (State == DhtState.NotReady) {
                 PendingNodes = Node.FromCompactNode (nodes);
@@ -143,14 +143,16 @@ namespace MonoTorrent.Dht
             }
         }
 
-        internal async Task Add (Node node)
+        internal async ReusableTask Add (Node node)
             => await SendQueryAsync (new Ping (RoutingTable.LocalNodeId), node);
 
-        public async void Announce (InfoHash infoHash, int port)
+        public async ReusableTask AnnounceAsync (InfoHash infoHash, int port)
         {
             CheckDisposed ();
             if (infoHash is null)
                 throw new ArgumentNullException (nameof (infoHash));
+            if (State != DhtState.Ready)
+                throw new InvalidOperationException ("You cannot 'Announce' while the dht table is initialising");
 
             try {
                 await MainLoop;
@@ -178,11 +180,13 @@ namespace MonoTorrent.Dht
             });
         }
 
-        public async void GetPeers (InfoHash infoHash)
+        public async ReusableTask GetPeersAsync (InfoHash infoHash)
         {
             CheckDisposed ();
             if (infoHash == null)
                 throw new ArgumentNullException (nameof (infoHash));
+            if (State != DhtState.Ready)
+                throw new InvalidOperationException ("You cannot 'GetPeers' while the dht table is initialising");
 
             try {
                 await MainLoop;
@@ -235,7 +239,7 @@ namespace MonoTorrent.Dht
                 await Task.WhenAll (refreshTasks).ConfigureAwait (false);
         }
 
-        public async Task<ReadOnlyMemory<byte>> SaveNodesAsync ()
+        public async ReusableTask<ReadOnlyMemory<byte>> SaveNodesAsync ()
         {
             await MainLoop;
 
@@ -276,19 +280,19 @@ namespace MonoTorrent.Dht
             return e;
         }
 
-        public Task StartAsync ()
+        public ReusableTask StartAsync ()
             => StartAsync (ReadOnlyMemory<byte>.Empty);
 
-        public Task StartAsync (ReadOnlyMemory<byte> initialNodes)
+        public ReusableTask StartAsync (ReadOnlyMemory<byte> initialNodes)
             => StartAsync (Node.FromCompactNode (BEncodedString.FromMemory (initialNodes)).Concat (PendingNodes), DefaultBootstrapRouters.ToArray ());
 
-        public Task StartAsync (params string[] bootstrapRouters)
+        public ReusableTask StartAsync (params string[] bootstrapRouters)
             => StartAsync (Array.Empty<Node> (), bootstrapRouters);
 
-        public Task StartAsync (ReadOnlyMemory<byte> initialNodes, params string[] bootstrapRouters)
+        public ReusableTask StartAsync (ReadOnlyMemory<byte> initialNodes, params string[] bootstrapRouters)
             => StartAsync (Node.FromCompactNode (BEncodedString.FromMemory (initialNodes)).Concat (PendingNodes), bootstrapRouters);
 
-        async Task StartAsync (IEnumerable<Node> nodes, string[] bootstrapRouters)
+        async ReusableTask StartAsync (IEnumerable<Node> nodes, string[] bootstrapRouters)
         {
             CheckDisposed ();
 
@@ -309,7 +313,7 @@ namespace MonoTorrent.Dht
             });
         }
 
-        public async Task StopAsync ()
+        public async ReusableTask StopAsync ()
         {
             await MainLoop;
 
@@ -337,7 +341,7 @@ namespace MonoTorrent.Dht
             await tcs.Task;
         }
 
-        public async Task SetListenerAsync (IDhtListener listener)
+        public async ReusableTask SetListenerAsync (IDhtListener listener)
         {
             await MainLoop;
             await MessageLoop.SetListener (listener);

--- a/src/MonoTorrent/MonoTorrent.Dht/IDhtEngine.cs
+++ b/src/MonoTorrent/MonoTorrent.Dht/IDhtEngine.cs
@@ -33,6 +33,8 @@ using System.Threading.Tasks;
 
 using MonoTorrent.Connections.Dht;
 
+using ReusableTasks;
+
 namespace MonoTorrent.Dht
 {
     public interface ITransferMonitor
@@ -70,13 +72,13 @@ namespace MonoTorrent.Dht
         int NodeCount { get; }
         DhtState State { get; }
 
-        void Add (IEnumerable<ReadOnlyMemory<byte>> nodes);
-        void Announce (InfoHash infoHash, int port);
-        void GetPeers (InfoHash infoHash);
-        Task<ReadOnlyMemory<byte>> SaveNodesAsync ();
-        Task SetListenerAsync (IDhtListener listener);
-        Task StartAsync ();
-        Task StartAsync (ReadOnlyMemory<byte> initialNodes);
-        Task StopAsync ();
+        ReusableTask AddAsync (IEnumerable<ReadOnlyMemory<byte>> nodes);
+        ReusableTask AnnounceAsync (InfoHash infoHash, int port);
+        ReusableTask GetPeersAsync (InfoHash infoHash);
+        ReusableTask<ReadOnlyMemory<byte>> SaveNodesAsync ();
+        ReusableTask SetListenerAsync (IDhtListener listener);
+        ReusableTask StartAsync ();
+        ReusableTask StartAsync (ReadOnlyMemory<byte> initialNodes);
+        ReusableTask StopAsync ();
     }
 }

--- a/src/Samples/DhtSampleClient/Program.cs
+++ b/src/Samples/DhtSampleClient/Program.cs
@@ -56,16 +56,16 @@ namespace ClientSample
             // Begin querying for a ubuntu torrent
             var infoHash = InfoHash.FromBase32 ("FKSPLJ7CBHSUWMUAHVBWOCLRYTEMVKQF");
 
-            // Kick off the firs search. Discovered peers will be returned via the 'PeersFound'
+            // Kick off the first search. Discovered peers will be returned via the 'PeersFound'
             // event in batches, as they're discovered.
-            engine.GetPeers (infoHash);
+            _ = engine.GetPeersAsync (infoHash);
 
             Console.Write ("Press enter to fetch some peers. press 'q' and enter to quit");
             while (Console.ReadLine () != "q") {
                 Console.WriteLine ("Getting some peers...");
 
                 // Get some peers for the torrent
-                engine.GetPeers (infoHash);
+                _ = engine.GetPeersAsync (infoHash);
                 for (int i = 0; i < 5; i++) {
                     Console.WriteLine ("Waiting: {0} seconds left", (30 - i));
                     System.Threading.Thread.Sleep (1000);

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/ClientEngineTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/ClientEngineTests.cs
@@ -47,14 +47,15 @@ namespace MonoTorrent.Client
     public class ClientEngineTests
     {
         [Test]
-        public async Task AddPeers_Dht ()
+        public async Task AddPeers_Dht_Public ()
         {
             var dht = new ManualDhtEngine ();
             var factories = EngineHelpers.Factories.WithDhtCreator (() => dht);
             var settings = EngineHelpers.CreateSettings (dhtEndPoint: new IPEndPoint (IPAddress.Any, 1234));
 
             using var engine = new ClientEngine (settings, factories);
-            var manager = await engine.AddAsync (new MagnetLink (InfoHash.FromMemory (new byte[20])), "asd");
+
+            var manager = await engine.AddAsync (TestRig.CreatePublic (), "path", new TorrentSettings ());
 
             var tcs = new TaskCompletionSource<DhtPeersAdded> ();
             manager.PeersFound += (o, e) => {
@@ -73,16 +74,13 @@ namespace MonoTorrent.Client
         [Test]
         public async Task AddPeers_Dht_Private ()
         {
-            // You can't manually add peers to private torrents
-            using var rig = TestRig.CreateMultiFile (new TestWriter ());
-            var editor = new TorrentEditor (rig.TorrentDict) {
-                CanEditSecureMetadata = true,
-                Private = true
-            };
+            var dht = new ManualDhtEngine ();
+            var factories = EngineHelpers.Factories.WithDhtCreator (() => dht);
+            var settings = EngineHelpers.CreateSettings (dhtEndPoint: new IPEndPoint (IPAddress.Any, 1234));
 
-            var manager = await rig.Engine.AddAsync (editor.ToTorrent (), "path", new TorrentSettings ());
+            using var engine = new ClientEngine (settings, factories);
 
-            var dht = (ManualDhtEngine) rig.Engine.DhtEngine;
+            var manager = await engine.AddAsync (TestRig.CreatePrivate (), "path", new TorrentSettings ());
 
             var tcs = new TaskCompletionSource<DhtPeersAdded> ();
             manager.PeersFound += (o, e) => {
@@ -90,8 +88,8 @@ namespace MonoTorrent.Client
                     tcs.TrySetResult (args);
             };
 
-            var peer = rig.CreatePeer (false).Peer;
-            dht.RaisePeersFound (manager.InfoHashes.V1OrV2, new[] { peer.Info });
+            var peer = new PeerInfo (new Uri ("http://test.peer"));
+            dht.RaisePeersFound (manager.InfoHashes.V1OrV2, new[] { peer });
             var result = await tcs.Task.WithTimeout (TimeSpan.FromSeconds (5));
             Assert.AreEqual (0, result.NewPeers, "#2");
             Assert.AreEqual (0, result.ExistingPeers, "#3");

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/ManualDhtEngine.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/ManualDhtEngine.cs
@@ -34,6 +34,8 @@ using System.Threading.Tasks;
 using MonoTorrent.Connections.Dht;
 using MonoTorrent.Dht;
 
+using ReusableTasks;
+
 namespace MonoTorrent.Client
 {
     public class ManualDhtEngine : IDhtEngine
@@ -48,22 +50,22 @@ namespace MonoTorrent.Client
         public event EventHandler<PeersFoundEventArgs> PeersFound;
         public event EventHandler StateChanged;
 
-        public void Add (IEnumerable<ReadOnlyMemory<byte>> nodes)
+        public ReusableTask AddAsync (IEnumerable<ReadOnlyMemory<byte>> nodes)
         {
-
+            return default;
         }
 
-        public void Announce (InfoHash infohash, int port)
+        public ReusableTask AnnounceAsync (InfoHash infohash, int port)
         {
-
+            return default;
         }
 
         public void Dispose ()
             => Disposed = true;
 
-        public void GetPeers (InfoHash infohash)
+        public ReusableTask GetPeersAsync (InfoHash infohash)
         {
-
+            return default;
         }
 
         public void RaisePeersFound (InfoHash infoHash, IList<PeerInfo> peers)
@@ -75,27 +77,27 @@ namespace MonoTorrent.Client
             StateChanged?.Invoke (this, EventArgs.Empty);
         }
 
-        public Task<ReadOnlyMemory<byte>> SaveNodesAsync ()
-            => Task.FromResult (ReadOnlyMemory<byte>.Empty);
+        public ReusableTask<ReadOnlyMemory<byte>> SaveNodesAsync ()
+            => ReusableTask.FromResult (ReadOnlyMemory<byte>.Empty);
 
-        public Task SetListenerAsync (IDhtListener listener)
+        public ReusableTask SetListenerAsync (IDhtListener listener)
         {
-            return Task.CompletedTask;
+            return ReusableTask.CompletedTask;
         }
 
-        public Task StartAsync ()
+        public ReusableTask StartAsync ()
             => StartAsync (null);
 
-        public Task StartAsync (ReadOnlyMemory<byte> initialNodes)
+        public ReusableTask StartAsync (ReadOnlyMemory<byte> initialNodes)
         {
             RaiseStateChanged (DhtState.Ready);
-            return Task.CompletedTask;
+            return ReusableTask.CompletedTask;
         }
 
-        public Task StopAsync ()
+        public ReusableTask StopAsync ()
         {
             RaiseStateChanged (DhtState.NotReady);
-            return Task.CompletedTask;
+            return ReusableTask.CompletedTask;
         }
     }
 }

--- a/src/Tests/Tests.MonoTorrent.Dht/MonoTorrent.Dht/DhtEngineTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Dht/MonoTorrent.Dht/DhtEngineTests.cs
@@ -13,12 +13,12 @@ namespace MonoTorrent.Dht
     public class DhtEngineTests
     {
         [Test]
-        public void AddRawNodesBeforeStarting ()
+        public async Task AddRawNodesBeforeStarting ()
         {
             int count = 0;
             var engine = new DhtEngine ();
             engine.MessageLoop.QuerySent += (o, e) => count++;
-            engine.Add (new ReadOnlyMemory<byte>[] { new byte[100] });
+            await engine.AddAsync (new ReadOnlyMemory<byte>[] { new byte[100] });
             Assert.AreEqual (0, engine.MessageLoop.PendingQueries);
             Assert.AreEqual (0, count);
             Assert.AreEqual (0, engine.RoutingTable.CountNodes ());


### PR DESCRIPTION
Redo how DHT is used within the engine. If you're the type who likes to load 15k torrents into the engine, you'll see a huge improvement in memory consumption as well as performance.

The engine will now limit dht annouces to 20 concurrent torrents (if they're hybrid torrents that'll be 40 concurrent infohashes). The normal event loop will ensure that as each torrent completes, the next one will start.