### PR TITLE
Remove a silly repetitive enumerator allocation

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Client/Managers/ChokeUnchokeManager.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Managers/ChokeUnchokeManager.cs
@@ -87,13 +87,6 @@ namespace MonoTorrent.Client
 
         #region Private Methods
 
-        IEnumerable<PeerList> AllLists ()
-        {
-            yield return nascentPeers;
-            yield return candidatePeers;
-            yield return optimisticUnchokeCandidates;
-        }
-
         void AllocateSlots (int alreadyUnchoked)
         {
             PeerId? peer;
@@ -108,9 +101,15 @@ namespace MonoTorrent.Client
 
             // Check the peer lists (nascent, then candidate then optimistic unchoke)
             // for an interested choked peer, if one is found, unchoke it.
-            foreach (PeerList list in AllLists ())
+            for (int i = 0; i < 3; i++) {
+                var list = i switch {
+                    0 => nascentPeers,
+                    1 => candidatePeers,
+                    _ => optimisticUnchokeCandidates
+                };
                 while ((peer = list.GetFirstInterestedChokedPeer ()) != null && (availableSlots-- > 0))
                     Unchoke (peer);
+            }
 
             // In the time that has passed since the last review we might have connected to more peers
             // that don't appear in AllLists.  It's also possible we have not yet run a review in


### PR DESCRIPTION
It's a small issue, but why not. When downloading 3000 torrents it starts showing up.

<img width="572" height="70" alt="enumerator" src="https://github.com/user-attachments/assets/a99041d0-c8da-441d-9e75-4aa18ca14de4" />
