### PR TITLE
Improved DHT bootstrap

### DIFF
--- a/src/BigEndianBigInteger.cs
+++ b/src/BigEndianBigInteger.cs
@@ -105,6 +105,9 @@ namespace MonoTorrent
         public static bool operator != (BigEndianBigInteger left, BigEndianBigInteger right)
             => left.Value != right.Value;
 
+        public static BigEndianBigInteger operator % (BigEndianBigInteger left, BigEndianBigInteger modulus)
+            => new BigEndianBigInteger (left.Value % modulus.Value);
+
         public int CompareTo (BigEndianBigInteger other)
             => Value.CompareTo (other.Value);
 

--- a/src/MonoTorrent.Dht/MonoTorrent.Dht.Messages/DhtMessageFactory.cs
+++ b/src/MonoTorrent.Dht/MonoTorrent.Dht.Messages/DhtMessageFactory.cs
@@ -33,7 +33,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Net;
 
 using MonoTorrent.BEncoding;
-using MonoTorrent.Dht.Messages.Efficient;
+using MonoTorrent.Dht.Messages;
 using MonoTorrent.Messages;
 
 namespace MonoTorrent.Dht.Messages

--- a/src/MonoTorrent.Dht/MonoTorrent.Dht.Messages/Efficient.cs
+++ b/src/MonoTorrent.Dht/MonoTorrent.Dht.Messages/Efficient.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 using MonoTorrent.BEncoding;
 
-namespace MonoTorrent.Dht.Messages.Efficient
+namespace MonoTorrent.Dht.Messages
 {
     static class Krpc
     {

--- a/src/MonoTorrent.Dht/MonoTorrent.Dht.Tasks/AnnounceTask.cs
+++ b/src/MonoTorrent.Dht/MonoTorrent.Dht.Tasks/AnnounceTask.cs
@@ -33,7 +33,6 @@ using System.Threading.Tasks;
 
 using MonoTorrent.BEncoding;
 using MonoTorrent.Dht.Messages;
-using MonoTorrent.Dht.Messages.Efficient;
 
 namespace MonoTorrent.Dht.Tasks
 {

--- a/src/MonoTorrent.Dht/MonoTorrent.Dht.Tasks/GetPeersTask.cs
+++ b/src/MonoTorrent.Dht/MonoTorrent.Dht.Tasks/GetPeersTask.cs
@@ -34,7 +34,6 @@ using System.Threading.Tasks;
 
 using MonoTorrent.BEncoding;
 using MonoTorrent.Dht.Messages;
-using MonoTorrent.Dht.Messages.Efficient;
 
 namespace MonoTorrent.Dht.Tasks
 {

--- a/src/MonoTorrent.Dht/MonoTorrent.Dht.Tasks/InitialiseTask.cs
+++ b/src/MonoTorrent.Dht/MonoTorrent.Dht.Tasks/InitialiseTask.cs
@@ -36,7 +36,6 @@ using System.Threading.Tasks;
 
 using MonoTorrent.BEncoding;
 using MonoTorrent.Dht.Messages;
-using MonoTorrent.Dht.Messages.Efficient;
 
 namespace MonoTorrent.Dht.Tasks
 {
@@ -80,12 +79,12 @@ namespace MonoTorrent.Dht.Tasks
             // If we were given a list of nodes to load at the start, use them
             try {
                 if (initialNodes.Count > 0) {
-                    await SendFindNode (initialNodes);
+                    await PopulateFirstNodes (initialNodes);
                 } else {
                     try {
                         if (BootstrapNodes is null)
-                            BootstrapNodes = await GenerateBootstrapNodes ();
-                        await SendFindNode (BootstrapNodes);
+                            BootstrapNodes = await GenerateBootstrapNodes (BootstrapRouters);
+                        await PopulateFirstNodes (BootstrapNodes);
                     } catch {
                         initializationComplete.TrySetResult (null);
                         return;
@@ -96,12 +95,11 @@ namespace MonoTorrent.Dht.Tasks
             }
         }
 
-        async Task<Node[]> GenerateBootstrapNodes ()
+        static async Task<Node[]> GenerateBootstrapNodes (string[] bootstrapRouters)
         {
-            // Handle when one, or more, of the bootstrap nodes are offline
             var results = new List<Node> ();
 
-            var tasks = BootstrapRouters.Select (Dns.GetHostAddressesAsync).ToList ();
+            var tasks = bootstrapRouters.Select (t => Dns.GetHostAddressesAsync (t, System.Net.Sockets.AddressFamily.InterNetwork)).ToList ();
             while (tasks.Count > 0) {
                 var completed = await Task.WhenAny (tasks);
                 tasks.Remove (completed);
@@ -109,8 +107,7 @@ namespace MonoTorrent.Dht.Tasks
                 try {
                     var addresses = await completed;
                     foreach (var v in addresses)
-                        if (v.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork)
-                            results.Add (new Node (NodeId.Create (), new CompactEndPoint (v, 6881)));
+                        results.Add (new Node (NodeId.Create (), new CompactEndPoint (v, 6881)));
                 } catch {
 
                 }
@@ -119,21 +116,77 @@ namespace MonoTorrent.Dht.Tasks
             return results.ToArray ();
         }
 
-        async Task SendFindNode (IEnumerable<Node> newNodes)
+        async Task PopulateFirstNodes (IEnumerable<Node> newNodes)
         {
-            var activeRequests = new List<Task<SendQueryEventArgs>> ();
-            var nodes = new ClosestNodesCollection (engine.RoutingTable.LocalNodeId);
+            // Bootstrapping approach:
+            // 1) Query the bootstrap nodes/routers for nodes close to the local ID.
+            // 2) Ping each of these to see if they're alive. If they respond they'll be inserted into the routing table.
+            //    Up to 32 nodes will be stored in the first bucket. If the bucket splits then each will be allowed store 16. Further splits will use the standard 8 node limit.
+            // 3) Pre-split the routing table so it has at least 20 buckets to ensure there is reasonable diversity across the id space. The up-to-32 initial nodes will distribute appropriately.
+            // 4) Querying each bucket for a random node in each buckets range. Stop once the bucket has > 4 nodes.
+            var activeFindNodes = new List<Task<SendQueryEventArgs>> ();
+            var activePings = new List<Task<SendQueryEventArgs>> ();
 
+            // Query for the first set of nodes close to our local id. Query *all* of them.
             foreach (Node node in newNodes) {
                 var transactionId = TransactionId.NextId ();
                 var request = KrpcMessageEncoder.EncodeFindNode (transactionId, engine.LocalId, engine.LocalId);
-                activeRequests.Add (engine.SendQueryAsync (request, node).AsTask ());
-                nodes.Add (node);
+                activeFindNodes.Add (engine.SendQueryAsync (request, node).AsTask ());
             }
 
-            while (activeRequests.Count > 0) {
-                var completed = await Task.WhenAny (activeRequests);
-                activeRequests.Remove (completed);
+            // For each initial node or bootstrap router which responds, ping each of the provided nodes to see if they're alive.
+            while (activeFindNodes.Count > 0) {
+                var completed = await Task.WhenAny (activeFindNodes);
+                activeFindNodes.Remove (completed);
+
+                SendQueryEventArgs args = await completed;
+                if (!args.Response.IsEmpty) {
+                    // Ping each node we get back to ensure it's alive/reachable. If it responds
+                    // it'll be in the table.
+                    var response = KrpcMessage.Parse (args.Response);
+                    foreach (Node node in Node.FromCompactNodes (response.Response.Nodes)) {
+                        var id = TransactionId.NextId ();
+                        var request = KrpcMessageEncoder.EncodePing (id, engine.LocalId);
+                        activePings.Add (engine.SendQueryAsync (request, node).AsTask ());
+                    }
+                }
+            }
+
+            // Wait for all the pings to finish (a response is received or it times out). Should take < 10 seconds.
+            await Task.WhenAll (activePings);
+
+            // If the routing table doesn't have at least 4 active nodes at this point and we launched using a cached list of dht nodes,
+            // retry bootstrapping using the DHT routers.
+            if (initialNodes.Count > 0 && engine.RoutingTable.NeedsBootstrap && BootstrapRouters.Length > 0) {
+                await new InitialiseTask (engine).ExecuteAsync ();
+            } else {
+                // Otherwise presplit the routing table and populate each bucket.
+                engine.RoutingTable.PreSplitBuckets (20);
+
+                // For each bucket search for a random id
+                List<Task> prefillTasks = new List<Task> ();
+                foreach (var bucket in engine.RoutingTable.Buckets) {
+                    prefillTasks.Add (Prefill (NodeId.RandomBetween (bucket.Min, bucket.Max)));
+                }
+                await Task.WhenAll (prefillTasks);
+            }
+        }
+
+        async Task Prefill (NodeId target)
+        {
+            var closestNodes = new ClosestNodesCollection (target);
+            var activeFindNodes = new List<Task<SendQueryEventArgs>> ();
+
+            // Query for the first set of nodes close to our local id.
+            foreach (Node node in engine.RoutingTable.GetClosest (target)) {
+                var transactionId = TransactionId.NextId ();
+                var request = KrpcMessageEncoder.EncodeFindNode (transactionId, engine.LocalId, target.Span);
+                activeFindNodes.Add (engine.SendQueryAsync (request, node).AsTask ());
+            }
+
+            while (activeFindNodes.Count > 0) {
+                var completed = await Task.WhenAny (activeFindNodes);
+                activeFindNodes.Remove (completed);
 
                 SendQueryEventArgs args = await completed;
                 if (!args.Response.IsEmpty) {
@@ -142,17 +195,14 @@ namespace MonoTorrent.Dht.Tasks
 
                     var response = KrpcMessage.Parse (args.Response);
                     foreach (Node node in Node.FromCompactNodes (response.Response.Nodes)) {
-                        if (nodes.Add (node)) {
+                        if (closestNodes.Add (node)) {
                             var id = TransactionId.NextId ();
-                            var request = KrpcMessageEncoder.EncodeFindNode (id, engine.LocalId, engine.LocalId);
-                            activeRequests.Add (engine.SendQueryAsync (request, node).AsTask ());
+                            var request = KrpcMessageEncoder.EncodeFindNode (id, engine.LocalId, target.Span);
+                            activeFindNodes.Add (engine.SendQueryAsync (request, node).AsTask ());
                         }
                     }
                 }
             }
-
-            if (initialNodes.Count > 0 && engine.RoutingTable.NeedsBootstrap && BootstrapRouters.Length > 0)
-                await new InitialiseTask (engine).ExecuteAsync ();
         }
     }
 }

--- a/src/MonoTorrent.Dht/MonoTorrent.Dht.Tasks/RefreshBucketTask.cs
+++ b/src/MonoTorrent.Dht/MonoTorrent.Dht.Tasks/RefreshBucketTask.cs
@@ -30,7 +30,6 @@
 using System.Threading.Tasks;
 
 using MonoTorrent.Dht.Messages;
-using MonoTorrent.Dht.Messages.Efficient;
 
 namespace MonoTorrent.Dht.Tasks
 {

--- a/src/MonoTorrent.Dht/MonoTorrent.Dht.Tasks/ReplaceNodeTask.cs
+++ b/src/MonoTorrent.Dht/MonoTorrent.Dht.Tasks/ReplaceNodeTask.cs
@@ -30,7 +30,6 @@
 using System;
 
 using MonoTorrent.Dht.Messages;
-using MonoTorrent.Dht.Messages.Efficient;
 
 namespace MonoTorrent.Dht.Tasks
 {

--- a/src/MonoTorrent.Dht/MonoTorrent.Dht/Bucket.cs
+++ b/src/MonoTorrent.Dht/MonoTorrent.Dht/Bucket.cs
@@ -55,12 +55,12 @@ namespace MonoTorrent.Dht
         internal Node? Replacement { get; set; }
 
         public Bucket ()
-            : this (NodeId.Minimum, NodeId.Maximum)
+            : this (NodeId.Minimum, NodeId.Maximum, MaxCapacity)
         {
 
         }
 
-        public Bucket (NodeId min, NodeId max)
+        public Bucket (NodeId min, NodeId max, int preferredCapacity)
         {
             Min = min;
             Max = max;
@@ -68,7 +68,7 @@ namespace MonoTorrent.Dht
             CanSplit = (Max - Min) > MaxCapacity;
             LastChangedDelta = TimeSpan.FromDays (1);
             LastChangedTimer = new ValueStopwatch ();
-            Nodes = new List<Node> (MaxCapacity);
+            Nodes = new List<Node> (Math.Max (preferredCapacity, MaxCapacity));
         }
 
         public bool Add (Node node)

--- a/src/MonoTorrent.Dht/MonoTorrent.Dht/DhtEngine.cs
+++ b/src/MonoTorrent.Dht/MonoTorrent.Dht/DhtEngine.cs
@@ -38,7 +38,6 @@ using MonoTorrent.BEncoding;
 using MonoTorrent.Client;
 using MonoTorrent.Connections.Dht;
 using MonoTorrent.Dht.Messages;
-using MonoTorrent.Dht.Messages.Efficient;
 using MonoTorrent.Dht.Tasks;
 
 using ReusableTasks;
@@ -266,7 +265,7 @@ namespace MonoTorrent.Dht
             await MainLoop;
 
             var e = default (SendQueryEventArgs);
-            for (int i = 0; i < 4; i++) {
+            for (int i = 0; i < 3; i++) {
                 e = await MessageLoop.SendAsync (query, node);
 
                 // If the message timed out and we we haven't already hit the maximum retries

--- a/src/MonoTorrent.Dht/MonoTorrent.Dht/MessageLoop.cs
+++ b/src/MonoTorrent.Dht/MonoTorrent.Dht/MessageLoop.cs
@@ -40,7 +40,6 @@ using MonoTorrent.BEncoding;
 using MonoTorrent.Connections;
 using MonoTorrent.Connections.Dht;
 using MonoTorrent.Dht.Messages;
-using MonoTorrent.Dht.Messages.Efficient;
 using MonoTorrent.Logging;
 
 using ReusableTasks;
@@ -126,7 +125,7 @@ namespace MonoTorrent.Dht
             Listener = new NullDhtListener ();
             ReceiveQueue = new Queue<KeyValuePair<CompactEndPoint, ReadOnlyMemory<byte>>> ();
             SendQueue = new Queue<SendDetails> ();
-            Timeout = TimeSpan.FromSeconds (10);
+            Timeout = TimeSpan.FromSeconds (2);
             WaitingResponse = new Dictionary<(TransactionId, CompactEndPoint), SendDetails> ();
             WaitingResponseTimedOut = new List<SendDetails> ();
 
@@ -174,7 +173,7 @@ namespace MonoTorrent.Dht
 
                 var m = KrpcMessage.Parse (buffer);
                 if (m.MessageType == KrpcType.Response || m.MessageType == KrpcType.Error) {
-                    // If we can' unregister the corresponding query then this response message should be ignored.
+                    // If we can't unregister the corresponding query then this response message should be ignored.
                     if (!DhtMessageFactory.UnregisterSend (m.TransactionId, endpoint))
                         return;
                 }
@@ -198,7 +197,7 @@ namespace MonoTorrent.Dht
 
         async Task SendMessages ()
         {
-            for (int i = 0; i < 50 && SendQueue.Count > 0; i++) {
+            for (int i = 0; i < 150 && SendQueue.Count > 0; i++) {
                 SendDetails details = SendQueue.Dequeue ();
 
                 details.SentAt = ValueStopwatch.StartNew ();

--- a/src/MonoTorrent.Dht/MonoTorrent.Dht/Node.cs
+++ b/src/MonoTorrent.Dht/MonoTorrent.Dht/Node.cs
@@ -44,7 +44,7 @@ namespace MonoTorrent.Dht
 {
     class Node : IEquatable<Node>
     {
-        public static readonly int MaxFailures = 4;
+        public static readonly int MaxFailures = 2;
         public CompactEndPoint EndPoint { get; }
         public int FailedCount { get; set; }
         public NodeId Id { get; }

--- a/src/MonoTorrent.Dht/MonoTorrent.Dht/NodeId.cs
+++ b/src/MonoTorrent.Dht/MonoTorrent.Dht/NodeId.cs
@@ -102,6 +102,18 @@ namespace MonoTorrent.Dht
         internal static NodeId Median (NodeId min, NodeId max)
             => new NodeId ((new BigEndianBigInteger (min.Span) + new BigEndianBigInteger (max.Span)) / 2);
 
+        internal static NodeId RandomBetween (NodeId min, NodeId max)
+        {
+            var minVal = new BigEndianBigInteger (min.Span);
+            var maxVal = new BigEndianBigInteger (max.Span);
+            var range = maxVal - minVal;
+
+            Span<byte> rand = stackalloc byte[20];
+            Random.Shared.NextBytes (rand);
+            var offset = new BigEndianBigInteger (rand) % range;
+            return new NodeId (minVal + offset);
+        }
+
         public static NodeId operator ^ (NodeId left, NodeId right)
         {
             var storage = new Storage ();

--- a/src/MonoTorrent.Dht/MonoTorrent.Dht/RoutingTable.cs
+++ b/src/MonoTorrent.Dht/MonoTorrent.Dht/RoutingTable.cs
@@ -39,7 +39,7 @@ namespace MonoTorrent.Dht
 
         public NodeId LocalNodeId { get; }
 
-        public bool NeedsBootstrap => CountNodes () < 10;
+        public bool NeedsBootstrap => CountNodes () < 4;
 
         public RoutingTable ()
             : this (NodeId.Create ())
@@ -51,14 +51,14 @@ namespace MonoTorrent.Dht
         {
             Buckets = new List<Bucket> ();
             LocalNodeId = localNodeId;
-            Add (new Bucket ());
+            Add (new Bucket (NodeId.Minimum, NodeId.Maximum, 32));
         }
 
         public bool Add (Node node)
         {
             return Add (node, true);
         }
-
+        int counter = 0;
         bool Add (Node node, bool raiseNodeAdded)
         {
             if (node == null)
@@ -107,8 +107,8 @@ namespace MonoTorrent.Dht
                 return false;//to avoid infinite loop when add same node
 
             var median = NodeId.Median (bucket.Min, bucket.Max);
-            var left = new Bucket (bucket.Min, median);
-            var right = new Bucket (median, bucket.Max);
+            var left = new Bucket (bucket.Min, median, Math.Max (Bucket.MaxCapacity, bucket.Nodes.Capacity / 2));
+            var right = new Bucket (median, bucket.Max, Math.Max (Bucket.MaxCapacity, bucket.Nodes.Capacity / 2));
 
             Remove (bucket);
             Add (left);
@@ -146,6 +146,14 @@ namespace MonoTorrent.Dht
             Buckets = new List<Bucket> {
                 new Bucket ()
             };
+        }
+
+        internal void PreSplitBuckets (int minBucketCount)
+        {
+            while (Buckets.Count < minBucketCount) {
+                var mine = Buckets.Find (b => b.CanContain (LocalNodeId))!;
+                Split (mine);
+            }
         }
     }
 }

--- a/src/Tests/Tests.MonoTorrent.Dht/MonoTorrent.Dht/BucketTest.cs
+++ b/src/Tests/Tests.MonoTorrent.Dht/MonoTorrent.Dht/BucketTest.cs
@@ -39,8 +39,8 @@ namespace MonoTorrent.Dht
         [Test]
         public void CompareTo ()
         {
-            var b1 = new Bucket (NodeId.Minimum, NodeId.Maximum);
-            var b2 = new Bucket (NodeId.Minimum, NodeId.Maximum);
+            var b1 = new Bucket (NodeId.Minimum, NodeId.Maximum, Bucket.MaxCapacity);
+            var b2 = new Bucket (NodeId.Minimum, NodeId.Maximum, Bucket.MaxCapacity);
             Assert.AreEqual (0, b1.CompareTo (b1), "#1");
             Assert.AreEqual (0, b1.CompareTo (b2), "#2");
         }
@@ -48,15 +48,15 @@ namespace MonoTorrent.Dht
         [Test]
         public void CompareTo_Null ()
         {
-            var b1 = new Bucket (NodeId.Minimum, NodeId.Maximum);
+            var b1 = new Bucket (NodeId.Minimum, NodeId.Maximum, Bucket.MaxCapacity);
             Assert.IsTrue (b1.CompareTo (null) > 0, "#1");
         }
 
         [Test]
         public void Equality ()
         {
-            var b1 = new Bucket (NodeId.Minimum, NodeId.Maximum);
-            var b2 = new Bucket (NodeId.Minimum, NodeId.Maximum);
+            var b1 = new Bucket (NodeId.Minimum, NodeId.Maximum, Bucket.MaxCapacity);
+            var b2 = new Bucket (NodeId.Minimum, NodeId.Maximum, Bucket.MaxCapacity);
             Assert.IsTrue (b1.Equals (b1), "#1");
             Assert.IsTrue (b1.Equals (b2), "#2");
         }
@@ -64,15 +64,15 @@ namespace MonoTorrent.Dht
         [Test]
         public void Equality_NotEqual ()
         {
-            var b1 = new Bucket (NodeId.Minimum, NodeId.Minimum);
-            var b2 = new Bucket (NodeId.Minimum, NodeId.Maximum);
+            var b1 = new Bucket (NodeId.Minimum, NodeId.Minimum, Bucket.MaxCapacity);
+            var b2 = new Bucket (NodeId.Minimum, NodeId.Maximum, Bucket.MaxCapacity);
             Assert.IsFalse (b1.Equals (b2), "#1");
         }
 
         [Test]
         public void Equality_Null ()
         {
-            var b1 = new Bucket (NodeId.Minimum, NodeId.Maximum);
+            var b1 = new Bucket (NodeId.Minimum, NodeId.Maximum, Bucket.MaxCapacity);
             Assert.IsFalse (b1.Equals (null), "#1");
         }
 

--- a/src/Tests/Tests.MonoTorrent.Dht/MonoTorrent.Dht/MessageHandlingTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Dht/MonoTorrent.Dht/MessageHandlingTests.cs
@@ -4,7 +4,6 @@ using System.Threading.Tasks;
 
 using MonoTorrent.BEncoding;
 using MonoTorrent.Dht.Messages;
-using MonoTorrent.Dht.Messages.Efficient;
 
 using NUnit.Framework;
 
@@ -155,7 +154,7 @@ namespace MonoTorrent.Dht
             // Send a ping which will time out
             engine.SendQueryAsync (timedOutPing, node).WithTimeout ().Wait ();
 
-            Assert.AreEqual (4, node.FailedCount, "#1");
+            Assert.AreEqual (3, node.FailedCount, "#1");
             Assert.AreEqual (NodeState.Bad, node.State, "#2");
             Assert.IsTrue (node.LastSeen >= TimeSpan.FromHours (1), "#3");
             Assert.IsTrue (pingSuccessful, "#4");

--- a/src/Tests/Tests.MonoTorrent.Dht/MonoTorrent.Dht/MessageTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Dht/MonoTorrent.Dht/MessageTests.cs
@@ -36,7 +36,6 @@ using System.Text.Unicode;
 
 using MonoTorrent.BEncoding;
 using MonoTorrent.Dht.Messages;
-using MonoTorrent.Dht.Messages.Efficient;
 
 using NUnit.Framework;
 

--- a/src/Tests/Tests.MonoTorrent.Dht/MonoTorrent.Dht/TaskTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Dht/MonoTorrent.Dht/TaskTests.cs
@@ -34,7 +34,6 @@ using System.Threading.Tasks;
 
 using MonoTorrent.BEncoding;
 using MonoTorrent.Dht.Messages;
-using MonoTorrent.Dht.Messages.Efficient;
 using MonoTorrent.Dht.Tasks;
 
 using NUnit.Framework;
@@ -87,7 +86,7 @@ namespace MonoTorrent.Dht
             };
 
             Assert.IsTrue ((await engine.SendQueryAsync (ping, node).WithTimeout (3000)).TimedOut, "#1");
-            Assert.AreEqual (4, counter, "#2");
+            Assert.AreEqual (3, counter, "#2");
         }
 
         [Test]


### PR DESCRIPTION
New bootstrapping approach:
1) Query the bootstrap nodes/routers for nodes close to the local ID.
2) Ping each of these to see if they're alive. If they respond they'll be inserted into the routing table. Up to 32 nodes will be stored in the first bucket. If the bucket splits then each will be allowed store 16. Further splits will use the standard 8 node limit.
3) Pre-split the routing table so it has at least 20 buckets to ensure there is reasonable diversity across the id space. The up-to-32 initial nodes will distribute appropriately.
4) Querying each bucket for a random node in each buckets range.

After the initial pings complete, allow the DHT table to be marked as 'healthy' or 'initialised' as soon as we have sufficient nodes in the table. Further background/non-blocking initialisation may continue until the full initialisation has completed, however the table is ready for querying once we have a bunch of healthy nodes.

This gets the table populated in far less time, the boosting of capacity during the initial bucket splits allows better diversity during bootstrap.