### PR TITLE
Ensure bootstrap routers don't end up in the table

### DIFF
--- a/src/MonoTorrent.Dht/MonoTorrent.Dht.Tasks/InitialiseTask.cs
+++ b/src/MonoTorrent.Dht/MonoTorrent.Dht.Tasks/InitialiseTask.cs
@@ -82,8 +82,11 @@ namespace MonoTorrent.Dht.Tasks
                     await PopulateFirstNodes (initialNodes);
                 } else {
                     try {
-                        if (BootstrapNodes is null)
+                        if (BootstrapNodes is null) {
                             BootstrapNodes = await GenerateBootstrapNodes (BootstrapRouters);
+                            foreach (var v in BootstrapNodes)
+                                engine.RoutingTable.AddIgnoredEndpoint (v.EndPoint);
+                        }
                         await PopulateFirstNodes (BootstrapNodes);
                     } catch {
                         initializationComplete.TrySetResult (null);

--- a/src/MonoTorrent.Dht/MonoTorrent.Dht/RoutingTable.cs
+++ b/src/MonoTorrent.Dht/MonoTorrent.Dht/RoutingTable.cs
@@ -41,6 +41,12 @@ namespace MonoTorrent.Dht
 
         public bool NeedsBootstrap => CountNodes () < 4;
 
+        /// <summary>
+        /// Used to ensure known bootstrap routers do not get added to the
+        /// routing table.
+        /// </summary>
+        HashSet<CompactEndPoint> NodesToIgnore { get; }
+
         public RoutingTable ()
             : this (NodeId.Create ())
         {
@@ -51,6 +57,7 @@ namespace MonoTorrent.Dht
         {
             Buckets = new List<Bucket> ();
             LocalNodeId = localNodeId;
+            NodesToIgnore = new HashSet<CompactEndPoint> ();
             Add (new Bucket (NodeId.Minimum, NodeId.Maximum, 32));
         }
 
@@ -58,11 +65,14 @@ namespace MonoTorrent.Dht
         {
             return Add (node, true);
         }
-        int counter = 0;
+
         bool Add (Node node, bool raiseNodeAdded)
         {
             if (node == null)
                 throw new ArgumentNullException (nameof (node));
+
+            if (NodesToIgnore.Contains (node.EndPoint))
+                return false;
 
             Bucket bucket = Buckets.Find (b => b.CanContain (node))!;
             if (bucket.Nodes.Contains (node))
@@ -82,6 +92,11 @@ namespace MonoTorrent.Dht
             newBuckets.Add (bucket);
             newBuckets.Sort ();
             Buckets = newBuckets;
+        }
+
+        public void AddIgnoredEndpoint (CompactEndPoint endpoint)
+        {
+            NodesToIgnore.Add (endpoint);
         }
 
         internal Node? FindNode (NodeId id)

--- a/src/Tests/Tests.MonoTorrent.Dht/MonoTorrent.Dht/RoutingTableTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Dht/MonoTorrent.Dht/RoutingTableTests.cs
@@ -68,6 +68,15 @@ namespace MonoTorrent.Dht
                 Assert.IsTrue (closest.Exists (node => nodes[i].Equals (closest[i].Id)));
         }
 
+        [Test]
+        public void DiscardBootstrapRouters ()
+        {
+            var ep = new CompactEndPoint (IPAddress.Parse ("12.23.34.45"), 1415);
+            table.AddIgnoredEndpoint (ep);
+            Assert.IsFalse (table.Add (new Node (NodeId.Create (), ep)));
+            Assert.AreEqual (0, table.CountNodes ());
+        }
+
         private void CheckBuckets ()
         {
             foreach (Bucket b in table.Buckets)


### PR DESCRIPTION
They're intended to simply provide a few nodes to start off. Don't use them in the steady state