### PR TITLE
Add additional bootstrap routers and make them configurable

### DIFF
--- a/src/MonoTorrent.Client/MonoTorrent.Client/ClientEngine.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/ClientEngine.cs
@@ -337,6 +337,8 @@ namespace MonoTorrent.Client
 
             DhtListener = (settings.DhtEndPoint == null ? null : Factories.CreateDhtListener (settings.DhtEndPoint)) ?? new NullDhtListener ();
             var engine = (settings.DhtEndPoint == null ? null : Factories.CreateDht ()) ?? new NullDhtEngine ();
+            engine.SetBootstrapRoutersAsync (settings.DhtBootstrapRouters).AsTask ().GetAwaiter ().GetResult ();
+
             DhtEngine = new DhtEngineWrapper (engine);
             DhtEngine.SetListenerAsync (DhtListener).AsTask ().GetAwaiter ().GetResult ();
 
@@ -926,6 +928,8 @@ namespace MonoTorrent.Client
                 await Task.WhenAll (Torrents.Select (t => DiskManager.FlushAsync (t)));
 
             ConnectionManager.Settings = newSettings;
+
+            await DhtEngine.SetBootstrapRoutersAsync (newSettings.DhtBootstrapRouters);
 
             if (oldSettings.UsePartialFiles != newSettings.UsePartialFiles) {
                 foreach (var manager in Torrents)

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Settings/EngineSettings.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Settings/EngineSettings.cs
@@ -29,6 +29,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
@@ -125,9 +126,9 @@ namespace MonoTorrent.Client
         /// a connection can be attempted with a new peer. Defaults to 10 seconds. It is highly recommended
         /// to keep this value within a range of 7-15 seconds unless absolutely necessary.
         /// </summary>
-        public IList<TimeSpan> ConnectionTimeouts { get; } = Debugger.IsAttached
+        public IList<TimeSpan> ConnectionTimeouts { get; } = Array.AsReadOnly (Debugger.IsAttached
             ? new[] { TimeSpan.FromSeconds (120) }
-            : new[] { TimeSpan.FromSeconds (3), TimeSpan.FromSeconds (6), TimeSpan.FromSeconds (10) };
+            : new[] { TimeSpan.FromSeconds (3), TimeSpan.FromSeconds (6), TimeSpan.FromSeconds (10) });
 
         /// <summary>
         /// Creates a cache which buffers data before it's written to the disk, or after it's been read from disk.
@@ -142,6 +143,18 @@ namespace MonoTorrent.Client
         /// Defaults to 5MB.
         /// </summary>
         public CachePolicy DiskCachePolicy { get; } = CachePolicy.WritesOnly;
+
+        /// <summary>
+        /// The bootstrap routers used to obtain the first set of nodes to access the BitTorrent DHT table.
+        /// </summary>
+        public IList<BootstrapRouter> DhtBootstrapRouters { get; } = Array.AsReadOnly (new[] {
+            new BootstrapRouter ("router.bittorrent.com", 6881),
+            new BootstrapRouter ("router.utorrent.com", 6881),
+            new BootstrapRouter ("dht.transmissionbt.com", 6881),
+            new BootstrapRouter ("dht.aelitis.com", 6881),
+            new BootstrapRouter ("router.bitcomet.com", 6881),
+            new BootstrapRouter ("dht.libtorrent.org", 25401)
+        });
 
         /// <summary>
         /// The UDP port used for DHT communications. Set the port to 0 to choose a random available port.
@@ -288,7 +301,7 @@ namespace MonoTorrent.Client
         internal EngineSettings (
             IList<EncryptionType> allowedEncryption, bool allowHaveSuppression, bool allowLocalPeerDiscovery, bool allowPortForwarding,
             bool autoSaveLoadDhtCache, bool autoSaveLoadFastResume, bool autoSaveLoadMagnetLinkMetadata, string cacheDirectory,
-            IList<TimeSpan> connectionTimeouts, IPEndPoint? dhtEndPoint, int diskCacheBytes, CachePolicy diskCachePolicy, FastResumeMode fastResumeMode,
+            IList<TimeSpan> connectionTimeouts, IList<BootstrapRouter> dhtBootstrapRouters, IPEndPoint? dhtEndPoint, int diskCacheBytes, CachePolicy diskCachePolicy, FastResumeMode fastResumeMode,
             FileCreationOptions fileCreationMode, Dictionary<string, IPEndPoint> listenEndPoints,
             int maximumConnections, int maximumDiskReadRate, int maximumDiskWriteRate, int maximumDownloadRate, int maximumHalfOpenConnections,
             int maximumOpenFiles, int maximumUploadRate, IDictionary<string, IPEndPoint> reportedListenEndPoints, bool usePartialFiles,
@@ -305,6 +318,7 @@ namespace MonoTorrent.Client
             AutoSaveLoadDhtCache = autoSaveLoadDhtCache;
             AutoSaveLoadFastResume = autoSaveLoadFastResume;
             AutoSaveLoadMagnetLinkMetadata = autoSaveLoadMagnetLinkMetadata;
+            DhtBootstrapRouters = Array.AsReadOnly (dhtBootstrapRouters.ToArray ());
             DhtEndPoint = dhtEndPoint;
             DiskCacheBytes = diskCacheBytes;
             DiskCachePolicy = diskCachePolicy;

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Settings/EngineSettingsBuilder.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Settings/EngineSettingsBuilder.cs
@@ -137,6 +137,11 @@ namespace MonoTorrent.Client
         public List<TimeSpan> ConnectionTimeouts { get; set; }
 
         /// <summary>
+        /// The bootstrap routers used to obtain the first set of nodes to access the BitTorrent DHT table.
+        /// </summary>
+        public List<BootstrapRouter> DhtBootstrapRouters { get; set; }
+
+        /// <summary>
         /// Creates a cache which buffers data before it's written to the disk, or after it's been read from disk.
         /// Set to 0 to disable the cache.
         /// Defaults to 5MB.
@@ -336,6 +341,7 @@ namespace MonoTorrent.Client
             CacheDirectory = settings.CacheDirectory;
             ConnectionRetryDelays = new List<TimeSpan> (settings.ConnectionRetryDelays);
             ConnectionTimeouts = new List<TimeSpan> (settings.ConnectionTimeouts);
+            DhtBootstrapRouters = new List<BootstrapRouter> (settings.DhtBootstrapRouters);
             DhtEndPoint = settings.DhtEndPoint;
             DiskCacheBytes = settings.DiskCacheBytes;
             DiskCachePolicy = settings.DiskCachePolicy;
@@ -381,6 +387,9 @@ namespace MonoTorrent.Client
             if (ConnectionTimeouts.Count == 0)
                 throw new ArgumentException ("At least one connection timeout must be specified", nameof (ConnectionTimeouts));
 
+            if (DhtBootstrapRouters is null)
+                throw new ArgumentNullException (nameof (DhtBootstrapRouters));
+
             return new EngineSettings (
                 allowedEncryption: AllowedEncryption,
                 allowHaveSuppression: AllowHaveSuppression,
@@ -392,6 +401,7 @@ namespace MonoTorrent.Client
                 cacheDirectory: string.IsNullOrEmpty (CacheDirectory) ? Environment.CurrentDirectory : Path.GetFullPath (CacheDirectory),
                 connectionRetryDelays: ConnectionRetryDelays,
                 connectionTimeouts: ConnectionTimeouts,
+                dhtBootstrapRouters : DhtBootstrapRouters,
                 dhtEndPoint: DhtEndPoint,
                 diskCacheBytes: DiskCacheBytes,
                 diskCachePolicy: DiskCachePolicy,

--- a/src/MonoTorrent.Client/MonoTorrent.Client/Settings/Serializer.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Client/Settings/Serializer.cs
@@ -29,11 +29,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Net;
 
 using MonoTorrent.BEncoding;
 using MonoTorrent.Connections;
+using MonoTorrent.Dht;
 using MonoTorrent.PieceWriter;
 
 namespace MonoTorrent.Client
@@ -77,7 +79,7 @@ namespace MonoTorrent.Client
                     property.SetValue (builder, new Uri (((BEncodedString) value).Text));
                 } else if (property.PropertyType == typeof (IPAddress)) {
                     property.SetValue (builder, IPAddress.Parse (((BEncodedString) value).Text));
-                } else if (property.PropertyType == typeof(FileCreationOptions)) {
+                } else if (property.PropertyType == typeof (FileCreationOptions)) {
                     property.SetValue (builder, Enum.Parse (typeof (FileCreationOptions), ((BEncodedString) value).Text));
                 } else if (property.PropertyType == typeof (IPEndPoint)) {
                     var list = (BEncodedList) value;
@@ -88,6 +90,14 @@ namespace MonoTorrent.Client
                         endPoint = new IPEndPoint (IPAddress.Parse (ipAddress.Text), (int) port.Number);
                     }
                     property.SetValue (builder, endPoint);
+                } else if (property.PropertyType == typeof (List<BootstrapRouter>)) {
+                    var list = (IList<BootstrapRouter>) property.GetValue (builder)!;
+                    list.Clear ();
+                    foreach (BEncodedList router in ((BEncodedList) value)) {
+                        var host = ((BEncodedString) router[0]).Text;
+                        var port = (int) ((BEncodedNumber) router[1]).Number;
+                        list.Add (new BootstrapRouter (host, port));
+                    }
                 } else if (property.PropertyType == typeof (List<EncryptionType>)) {
                     var list = (IList<EncryptionType>) property.GetValue (builder)!;
                     list.Clear ();
@@ -122,7 +132,8 @@ namespace MonoTorrent.Client
                     Uri value => new BEncodedString (value.OriginalString),
                     FileCreationOptions value => new BEncodedString (value.ToString ()),
                     null => null,
-                    Dictionary<string, IPEndPoint> value => FromIPAddressDictionary(value),
+                    Dictionary<string, IPEndPoint> value => FromIPAddressDictionary (value),
+                    List<BootstrapRouter> value => FromBootstrapRouters (value),
                     _ => throw new NotSupportedException ($"{property.Name} => type: ${property.PropertyType}"),
                 };
                 // Ensure default values aren't accidentally propagated.
@@ -133,6 +144,15 @@ namespace MonoTorrent.Client
             }
 
             return dict;
+        }
+
+        static BEncodedList FromBootstrapRouters (List<BootstrapRouter> value)
+        {
+            var result = new BEncodedList ();
+            foreach (var v in value) {
+                result.Add (new BEncodedList { (BEncodedString) v.Host, (BEncodedNumber) v.Port });
+            }
+            return result;
         }
 
         static BEncodedDictionary FromIPAddressDictionary (Dictionary<string, IPEndPoint> value)

--- a/src/MonoTorrent.Client/MonoTorrent.Dht/DhtEngineWrapper.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Dht/DhtEngineWrapper.cs
@@ -145,5 +145,8 @@ namespace MonoTorrent.Client
 
         internal ReusableTask<ReadOnlyMemory<byte>> SaveNodesAsync ()
             => Engine.SaveNodesAsync ();
+
+        internal ReusableTask SetBootstrapRoutersAsync (IList<BootstrapRouter> routers)
+            => Engine.SetBootstrapRoutersAsync (routers);
     }
 }

--- a/src/MonoTorrent.Client/MonoTorrent.Dht/NullDhtEngine.cs
+++ b/src/MonoTorrent.Client/MonoTorrent.Dht/NullDhtEngine.cs
@@ -29,6 +29,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading.Tasks;
 
 using MonoTorrent.Connections.Dht;
@@ -67,6 +68,8 @@ namespace MonoTorrent.Client
         public ITransferMonitor Monitor { get; } = new NullTransferMonitor ();
 
         public DhtState State => DhtState.NotReady;
+
+        public ImmutableHashSet<BootstrapRouter> BootstrapRouters { get; } = ImmutableHashSet<BootstrapRouter>.Empty;
 
         public ReusableTask AddAsync (IEnumerable<ReadOnlyMemory<byte>> nodes)
         {
@@ -109,6 +112,11 @@ namespace MonoTorrent.Client
         }
 
         public ReusableTask StopAsync ()
+        {
+            return default;
+        }
+
+        public ReusableTask SetBootstrapRoutersAsync (IEnumerable<BootstrapRouter> routers)
         {
             return default;
         }

--- a/src/MonoTorrent.Dht/MonoTorrent.Dht.Tasks/InitialiseTask.cs
+++ b/src/MonoTorrent.Dht/MonoTorrent.Dht.Tasks/InitialiseTask.cs
@@ -32,6 +32,7 @@ using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Net.Sockets;
 using System.Threading.Tasks;
 
 using MonoTorrent.BEncoding;
@@ -51,19 +52,19 @@ namespace MonoTorrent.Dht.Tasks
         readonly TaskCompletionSource<object?> initializationComplete;
 
         static Node[]? BootstrapNodes { get; set; }
-        string[] BootstrapRouters { get; set; }
+        BootstrapRouter[] BootstrapRouters { get; set; }
 
         public InitialiseTask (DhtEngine engine)
-            : this (engine, Enumerable.Empty<Node> (), DhtEngine.DefaultBootstrapRouters.ToArray ())
+            : this (engine, Enumerable.Empty<Node> ())
         {
 
         }
 
-        public InitialiseTask (DhtEngine engine, IEnumerable<Node> nodes, string[] bootstrapRouters)
+        public InitialiseTask (DhtEngine engine, IEnumerable<Node> nodes)
         {
             this.engine = engine;
             initialNodes = nodes.ToList ();
-            BootstrapRouters = bootstrapRouters;
+            BootstrapRouters = engine.BootstrapRouters.ToArray ();
             initializationComplete = new TaskCompletionSource<object?> ();
         }
 
@@ -98,19 +99,25 @@ namespace MonoTorrent.Dht.Tasks
             }
         }
 
-        static async Task<Node[]> GenerateBootstrapNodes (string[] bootstrapRouters)
+        static async Task<Node[]> GenerateBootstrapNodes (BootstrapRouter[] bootstrapRouters)
         {
-            var results = new List<Node> ();
+            static async Task<CompactEndPoint[]> ResolveRouter (BootstrapRouter router)
+            {
+                var addresses = await Dns.GetHostAddressesAsync (router.Host, AddressFamily.InterNetwork);
+                return addresses.Select (t => new CompactEndPoint (t, router.Port))
+                    .ToArray ();
+            }
 
-            var tasks = bootstrapRouters.Select (t => Dns.GetHostAddressesAsync (t, System.Net.Sockets.AddressFamily.InterNetwork)).ToList ();
+            var results = new List<Node> ();
+            var tasks = bootstrapRouters.Select (ResolveRouter).ToList ();
             while (tasks.Count > 0) {
                 var completed = await Task.WhenAny (tasks);
                 tasks.Remove (completed);
 
                 try {
-                    var addresses = await completed;
-                    foreach (var v in addresses)
-                        results.Add (new Node (NodeId.Create (), new CompactEndPoint (v, 6881)));
+                    var endpoints = await completed;
+                    foreach (var endpoint in endpoints)
+                        results.Add (new Node (NodeId.Create (), endpoint));
                 } catch {
 
                 }

--- a/src/MonoTorrent.Dht/MonoTorrent.Dht/DhtEngine.cs
+++ b/src/MonoTorrent.Dht/MonoTorrent.Dht/DhtEngine.cs
@@ -29,6 +29,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Net.Sockets;
 using System.Security.Cryptography;
@@ -65,10 +66,13 @@ namespace MonoTorrent.Dht
 
     public class DhtEngine : IDisposable, IDhtEngine
     {
-        internal static readonly IList<string> DefaultBootstrapRouters = Array.AsReadOnly (new[] {
-            "router.bittorrent.com",
-            "router.utorrent.com",
-            "dht.transmissionbt.com"
+        public static readonly ImmutableHashSet<BootstrapRouter> DefaultBootstrapRouters = ImmutableHashSet.Create (new[] {
+            new BootstrapRouter ("router.bittorrent.com", 6881),
+            new BootstrapRouter ("router.utorrent.com", 6881),
+            new BootstrapRouter ("dht.transmissionbt.com", 6881),
+            new BootstrapRouter ("dht.aelitis.com", 6881),
+            new BootstrapRouter ("router.bitcomet.com", 6881),
+            new BootstrapRouter ("dht.libtorrent.org", 25401)
         });
 
         static readonly TimeSpan DefaultAnnounceInternal = TimeSpan.FromMinutes (10);
@@ -87,6 +91,8 @@ namespace MonoTorrent.Dht
         public AddressFamily AddressFamily { get; private set; } = AddressFamily.InterNetwork;
 
         public TimeSpan AnnounceInterval => DefaultAnnounceInternal;
+
+        public ImmutableHashSet<BootstrapRouter> BootstrapRouters { get; private set; } = DefaultBootstrapRouters;
 
         public bool Disposed { get; private set; }
 
@@ -201,11 +207,11 @@ namespace MonoTorrent.Dht
             }
         }
 
-        async void InitializeAsync (IEnumerable<Node> nodes, string[] bootstrapRouters)
+        async void InitializeAsync (IEnumerable<Node> nodes)
         {
             await MainLoop;
 
-            var initTask = new InitialiseTask (this, nodes, bootstrapRouters);
+            var initTask = new InitialiseTask (this, nodes);
             await initTask.ExecuteAsync ();
             if (RoutingTable.NeedsBootstrap)
                 RaiseStateChanged (DhtState.NotReady);
@@ -282,19 +288,20 @@ namespace MonoTorrent.Dht
             return e;
         }
 
+        public async ReusableTask SetBootstrapRoutersAsync (IEnumerable<BootstrapRouter> routers)
+        {
+            await MainLoop;
+
+            BootstrapRouters = ImmutableHashSet.Create<BootstrapRouter> (routers.ToArray ());
+        }
+
         public ReusableTask StartAsync ()
             => StartAsync (ReadOnlyMemory<byte>.Empty);
 
         public ReusableTask StartAsync (ReadOnlyMemory<byte> initialNodes)
-            => StartAsync (Node.FromCompactNodes (BEncodedString.FromMemory (initialNodes)).Concat (PendingNodes), DefaultBootstrapRouters.ToArray ());
+            => StartAsync (Node.FromCompactNodes (initialNodes.Span).Concat (PendingNodes));
 
-        public ReusableTask StartAsync (params string[] bootstrapRouters)
-            => StartAsync (Array.Empty<Node> (), bootstrapRouters);
-
-        public ReusableTask StartAsync (ReadOnlyMemory<byte> initialNodes, params string[] bootstrapRouters)
-            => StartAsync (Node.FromCompactNodes (initialNodes.Span).Concat (PendingNodes), bootstrapRouters);
-
-        async ReusableTask StartAsync (IEnumerable<Node> nodes, string[] bootstrapRouters)
+        async ReusableTask StartAsync (IEnumerable<Node> nodes)
         {
             CheckDisposed ();
 
@@ -302,7 +309,7 @@ namespace MonoTorrent.Dht
             MessageLoop.Start ();
             if (RoutingTable.NeedsBootstrap) {
                 RaiseStateChanged (DhtState.Initialising);
-                InitializeAsync (nodes, bootstrapRouters);
+                InitializeAsync (nodes);
             } else {
                 RaiseStateChanged (DhtState.Ready);
             }

--- a/src/MonoTorrent/MonoTorrent.Dht/BootstrapRouter.cs
+++ b/src/MonoTorrent/MonoTorrent.Dht/BootstrapRouter.cs
@@ -1,0 +1,32 @@
+//
+// BootstrapRouter.cs
+//
+// Authors:
+//   Alan McGovern alan.mcgovern@gmail.com
+//
+// Copyright (C) 2026 Alan McGovern
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+
+namespace MonoTorrent.Dht
+{
+    public readonly record struct BootstrapRouter (string Host, int Port);
+}

--- a/src/MonoTorrent/MonoTorrent.Dht/IDhtEngine.cs
+++ b/src/MonoTorrent/MonoTorrent.Dht/IDhtEngine.cs
@@ -29,6 +29,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading.Tasks;
 
 using MonoTorrent.Connections.Dht;
@@ -66,6 +67,7 @@ namespace MonoTorrent.Dht
         event EventHandler StateChanged;
 
         TimeSpan AnnounceInterval { get; }
+        ImmutableHashSet<BootstrapRouter> BootstrapRouters { get; }
         bool Disposed { get; }
         ITransferMonitor Monitor { get; }
         TimeSpan MinimumAnnounceInterval { get; }
@@ -76,6 +78,7 @@ namespace MonoTorrent.Dht
         ReusableTask AnnounceAsync (InfoHash infoHash, int port);
         ReusableTask GetPeersAsync (InfoHash infoHash);
         ReusableTask<ReadOnlyMemory<byte>> SaveNodesAsync ();
+        ReusableTask SetBootstrapRoutersAsync (IEnumerable<BootstrapRouter> routers);
         ReusableTask SetListenerAsync (IDhtListener listener);
         ReusableTask StartAsync ();
         ReusableTask StartAsync (ReadOnlyMemory<byte> initialNodes);

--- a/src/Samples/DhtSampleClient/Program.cs
+++ b/src/Samples/DhtSampleClient/Program.cs
@@ -64,8 +64,16 @@ namespace ClientSample
                 await Task.Delay (1000);
             }
 
-            var infoHashes = new[] { InfoHash.FromHex ("d160b8d8ea35a5b4e52837468fc8f03d55cef1f7") };
+            DumpStats (engine);
+            static async void DumpStats (DhtEngine engine)
+            {
+                while (true) {
+                    Console.WriteLine ("Nodes: " + engine.NodeCount);
+                    await Task.Delay (1500);
+                }
+            }
 
+            var infoHashes = new[] { InfoHash.FromHex ("d160b8d8ea35a5b4e52837468fc8f03d55cef1f7") };
 
             var tasks = new List<Task> ();
             var s = new SemaphoreSlim (50, 50);

--- a/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/ManualDhtEngine.cs
+++ b/src/Tests/Tests.MonoTorrent.Client/MonoTorrent.Client/ManualDhtEngine.cs
@@ -29,6 +29,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Threading.Tasks;
 
 using MonoTorrent.Connections.Dht;
@@ -46,6 +47,7 @@ namespace MonoTorrent.Client
         public ITransferMonitor Monitor { get; }
         public int NodeCount => 0;
         public DhtState State { get; private set; }
+        public ImmutableHashSet<BootstrapRouter> BootstrapRouters { get; } = ImmutableHashSet<BootstrapRouter>.Empty;
 
         public event EventHandler<PeersFoundEventArgs> PeersFound;
         public event EventHandler StateChanged;
@@ -79,6 +81,11 @@ namespace MonoTorrent.Client
 
         public ReusableTask<ReadOnlyMemory<byte>> SaveNodesAsync ()
             => ReusableTask.FromResult (ReadOnlyMemory<byte>.Empty);
+
+        public ReusableTask SetBootstrapRoutersAsync (IEnumerable<BootstrapRouter> routers)
+        {
+            return default;
+        }
 
         public ReusableTask SetListenerAsync (IDhtListener listener)
         {

--- a/src/Tests/Tests.MonoTorrent.Dht/MonoTorrent.Dht/DhtEngineTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Dht/MonoTorrent.Dht/DhtEngineTests.cs
@@ -13,6 +13,23 @@ namespace MonoTorrent.Dht
     public class DhtEngineTests
     {
         [Test]
+        public async Task BootstrapRouters ()
+        {
+            var engine = new DhtEngine ();
+            Assert.IsNotEmpty (engine.BootstrapRouters);
+
+            await engine.SetBootstrapRoutersAsync (Array.Empty<BootstrapRouter> ());
+
+            Assert.IsEmpty (engine.BootstrapRouters);
+            await engine.SetBootstrapRoutersAsync (new[] {
+                new BootstrapRouter ("test", 123),
+                new BootstrapRouter ("test", 123),
+                new BootstrapRouter ("test", 123)
+            });
+            Assert.AreEqual (1, engine.BootstrapRouters.Count);
+        }
+
+        [Test]
         public async Task AddRawNodesBeforeStarting ()
         {
             int count = 0;

--- a/src/Tests/Tests.MonoTorrent.Dht/MonoTorrent.Dht/TaskTests.cs
+++ b/src/Tests/Tests.MonoTorrent.Dht/MonoTorrent.Dht/TaskTests.cs
@@ -65,7 +65,7 @@ namespace MonoTorrent.Dht
             var errorSource = new TaskCompletionSource<object> ();
             listener.MessageSent += (o, e) => errorSource.Task.GetAwaiter ().GetResult ();
 
-            await engine.StartAsync (node.CompactNode ().Span.ToArray (), Array.Empty<string> ());
+            await engine.StartAsync (node.CompactNode ().Span.ToArray ());
             Assert.AreEqual (DhtState.Initialising, engine.State);
 
             // Then set an error and make sure the engine state moves to 'NotReady'


### PR DESCRIPTION
These are now configurable via EngineSettings. The set of bootstrap routers can also be changed by calling DhtEngine.SetBootstrapRouters

Additionally, extra bootstrap routers have been added to make bootstrapping a little more reliable if there is no other source of node data.

Addresses: https://github.com/alanmcgovern/monotorrent/issues/734